### PR TITLE
feat: add delete project endpoint

### DIFF
--- a/gateway/alembic/versions/a2b3c4d5e6f7_add_deleted_at_to_project.py
+++ b/gateway/alembic/versions/a2b3c4d5e6f7_add_deleted_at_to_project.py
@@ -1,0 +1,31 @@
+"""add_deleted_at_to_project
+
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'a2b3c4d5e6f7'
+down_revision: Union[str, None] = 'f1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'project',
+        sa.Column('DELETED_AT', sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('project', 'DELETED_AT')

--- a/gateway/radicalbit_ai_gateway/db/dao/group_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/group_dao.py
@@ -110,7 +110,10 @@ class GroupDAO:
             stmt = (
                 select(Project.name, GroupRoute.route_name)
                 .join(GroupRoute, GroupRoute.project_uuid == Project.uuid)
-                .where(GroupRoute.group_uuid == group_uuid)
+                .where(
+                    GroupRoute.group_uuid == group_uuid,
+                    Project.deleted_at.is_(None),
+                )
             )
             rows = session.execute(stmt).all()
             return [f'{row[0]}/{row[1]}' for row in rows]

--- a/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
@@ -24,19 +24,22 @@ class ProjectDAO:
 
     def get_by_uuid(self, project_uuid: UUID) -> Project | None:
         with self.db.begin_session() as session:
-            stmt = select(Project).where(Project.uuid == project_uuid)
+            stmt = select(Project).where(
+                Project.uuid == project_uuid,
+                Project.deleted_at.is_(None),
+            )
             return session.scalar(stmt)
 
     def get_all(self) -> Sequence[Project]:
         with self.db.begin_session() as session:
-            stmt = select(Project)
+            stmt = select(Project).where(Project.deleted_at.is_(None))
             return session.scalars(stmt).all()
 
     def get_all_filtered(
         self, project_filter: ProjectFilter | None = None
     ) -> Sequence[Project]:
         with self.db.begin_session() as session:
-            stmt = select(Project)
+            stmt = select(Project).where(Project.deleted_at.is_(None))
             if project_filter == ProjectFilter.ACTIVE:
                 stmt = stmt.where(Project.config_file.is_not(None))
             elif project_filter == ProjectFilter.WITH_USAGE:
@@ -45,7 +48,10 @@ class ProjectDAO:
 
     def get_all_with_config(self) -> Sequence[Project]:
         with self.db.begin_session() as session:
-            stmt = select(Project).where(Project.config_file.is_not(None))
+            stmt = select(Project).where(
+                Project.config_file.is_not(None),
+                Project.deleted_at.is_(None),
+            )
             return session.scalars(stmt).all()
 
     def update_draft_config_file(
@@ -90,11 +96,24 @@ class ProjectDAO:
             )
             return session.execute(query).rowcount
 
+    def soft_delete(self, project_uuid: UUID) -> int:
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            query = (
+                update(Project)
+                .where(Project.uuid == project_uuid)
+                .values(deleted_at=now, updated_at=now)
+            )
+            return session.execute(query).rowcount
+
     def unserve_config(self, project_uuid: UUID, restore_draft: bool) -> int:
         now = datetime.datetime.now(tz=_UTC)
         with self.db.begin_session() as session:
             project = session.scalar(
-                select(Project).where(Project.uuid == project_uuid)
+                select(Project).where(
+                    Project.uuid == project_uuid,
+                    Project.deleted_at.is_(None),
+                )
             )
             if project is None:
                 return 0

--- a/gateway/radicalbit_ai_gateway/db/tables/project_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/project_table.py
@@ -38,3 +38,4 @@ class Project(Reflected, BaseTable, BaseDAO):
     created_at = Column('CREATED_AT', TIMESTAMP(timezone=True), nullable=False)
     updated_at = Column('UPDATED_AT', TIMESTAMP(timezone=True), nullable=False)
     first_served_at = Column('FIRST_SERVED_AT', TIMESTAMP(timezone=True), nullable=True)
+    deleted_at = Column('DELETED_AT', TIMESTAMP(timezone=True), nullable=True)

--- a/gateway/radicalbit_ai_gateway/models/auth_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/auth_dto.py
@@ -245,7 +245,9 @@ class GroupFullOut(GroupOut):
             owner=group.owner,
             metadata=json.loads(group.group_metadata) if group.group_metadata else None,
             routes=[
-                GroupRouteOut.from_group_route(route) for route in group.group_routes
+                GroupRouteOut.from_group_route(route)
+                for route in group.group_routes
+                if route.project and route.project.deleted_at is None
             ]
             if include_routes
             else None,

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -141,6 +141,18 @@ class ProjectRoute:
             logger.info('Unserved config for project %s', project_uuid)
             return project
 
+        @router.delete(
+            '/projects/{project_uuid}',
+            status_code=200,
+            response_model=ProjectOut,
+        )
+        async def delete_project(project_uuid: UUID):
+            project = project_service.delete_project(project_uuid)
+            if deregister_project_routes and project.config_file:
+                await deregister_project_routes(project_uuid)
+            logger.info('Deleted project %s', project_uuid)
+            return project
+
         @router.patch(
             '/projects/{project_uuid}/routes/{route_name}/groups',
             status_code=200,

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -127,6 +127,16 @@ class ProjectService:
 
         return self._get_updated_or_raise(project_uuid)
 
+    def delete_project(self, project_uuid: UUID) -> ProjectOut:
+        project = self._get_project_or_raise(project_uuid)
+
+        if project.config_file is not None:
+            restore_draft = project.draft_config_file is None
+            self.project_dao.unserve_config(project_uuid, restore_draft)
+
+        self.project_dao.soft_delete(project_uuid)
+        return ProjectOut.from_project(project)
+
     def get_by_uuid(self, project_uuid: UUID) -> ProjectOut:
         return ProjectOut.from_project(self._get_project_or_raise(project_uuid))
 

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -140,6 +140,7 @@ def get_sample_group_route_plain(
             config_status='DRAFT',
             created_at=datetime.datetime.now(tz=UTC),
             updated_at=datetime.datetime.now(tz=UTC),
+            deleted_at=None,
         ),
     )
 
@@ -169,6 +170,7 @@ def get_sample_group_route(
             config_status='DRAFT',
             created_at=datetime.datetime.now(tz=UTC),
             updated_at=datetime.datetime.now(tz=UTC),
+            deleted_at=None,
         ),
     )
 
@@ -284,6 +286,7 @@ def get_sample_project(
     draft_config_file: str | None = None,
     config_status: ConfigStatus = ConfigStatus.DRAFT,
     first_served_at: datetime.datetime | None = None,
+    deleted_at: datetime.datetime | None = None,
 ) -> Project:
     now = datetime.datetime.now(tz=UTC)
     return Project(
@@ -296,6 +299,7 @@ def get_sample_project(
         created_at=now,
         updated_at=now,
         first_served_at=first_served_at,
+        deleted_at=deleted_at,
     )
 
 

--- a/gateway/tests/dao/group_dao_test.py
+++ b/gateway/tests/dao/group_dao_test.py
@@ -5,6 +5,7 @@ from tests.common.db_integration import DatabaseIntegration
 
 from radicalbit_ai_gateway.db.dao.group_dao import GroupDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
+from radicalbit_ai_gateway.db.tables.group_route_table import GroupRoute
 
 
 class GroupDAOTest(DatabaseIntegration):
@@ -149,6 +150,36 @@ class GroupDAOTest(DatabaseIntegration):
             self.project_uuid, 'this-route-does-not-exist'
         )
         assert len(rows) == 0
+
+    def test_get_route_names_by_group_uuid_excludes_deleted_project_routes(self):
+        group_uuid = uuid.uuid4()
+        live_project_uuid = self.project_uuid
+        deleted_project_uuid = uuid.uuid4()
+        self.project_dao.insert(
+            db_mock.get_sample_project(
+                uuid=deleted_project_uuid, name='deleted-project'
+            )
+        )
+        self.group_dao.insert(
+            db_mock.get_sample_group(uuid=group_uuid, group_routes=[])
+        )
+        self.group_dao.add_route(
+            GroupRoute(
+                group_uuid=group_uuid,
+                route_name='live-route',
+                project_uuid=live_project_uuid,
+            )
+        )
+        self.group_dao.add_route(
+            GroupRoute(
+                group_uuid=group_uuid,
+                route_name='dead-route',
+                project_uuid=deleted_project_uuid,
+            )
+        )
+        self.project_dao.soft_delete(deleted_project_uuid)
+        result = self.group_dao.get_route_names_by_group_uuid(group_uuid)
+        assert result == ['my-project/live-route']
 
     def test_get_group_associated_with_multiple_routes(self):
         power_user_group_uuid = uuid.uuid4()

--- a/gateway/tests/dao/project_dao_test.py
+++ b/gateway/tests/dao/project_dao_test.py
@@ -165,3 +165,64 @@ class ProjectDAOTest(DatabaseIntegration):
         result = self.project_dao.get_all_filtered(ProjectFilter.WITH_USAGE)
         assert len(result) == 1
         assert result[0].name == 'was-served'
+
+    # --- soft_delete ---
+
+    def test_soft_delete(self):
+        project = db_mock.get_sample_project()
+        self.project_dao.insert(project)
+        rows = self.project_dao.soft_delete(project.uuid)
+        assert rows == 1
+
+    def test_soft_delete_not_found(self):
+        rows = self.project_dao.soft_delete(uuid.uuid4())
+        assert rows == 0
+
+    def test_get_by_uuid_excludes_deleted(self):
+        project = db_mock.get_sample_project()
+        self.project_dao.insert(project)
+        self.project_dao.soft_delete(project.uuid)
+        result = self.project_dao.get_by_uuid(project.uuid)
+        assert result is None
+
+    def test_get_all_excludes_deleted(self):
+        projects = [
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='one'),
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='two'),
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='three'),
+        ]
+        for p in projects:
+            self.project_dao.insert(p)
+        self.project_dao.soft_delete(projects[0].uuid)
+        result = self.project_dao.get_all()
+        assert len(result) == 2
+        assert 'one' not in {p.name for p in result}
+
+    def test_get_all_filtered_excludes_deleted(self):
+        self.project_dao.insert(
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='live')
+        )
+        deleted = db_mock.get_sample_project(uuid=uuid.uuid4(), name='deleted')
+        self.project_dao.insert(deleted)
+        self.project_dao.soft_delete(deleted.uuid)
+        result = self.project_dao.get_all_filtered(None)
+        assert len(result) == 1
+        assert result[0].name == 'live'
+
+    def test_get_all_with_config_excludes_deleted(self):
+        served = db_mock.get_sample_project(
+            uuid=uuid.uuid4(), name='served', config_file='some-yaml'
+        )
+        self.project_dao.insert(served)
+        self.project_dao.soft_delete(served.uuid)
+        result = self.project_dao.get_all_with_config()
+        assert list(result) == []
+
+    def test_unserve_config_noop_on_deleted_project(self):
+        project = db_mock.get_sample_project(
+            uuid=uuid.uuid4(), name='served', config_file='some-yaml'
+        )
+        self.project_dao.insert(project)
+        self.project_dao.soft_delete(project.uuid)
+        rows = self.project_dao.unserve_config(project.uuid, restore_draft=False)
+        assert rows == 0

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -515,3 +515,68 @@ class TestProjectRoute(unittest.TestCase):
             json=jsonable_encoder(gen_in),
         )
         assert res.status_code == 500
+
+    # --- DELETE /projects/{project_uuid} ---
+
+    def test_delete_project_ok(self):
+        project = db_mock.get_sample_project()
+        project_out = ProjectOut.from_project(project)
+        self.project_service.delete_project = MagicMock(return_value=project_out)
+        res = self.client.delete(f'{self.prefix}/projects/{project.uuid}')
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder(project_out)
+        self.project_service.delete_project.assert_called_once_with(project.uuid)
+
+    def test_delete_project_not_found(self):
+        unknown_uuid = uuid.uuid4()
+        self.project_service.delete_project = MagicMock(
+            side_effect=ProjectNotFoundError('error')
+        )
+        res = self.client.delete(f'{self.prefix}/projects/{unknown_uuid}')
+        assert res.status_code == 404
+        assert (
+            res.json()['error']
+            == ErrorOut(
+                'error',
+                'auth_registry_error',
+                code='project_not_found',
+                param=None,
+            ).error
+        )
+
+    def test_delete_project_dev_does_not_call_deregister(self):
+        project = db_mock.get_sample_project(config_file=None)
+        project_out = ProjectOut.from_project(project)
+        deregister_fn = AsyncMock()
+        router = ProjectRoute.get_project_router(
+            self.project_service,
+            self.group_service,
+            deregister_project_routes=deregister_fn,
+        )
+        app = FastAPI(title='AI Gateway', debug=True)
+        app.add_exception_handler(AuthRegistryError, auth_registry_exception_handler)
+        app.include_router(router, prefix=self.prefix)
+        client = TestClient(app)
+        self.project_service.delete_project = MagicMock(return_value=project_out)
+        res = client.delete(f'{self.prefix}/projects/{project.uuid}')
+        assert res.status_code == 200
+        deregister_fn.assert_not_called()
+
+    def test_delete_project_prod_calls_deregister(self):
+        config_in = db_mock.get_sample_project_config_file_in()
+        project = db_mock.get_sample_project(config_file=config_in.config_file)
+        project_out = ProjectOut.from_project(project)
+        deregister_fn = AsyncMock()
+        router = ProjectRoute.get_project_router(
+            self.project_service,
+            self.group_service,
+            deregister_project_routes=deregister_fn,
+        )
+        app = FastAPI(title='AI Gateway', debug=True)
+        app.add_exception_handler(AuthRegistryError, auth_registry_exception_handler)
+        app.include_router(router, prefix=self.prefix)
+        client = TestClient(app)
+        self.project_service.delete_project = MagicMock(return_value=project_out)
+        res = client.delete(f'{self.prefix}/projects/{project.uuid}')
+        assert res.status_code == 200
+        deregister_fn.assert_called_once_with(project.uuid)

--- a/gateway/tests/services/group_service_test.py
+++ b/gateway/tests/services/group_service_test.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from unittest.mock import MagicMock, call
 import uuid
@@ -111,6 +112,23 @@ class GroupServiceTest(unittest.TestCase):
         keys = [i.keys for i in res]
         assert all(r is None for r in keys)
         assert len(res) == 3
+
+    def test_get_all_include_routes_excludes_deleted_project_routes(self):
+        UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
+        group_uuid = uuid.uuid4()
+        live_route = db_mock.get_sample_group_route(
+            group_uuid=group_uuid, route_name='live-route'
+        )
+        deleted_route = db_mock.get_sample_group_route(
+            group_uuid=group_uuid, route_name='deleted-route'
+        )
+        deleted_route.project.deleted_at = datetime.datetime.now(tz=UTC)
+        group = db_mock.get_sample_group(
+            uuid=group_uuid, group_routes=[live_route, deleted_route]
+        )
+        self.group_dao.get_all = MagicMock(return_value=[group])
+        res = self.group_service.get_all(include_keys=False, include_routes=True)
+        assert res[0].routes == [GroupRouteOut.from_group_route(live_route)]
 
     def test_add_key(self):
         group_uuid = uuid.uuid4()

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -398,6 +398,66 @@ routes:
         result = self.project_service.get_all_active()
         assert result == []
 
+    # --- delete_project ---
+
+    def test_delete_project_ok_dev_state(self):
+        project = db_mock.get_sample_project(
+            config_file=None, config_status=ConfigStatus.DRAFT
+        )
+        self.project_dao.get_by_uuid = MagicMock(return_value=project)
+        self.project_dao.soft_delete = MagicMock(return_value=1)
+        result = self.project_service.delete_project(project.uuid)
+        self.project_dao.soft_delete.assert_called_once_with(project.uuid)
+        self.project_dao.unserve_config.assert_not_called()
+        assert result == ProjectOut.from_project(project)
+
+    def test_delete_project_ok_prod_state_restores_draft(self):
+        config_in = db_mock.get_sample_project_config_file_in()
+        project = db_mock.get_sample_project(
+            config_file=config_in.config_file,
+            draft_config_file=None,
+            config_status=ConfigStatus.SERVED,
+        )
+        self.project_dao.get_by_uuid = MagicMock(return_value=project)
+        self.project_dao.unserve_config = MagicMock(return_value=1)
+        self.project_dao.soft_delete = MagicMock(return_value=1)
+        result = self.project_service.delete_project(project.uuid)
+        self.project_dao.unserve_config.assert_called_once_with(project.uuid, True)
+        self.project_dao.soft_delete.assert_called_once_with(project.uuid)
+        assert result.config_file == config_in.config_file
+
+    def test_delete_project_ok_prod_state_keeps_existing_draft(self):
+        config_in = db_mock.get_sample_project_config_file_in()
+        project = db_mock.get_sample_project(
+            config_file=config_in.config_file,
+            draft_config_file='existing-draft',
+            config_status=ConfigStatus.SERVED,
+        )
+        self.project_dao.get_by_uuid = MagicMock(return_value=project)
+        self.project_dao.unserve_config = MagicMock(return_value=1)
+        self.project_dao.soft_delete = MagicMock(return_value=1)
+        self.project_service.delete_project(project.uuid)
+        self.project_dao.unserve_config.assert_called_once_with(project.uuid, False)
+
+    def test_delete_project_not_found(self):
+        self.project_dao.get_by_uuid = MagicMock(return_value=None)
+        with pytest.raises(ProjectNotFoundError):
+            self.project_service.delete_project(uuid.uuid4())
+
+    def test_delete_project_returns_pre_deletion_state(self):
+        # DTO must reflect state before deletion so route can call deregister_project_routes.
+        config_in = db_mock.get_sample_project_config_file_in()
+        project = db_mock.get_sample_project(
+            config_file=config_in.config_file,
+            config_status=ConfigStatus.SERVED,
+        )
+        self.project_dao.get_by_uuid = MagicMock(return_value=project)
+        self.project_dao.unserve_config = MagicMock(return_value=1)
+        self.project_dao.soft_delete = MagicMock(return_value=1)
+        result = self.project_service.delete_project(project.uuid)
+        assert result.config_file == config_in.config_file
+        assert result.project_status == ProjectStatus.PROD
+
     # --- get_all_filtered ---
 
     def test_get_all_filtered_delegates_to_dao(self):


### PR DESCRIPTION
# PR Summary: feat/project-delete-endpoint

Adds a soft-delete endpoint for projects (`DELETE /projects/{project_uuid}`). Deleted projects are hidden from all reads immediately via a `deleted_at` timestamp, and any served configuration is automatically unserved before deletion.

---

## DTO Changes

### `ProjectOut` (MODIFIED)

No field changes — the response shape is unchanged. The endpoint returns the project's state **at the moment of deletion** (before the soft-delete is applied), so callers can inspect `configFile` to decide whether to deregister routes.

**Example response:**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "name": "my-project",
  "description": null,
  "configFile": "providers:\n  - name: openai\n    ...",
  "draftConfigFile": null,
  "configStatus": "SERVED",
  "projectStatus": "PROD",
  "createdAt": "2024-01-15T10:30:00Z",
  "updatedAt": "2024-01-15T10:30:00Z",
  "firstServedAt": "2024-01-15T10:30:00Z"
}
```

---

### `GroupFullOut` (MODIFIED)

**Changes:**
```diff
? routes: list[GroupRouteOut]  — now filters out routes belonging to deleted projects
```

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Group UUID |
| `name` | string | Group name |
| `owner` | string | Owner identifier |
| `metadata` | object \| null | Arbitrary key-value metadata |
| `routes` | object[] \| null | Routes — deleted-project routes excluded **CHANGED** |
| `keys` | object[] \| null | Associated API keys |
| `createdAt` | datetime | Creation timestamp |
| `updatedAt` | datetime | Last update timestamp |

---

## Affected Endpoints

### `DELETE /projects/{project_uuid}` (NEW)

Soft-deletes a project. If the project has a served configuration, it is unserved first and the gateway deregisters the project's routes. Returns the pre-deletion state of the project.

**Example request:**
```
DELETE /projects/550e8400-e29b-41d4-a716-446655440000
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string (UUID) | yes | UUID of the project to delete |

**Responses:**

| Status | Description |
|--------|-------------|
| `200` | Project deleted — returns `ProjectOut` snapshot |
| `404` | Project not found |

**Example response (200):**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "name": "my-project",
  "description": null,
  "configFile": null,
  "draftConfigFile": null,
  "configStatus": "DRAFT",
  "projectStatus": "DEV",
  "createdAt": "2024-01-15T10:30:00Z",
  "updatedAt": "2024-01-15T10:30:00Z",
  "firstServedAt": null
}
```

---

## Other Changes

- `db/tables/project_table.py` — added `deleted_at` column (`TIMESTAMP`, nullable)
- `db/dao/project_dao.py` — all read queries (`get_by_uuid`, `get_all`, `get_all_filtered`, `get_all_with_config`, `unserve_config`) now filter `deleted_at IS NULL`; new `soft_delete` method
- `db/dao/group_dao.py` — `get_route_names_by_group_uuid` filters out routes belonging to deleted projects
- `services/project_service.py` — new `delete_project` method: unserves config if active, then soft-deletes
- `alembic/versions/a2b3c4d5e6f7_add_deleted_at_to_project.py` — migration adding `DELETED_AT` column to `project` table
- `tests/` — 17 new tests covering DAO, service, and route layers
