### PR TITLE
feat: add github actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/issue_report.yml
@@ -1,0 +1,55 @@
+name: Create an issue for Radicalbit AI Gateway
+description: Create an issue for bugs, features, or other activities in Radicalbit AI Gateway.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue form is for reporting bugs, requesting features, or creating tasks for Radicalbit AI Gateway.
+
+        Use this template for any type of work item including bugs, enhancements, documentation updates, or other activities.
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      options:
+        - label: I have filled out the template to the best of my ability.
+          required: true
+        - label: This only contains 1 issue (if you have multiple issues, open one issue for each item).
+          required: true
+        - label: This issue is not a duplicate of [previous issues](https://github.com/radicalbit/radicalbit-ai-gateway-oss/issues).
+          required: true
+
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Description
+      description: >-
+        Describe the issue, feature request, or task you want to create.
+
+        For bugs: Tell us what you were trying to do and what happened.
+        For features: Explain what functionality you'd like to see added.
+        For tasks: Describe the work that needs to be done.
+
+        Provide a clear and concise description of what you want to accomplish.
+
+  - type: markdown
+    attributes:
+      value: |
+        # Additional Information
+
+  - type: textarea
+    attributes:
+      label: Logs or Error Messages (if applicable)
+      description: For bugs, include any error messages, stack traces, or relevant logs. For other issues, this field is optional.
+      render: txt
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: >
+        Any additional information that might be helpful, such as:
+        - Steps to reproduce (for bugs)
+        - Expected vs actual behavior (for bugs)
+        - Use cases or business value (for features)
+        - Dependencies or related issues
+        - Screenshots or examples

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+Briefly describe what this PR changes and why.
+
+## Linked Issue
+Closes #123
+
+## Type of Change
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Docs
+- [ ] Refactor/Chore
+- [ ] Performance
+- [ ] Security
+
+## Checklist
+- [ ] Tests pass (locally/CI)
+- [ ] Lint/build pass
+- [ ] No secrets committed
+- [ ] Docs updated (if needed)

--- a/.github/workflows/gateway-workflow.yaml
+++ b/.github/workflows/gateway-workflow.yaml
@@ -1,0 +1,148 @@
+name: gateway-wf
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+    branches:
+      - "main"
+    paths:
+      - "gateway/**"
+      - ".github/workflows/gateway-**"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "gateway/**"
+      - ".github/workflows/gateway-**"
+
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.7.13"
+  APP_IMAGE: radicalbit/radicalbit-ai-gateway
+  MIGRATIONS_IMAGE: radicalbit/radicalbit-ai-gateway-migrations
+  IMAGES_TAG: main
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./gateway
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Setup uv
+        run: |
+          curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
+      - name: Run formatting validation
+        run: |
+          uv run ruff check
+      - name: Run format check
+        run: |
+          uv run ruff format --check
+      - name: Run tests
+        run: |
+          uv run pytest -v
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            platform_short: amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            platform_short: arm64
+    runs-on: ${{ matrix.runner }}
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
+            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push app image by digest
+        id: build-app
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.APP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push migrations image by digest
+        id: build-migrations
+        uses: docker/build-push-action@v6
+        with:
+          context: ./gateway
+          file: ./gateway/migrations.Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/app /tmp/digests/migrations
+          touch "/tmp/digests/app/${APP_DIGEST#sha256:}"
+          touch "/tmp/digests/migrations/${MIGRATIONS_DIGEST#sha256:}"
+        env:
+          APP_DIGEST: ${{ steps.build-app.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.build-migrations.outputs.digest }}
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-gateway-${{ matrix.platform_short }}
+          path: /tmp/digests/**
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-gateway-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create app manifest and push
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.APP_IMAGE }}:${{ env.IMAGES_TAG }} \
+            $(printf '${{ env.APP_IMAGE }}@sha256:%s ' $(ls /tmp/digests/app/))
+      - name: Create migrations manifest and push
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} \
+            $(printf '${{ env.MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/migrations/))
+      - name: Inspect images
+        run: |
+          docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ env.IMAGES_TAG }}
+          docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }}

--- a/.github/workflows/metrics-worker-workflow.yaml
+++ b/.github/workflows/metrics-worker-workflow.yaml
@@ -1,0 +1,147 @@
+name: metrics-worker-wf
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+    branches:
+      - "main"
+    paths:
+      - "metrics-worker/**"
+      - "clickhouse-migrations/**"
+      - ".github/workflows/metrics-worker-**"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "metrics-worker/**"
+      - "clickhouse-migrations/**"
+      - ".github/workflows/metrics-worker-**"
+
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.7.13"
+  WORKER_IMAGE: radicalbit/metrics-worker
+  CLICKHOUSE_MIGRATIONS_IMAGE: radicalbit/radicalbit-ai-gateway-clickhouse-migrations
+  IMAGES_TAG: main
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./metrics-worker
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Setup uv
+        run: |
+          curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
+      - name: Run formatting validation
+        run: |
+          uv run ruff check
+      - name: Run format check
+        run: |
+          uv run ruff format --check
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            platform_short: amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            platform_short: arm64
+    runs-on: ${{ matrix.runner }}
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
+            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push metrics-worker image by digest
+        id: build-worker
+        uses: docker/build-push-action@v6
+        with:
+          context: ./metrics-worker
+          file: ./metrics-worker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.WORKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push clickhouse-migrations image by digest
+        id: build-clickhouse-migrations
+        uses: docker/build-push-action@v6
+        with:
+          context: ./clickhouse-migrations
+          file: ./clickhouse-migrations/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/worker /tmp/digests/clickhouse-migrations
+          touch "/tmp/digests/worker/${WORKER_DIGEST#sha256:}"
+          touch "/tmp/digests/clickhouse-migrations/${CLICKHOUSE_DIGEST#sha256:}"
+        env:
+          WORKER_DIGEST: ${{ steps.build-worker.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.build-clickhouse-migrations.outputs.digest }}
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-worker-${{ matrix.platform_short }}
+          path: /tmp/digests/**
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-worker-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create metrics-worker manifest and push
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.WORKER_IMAGE }}:${{ env.IMAGES_TAG }} \
+            $(printf '${{ env.WORKER_IMAGE }}@sha256:%s ' $(ls /tmp/digests/worker/))
+      - name: Create clickhouse-migrations manifest and push
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} \
+            $(printf '${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/clickhouse-migrations/))
+      - name: Inspect images
+        run: |
+          docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ env.IMAGES_TAG }}
+          docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,205 @@
+name: release
+on:
+  push:
+    tags:
+      - '*'
+
+concurrency:
+  group: docker-tag-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.7.13"
+  APP_IMAGE: radicalbit/radicalbit-ai-gateway
+  MIGRATIONS_IMAGE: radicalbit/radicalbit-ai-gateway-migrations
+  CLICKHOUSE_MIGRATIONS_IMAGE: radicalbit/radicalbit-ai-gateway-clickhouse-migrations
+  WORKER_IMAGE: radicalbit/metrics-worker
+
+jobs:
+  prep:
+    runs-on: ubuntu-22.04
+    outputs:
+      is_semver: ${{ steps.check.outputs.is_semver }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Set version/tag
+        id: check
+        run: |
+          echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+          echo "is_semver=$(if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_OUTPUT
+
+  publish-pypi:
+    runs-on: ubuntu-22.04
+    needs: prep
+    if: needs.prep.outputs.is_semver == 'true'
+    defaults:
+      run:
+        working-directory: ./gateway
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Setup uv
+        run: |
+          curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
+      - name: Build package
+        run: |
+          uv build
+      - name: Publish to PyPI
+        run: |
+          uv publish --token ${{ secrets.PYPI_TOKEN }}
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            platform_short: amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            platform_short: arm64
+    runs-on: ${{ matrix.runner }}
+    needs: prep
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
+            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push app image by digest
+        id: build-app
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.APP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push migrations image by digest
+        id: build-migrations
+        uses: docker/build-push-action@v6
+        with:
+          context: ./gateway
+          file: ./gateway/migrations.Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push clickhouse-migrations image by digest
+        id: build-clickhouse-migrations
+        uses: docker/build-push-action@v6
+        with:
+          context: ./clickhouse-migrations
+          file: ./clickhouse-migrations/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push metrics-worker image by digest
+        id: build-worker
+        uses: docker/build-push-action@v6
+        with:
+          context: ./metrics-worker
+          file: ./metrics-worker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.WORKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/app /tmp/digests/migrations /tmp/digests/clickhouse-migrations /tmp/digests/worker
+          touch "/tmp/digests/app/${APP_DIGEST#sha256:}"
+          touch "/tmp/digests/migrations/${MIGRATIONS_DIGEST#sha256:}"
+          touch "/tmp/digests/clickhouse-migrations/${CLICKHOUSE_DIGEST#sha256:}"
+          touch "/tmp/digests/worker/${WORKER_DIGEST#sha256:}"
+        env:
+          APP_DIGEST: ${{ steps.build-app.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.build-migrations.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.build-clickhouse-migrations.outputs.digest }}
+          WORKER_DIGEST: ${{ steps.build-worker.outputs.digest }}
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-release-${{ matrix.platform_short }}
+          path: /tmp/digests/**
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs: [prep, build]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-release-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create and push app manifest
+        run: |
+          TAGS="-t ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }}"
+          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
+            TAGS="$TAGS -t ${{ env.APP_IMAGE }}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${{ env.APP_IMAGE }}@sha256:%s ' $(ls /tmp/digests/app/))
+      - name: Create and push migrations manifest
+        run: |
+          TAGS="-t ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
+          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
+            TAGS="$TAGS -t ${{ env.MIGRATIONS_IMAGE }}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${{ env.MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/migrations/))
+      - name: Create and push clickhouse-migrations manifest
+        run: |
+          TAGS="-t ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
+          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
+            TAGS="$TAGS -t ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/clickhouse-migrations/))
+      - name: Create and push metrics-worker manifest
+        run: |
+          TAGS="-t ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }}"
+          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
+            TAGS="$TAGS -t ${{ env.WORKER_IMAGE }}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${{ env.WORKER_IMAGE }}@sha256:%s ' $(ls /tmp/digests/worker/))
+      - name: Inspect images
+        run: |
+          docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }}
+          docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}
+          docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}
+          docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }}
+      - name: Output image information
+        run: |
+          echo "Successfully built and pushed images:"
+          echo "   Gateway: ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }}"
+          echo "   Migrations: ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
+          echo "   Clickhouse Migrations: ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
+          echo "   Metrics Worker: ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }}"
+          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
+            echo "   Latest tags also created for semantic version"
+          fi

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "radicabit-ai-gateway"
+name = "radicalbit-ai-gateway"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"


### PR DESCRIPTION
Add GitHub Actions CI/CD workflows, community templates, and fix package name typo.

---

## Added

- **`.github/workflows/gateway-workflow.yaml`** - CI/CD for `gateway/` service
  - **test job**: ruff check, ruff format, pytest on PR and push to main
  - **build job**: multi-arch Docker build (amd64 + arm64) for `radicalbit/radicalbit-ai-gateway` and `radicalbit/radicalbit-ai-gateway-migrations` on push to main

- **`.github/workflows/metrics-worker-workflow.yaml`** - CI/CD for `metrics-worker/` service
  - **test job**: ruff check, ruff format on PR and push to main
  - **build job**: multi-arch Docker build (amd64 + arm64) for `radicalbit/metrics-worker` and `radicalbit/radicalbit-ai-gateway-clickhouse-migrations` on push to main

- **`.github/workflows/release.yaml`** - Release workflow triggered by tags
  - **publish-pypi job**: builds and publishes `gateway` package to PyPI (semver tags only)
  - **build job**: multi-arch Docker build and push for all 4 images with tag-based versioning

- **`.github/ISSUE_TEMPLATE/issue_report.yml`** - GitHub issue template for bugs, features, and tasks

- **`.github/pull_request_template.md`** - PR template with checklist

---

## Fixed

- **`gateway/pyproject.toml`** - Package name corrected from `radicabit-ai-gateway` to `radicalbit-ai-gateway`
