### PR TITLE
feat: DeepSeek reasoning_content support

### DIFF
--- a/gateway/radicalbit_ai_gateway/invocation/chat_model_invoker.py
+++ b/gateway/radicalbit_ai_gateway/invocation/chat_model_invoker.py
@@ -14,6 +14,7 @@ from radicalbit_ai_gateway.invocation.model_invoker import ModelInvoker
 from radicalbit_ai_gateway.models.fallback import Fallback
 from radicalbit_ai_gateway.models.model import (
     ENABLE_PROMPT_CACHE_PARAM,
+    GatewayDeepSeekChatModel,
     MockGatewayChatModel,
     Model,
 )
@@ -72,12 +73,6 @@ class ChatModelInvoker(ModelInvoker):
                 response_text=response_text,
             )
 
-        # Map gateway provider names to LangChain provider names
-        # LangChain uses underscore (google_genai) while gateway uses hyphen (google-genai)
-        langchain_provider = provider.replace('-', '_')
-
-        # init_chat_model handles provider recognition and model initialization
-        # LangChain accepts api_key directly as an alias for provider-specific keys
         # Strip gateway-only params that must not reach LangChain
         _GATEWAY_PARAMS = {ENABLE_PROMPT_CACHE_PARAM}
         init_kwargs = {
@@ -85,6 +80,18 @@ class ChatModelInvoker(ModelInvoker):
             for k, v in {**params, **credentials}.items()
             if k not in _GATEWAY_PARAMS
         }
+
+        if provider == 'deepseek':
+            return GatewayDeepSeekChatModel(
+                model=model_name,
+                http_async_client=self.httpx_client,
+                **init_kwargs,
+            )
+
+        # Map gateway provider names to LangChain provider names
+        # LangChain uses underscore (google_genai) while gateway uses hyphen (google-genai)
+        langchain_provider = provider.replace('-', '_')
+
         if provider not in ('anthropic', 'mistralai'):
             init_kwargs['http_async_client'] = self.httpx_client
         return init_chat_model(

--- a/gateway/radicalbit_ai_gateway/models/chat_request.py
+++ b/gateway/radicalbit_ai_gateway/models/chat_request.py
@@ -204,6 +204,9 @@ def convert_openai_messages(messages: list) -> list[BaseMessage]:
             tool_calls=parse_tool_calls(list(m.get('tool_calls', []) or [])),
             tool_call_id=m.get('tool_call_id'),
         )
+        reasoning_content = m.get('reasoning_content')
+        if reasoning_content and isinstance(message, AIMessage):
+            message.additional_kwargs['reasoning_content'] = reasoning_content
         openai_messages.append(message)
 
     return openai_messages

--- a/gateway/radicalbit_ai_gateway/models/model.py
+++ b/gateway/radicalbit_ai_gateway/models/model.py
@@ -11,9 +11,11 @@ except ImportError:
     from typing_extensions import Self
 
 from langchain_core.embeddings import Embeddings
+from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_deepseek import ChatDeepSeek
 from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
 
 from radicalbit_ai_gateway.models.credentials import Credentials
@@ -247,6 +249,28 @@ class Model(BaseModel):
         )
         prompt_manager.get_model_prompt(self.prompt_ref)
         return self
+
+
+class GatewayDeepSeekChatModel(ChatDeepSeek):
+    def _get_request_payload(
+        self,
+        input_: LanguageModelInput,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        messages = self._convert_input(input_).to_messages()
+        for msg_dict, msg in zip(payload['messages'], messages):
+            if (
+                isinstance(msg, AIMessage)
+                and msg_dict.get('role') == 'assistant'
+                and msg.additional_kwargs.get('reasoning_content')
+            ):
+                msg_dict['reasoning_content'] = msg.additional_kwargs[
+                    'reasoning_content'
+                ]
+        return payload
 
 
 # Mock models for testing purposes

--- a/gateway/radicalbit_ai_gateway/utils/chat_utils.py
+++ b/gateway/radicalbit_ai_gateway/utils/chat_utils.py
@@ -51,6 +51,9 @@ class ChatUtils:
                 content=content,
                 tool_calls=None,
             )
+            reasoning_content = ai_message.additional_kwargs.get('reasoning_content')
+            if reasoning_content:
+                message_to_send.reasoning_content = reasoning_content
             # Normalize finish_reason to lowercase (Gemini returns uppercase like 'STOP')
             finish_reason_raw = response_metadata.get('finish_reason', 'stop')
             finish_reason = (

--- a/gateway/radicalbit_ai_gateway/utils/chat_utils.py
+++ b/gateway/radicalbit_ai_gateway/utils/chat_utils.py
@@ -41,6 +41,9 @@ class ChatUtils:
                 content=None,
                 tool_calls=openai_tool_calls,
             )
+            reasoning_content = ai_message.additional_kwargs.get('reasoning_content')
+            if reasoning_content:
+                message_to_send.reasoning_content = reasoning_content
             finish_reason = 'tool_calls'
         else:
             content = ai_message.content

--- a/gateway/tests/models/test_chat_request.py
+++ b/gateway/tests/models/test_chat_request.py
@@ -165,3 +165,44 @@ def test_convert_messages():
     assert isinstance(result[0], SystemMessage)
     assert isinstance(result[1], HumanMessage)
     assert isinstance(result[2], AIMessage)
+
+
+def test_convert_openai_messages_assistant_with_reasoning_content():
+    messages = [
+        {'role': 'user', 'content': 'What is the capital of France?'},
+        {
+            'role': 'assistant',
+            'content': 'Paris.',
+            'reasoning_content': 'The user is asking a geography question...',
+        },
+    ]
+    result = convert_openai_messages(messages)
+    assert len(result) == 2
+    ai_msg = result[1]
+    assert isinstance(ai_msg, AIMessage)
+    assert ai_msg.content == 'Paris.'
+    assert ai_msg.additional_kwargs.get('reasoning_content') == (
+        'The user is asking a geography question...'
+    )
+
+
+def test_convert_openai_messages_assistant_without_reasoning_content():
+    messages = [
+        {'role': 'user', 'content': 'Hello'},
+        {'role': 'assistant', 'content': 'Hi there!'},
+    ]
+    result = convert_openai_messages(messages)
+    ai_msg = result[1]
+    assert isinstance(ai_msg, AIMessage)
+    assert 'reasoning_content' not in ai_msg.additional_kwargs
+
+
+def test_convert_openai_messages_reasoning_content_ignored_for_non_assistant():
+    messages = [
+        {'role': 'user', 'content': 'Hello', 'reasoning_content': 'should be ignored'},
+    ]
+    result = convert_openai_messages(messages)
+    assert isinstance(result[0], HumanMessage)
+    assert not hasattr(result[0], 'additional_kwargs') or 'reasoning_content' not in (
+        result[0].additional_kwargs or {}
+    )

--- a/gateway/tests/models/test_deepseek_reasoning.py
+++ b/gateway/tests/models/test_deepseek_reasoning.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from radicalbit_ai_gateway.models.model import GatewayDeepSeekChatModel
 
@@ -124,3 +124,60 @@ def test_multiple_assistant_messages_with_reasoning_content():
     assert 'reasoning_content' not in payload['messages'][0]
     assert 'reasoning_content' not in payload['messages'][2]
     assert 'reasoning_content' not in payload['messages'][4]
+
+
+def test_reasoning_content_injected_for_tool_call_assistant_message():
+    model = _make_model()
+    input_messages = [
+        HumanMessage(content="What's the weather in Paris?"),
+        AIMessage(
+            content='',
+            tool_calls=[
+                {
+                    'id': 'call_1',
+                    'name': 'get_weather',
+                    'args': {'city': 'Paris'},
+                    'type': 'tool_call',
+                }
+            ],
+            additional_kwargs={
+                'reasoning_content': 'I need to call the weather API to answer this.'
+            },
+        ),
+        ToolMessage(content='Sunny, 22°C', tool_call_id='call_1'),
+    ]
+    base_payload = _base_payload(
+        [
+            {'role': 'user', 'content': "What's the weather in Paris?"},
+            {
+                'role': 'assistant',
+                'content': '',
+                'tool_calls': [
+                    {
+                        'id': 'call_1',
+                        'function': {
+                            'name': 'get_weather',
+                            'arguments': '{"city": "Paris"}',
+                        },
+                        'type': 'function',
+                    }
+                ],
+            },
+            {'role': 'tool', 'content': 'Sunny, 22°C', 'tool_call_id': 'call_1'},
+        ]
+    )
+    with patch.object(
+        GatewayDeepSeekChatModel.__bases__[0],
+        '_get_request_payload',
+        return_value=base_payload,
+    ):
+        payload = model._get_request_payload(input_messages)
+
+    # reasoning_content must be injected on the assistant message with tool_calls
+    assert (
+        payload['messages'][1]['reasoning_content']
+        == 'I need to call the weather API to answer this.'
+    )
+    # user and tool messages must not carry reasoning_content
+    assert 'reasoning_content' not in payload['messages'][0]
+    assert 'reasoning_content' not in payload['messages'][2]

--- a/gateway/tests/models/test_deepseek_reasoning.py
+++ b/gateway/tests/models/test_deepseek_reasoning.py
@@ -1,0 +1,126 @@
+from unittest.mock import patch
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from radicalbit_ai_gateway.models.model import GatewayDeepSeekChatModel
+
+
+def _make_model() -> GatewayDeepSeekChatModel:
+    return GatewayDeepSeekChatModel(model='deepseek-reasoner', api_key='test-key')
+
+
+def _base_payload(messages: list[dict]) -> dict:
+    return {'model': 'deepseek-reasoner', 'messages': messages}
+
+
+def test_reasoning_content_injected_for_assistant_message():
+    model = _make_model()
+    input_messages = [
+        HumanMessage(content='What is 2+2?'),
+        AIMessage(
+            content='4.',
+            additional_kwargs={'reasoning_content': 'Simple arithmetic: 2+2=4.'},
+        ),
+        HumanMessage(content='And 3+3?'),
+    ]
+    base_payload = _base_payload(
+        [
+            {'role': 'user', 'content': '什么是2+2?'},
+            {'role': 'assistant', 'content': '4.'},
+            {'role': 'user', 'content': '和3+3?'},
+        ]
+    )
+    with patch.object(
+        GatewayDeepSeekChatModel.__bases__[0],
+        '_get_request_payload',
+        return_value=base_payload,
+    ):
+        payload = model._get_request_payload(input_messages)
+
+    assert payload['messages'][1]['reasoning_content'] == 'Simple arithmetic: 2+2=4.'
+    assert 'reasoning_content' not in payload['messages'][0]
+    assert 'reasoning_content' not in payload['messages'][2]
+
+
+def test_reasoning_content_not_injected_when_absent():
+    model = _make_model()
+    input_messages = [
+        HumanMessage(content='Hello'),
+        AIMessage(content='Hi there!'),
+    ]
+    base_payload = _base_payload(
+        [
+            {'role': 'user', 'content': 'Hello'},
+            {'role': 'assistant', 'content': 'Hi there!'},
+        ]
+    )
+    with patch.object(
+        GatewayDeepSeekChatModel.__bases__[0],
+        '_get_request_payload',
+        return_value=base_payload,
+    ):
+        payload = model._get_request_payload(input_messages)
+
+    for msg in payload['messages']:
+        assert 'reasoning_content' not in msg
+
+
+def test_reasoning_content_injected_only_for_assistant_role():
+    model = _make_model()
+    input_messages = [
+        SystemMessage(content='You are helpful.'),
+        HumanMessage(content='Hi'),
+        AIMessage(
+            content='Hello!',
+            additional_kwargs={'reasoning_content': 'Greeting response.'},
+        ),
+    ]
+    base_payload = _base_payload(
+        [
+            {'role': 'system', 'content': 'You are helpful.'},
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'assistant', 'content': 'Hello!'},
+        ]
+    )
+    with patch.object(
+        GatewayDeepSeekChatModel.__bases__[0],
+        '_get_request_payload',
+        return_value=base_payload,
+    ):
+        payload = model._get_request_payload(input_messages)
+
+    assert 'reasoning_content' not in payload['messages'][0]
+    assert 'reasoning_content' not in payload['messages'][1]
+    assert payload['messages'][2]['reasoning_content'] == 'Greeting response.'
+
+
+def test_multiple_assistant_messages_with_reasoning_content():
+    model = _make_model()
+    input_messages = [
+        HumanMessage(content='Turn 1'),
+        AIMessage(content='A1', additional_kwargs={'reasoning_content': 'R1'}),
+        HumanMessage(content='Turn 2'),
+        AIMessage(content='A2', additional_kwargs={'reasoning_content': 'R2'}),
+        HumanMessage(content='Turn 3'),
+    ]
+    base_payload = _base_payload(
+        [
+            {'role': 'user', 'content': 'Turn 1'},
+            {'role': 'assistant', 'content': 'A1'},
+            {'role': 'user', 'content': 'Turn 2'},
+            {'role': 'assistant', 'content': 'A2'},
+            {'role': 'user', 'content': 'Turn 3'},
+        ]
+    )
+    with patch.object(
+        GatewayDeepSeekChatModel.__bases__[0],
+        '_get_request_payload',
+        return_value=base_payload,
+    ):
+        payload = model._get_request_payload(input_messages)
+
+    assert payload['messages'][1]['reasoning_content'] == 'R1'
+    assert payload['messages'][3]['reasoning_content'] == 'R2'
+    assert 'reasoning_content' not in payload['messages'][0]
+    assert 'reasoning_content' not in payload['messages'][2]
+    assert 'reasoning_content' not in payload['messages'][4]

--- a/gateway/tests/utils/test_chat_utils.py
+++ b/gateway/tests/utils/test_chat_utils.py
@@ -1,0 +1,54 @@
+from langchain_core.messages import AIMessage
+
+from radicalbit_ai_gateway.utils.chat_utils import ChatUtils
+
+
+def test_to_openai_chat_completion_with_reasoning_content():
+    ai_message = AIMessage(
+        content='Paris is the capital of France.',
+        additional_kwargs={'reasoning_content': 'The user is asking about France...'},
+        response_metadata={'finish_reason': 'stop'},
+        usage_metadata={'input_tokens': 10, 'output_tokens': 8, 'total_tokens': 18},
+    )
+    result = ChatUtils.to_openai_chat_completion(
+        ai_message, model_id_invoked='deepseek-reasoner', request_id='req-123'
+    )
+    msg = result.choices[0].message
+    assert msg.content == 'Paris is the capital of France.'
+    assert msg.reasoning_content == 'The user is asking about France...'
+
+
+def test_to_openai_chat_completion_without_reasoning_content():
+    ai_message = AIMessage(
+        content='Paris is the capital of France.',
+        response_metadata={'finish_reason': 'stop'},
+        usage_metadata={'input_tokens': 10, 'output_tokens': 8, 'total_tokens': 18},
+    )
+    result = ChatUtils.to_openai_chat_completion(
+        ai_message, model_id_invoked='gpt-4o', request_id='req-456'
+    )
+    msg = result.choices[0].message
+    assert msg.content == 'Paris is the capital of France.'
+    assert not hasattr(msg, 'reasoning_content') or msg.reasoning_content is None
+
+
+def test_to_openai_chat_completion_reasoning_content_not_set_on_tool_calls():
+    ai_message = AIMessage(
+        content='',
+        additional_kwargs={'reasoning_content': 'some reasoning'},
+        tool_calls=[
+            {
+                'id': 'call_1',
+                'name': 'get_weather',
+                'args': {'city': 'Rome'},
+                'type': 'tool_call',
+            }
+        ],
+        response_metadata={'finish_reason': 'tool_calls'},
+    )
+    result = ChatUtils.to_openai_chat_completion(
+        ai_message, model_id_invoked='deepseek-reasoner', request_id='req-789'
+    )
+    msg = result.choices[0].message
+    assert msg.tool_calls is not None
+    assert not hasattr(msg, 'reasoning_content') or msg.reasoning_content is None

--- a/gateway/tests/utils/test_chat_utils.py
+++ b/gateway/tests/utils/test_chat_utils.py
@@ -32,7 +32,11 @@ def test_to_openai_chat_completion_without_reasoning_content():
     assert not hasattr(msg, 'reasoning_content') or msg.reasoning_content is None
 
 
-def test_to_openai_chat_completion_reasoning_content_not_set_on_tool_calls():
+def test_to_openai_chat_completion_reasoning_content_set_on_tool_calls():
+    """DeepSeek requires reasoning_content echoed back in multi-turn tool call flows.
+    The gateway must include it in Turn 1 tool_call responses so the client can send
+    it back in Turn 2.
+    """
     ai_message = AIMessage(
         content='',
         additional_kwargs={'reasoning_content': 'some reasoning'},
@@ -51,4 +55,4 @@ def test_to_openai_chat_completion_reasoning_content_not_set_on_tool_calls():
     )
     msg = result.choices[0].message
     assert msg.tool_calls is not None
-    assert not hasattr(msg, 'reasoning_content') or msg.reasoning_content is None
+    assert msg.reasoning_content == 'some reasoning'


### PR DESCRIPTION
# PR Summary
End-to-end support for DeepSeek reasoning models (`deepseek-reasoner`, `deepseek-v4-pro`): `reasoning_content` is now preserved across multi-turn conversations — including tool-call flows — and correctly injected back into outbound DeepSeek API requests.

---

## New Model: `GatewayDeepSeekChatModel` (`models/model.py`) — NEW

Custom LangChain chat model that extends `ChatDeepSeek` to handle `reasoning_content` in multi-turn conversations.

**Why it's needed:** DeepSeek reasoning models return a `reasoning_content` field alongside the assistant's `content`. In multi-turn conversations (including tool-call flows), DeepSeek requires that field to be echoed back in the `messages` array of subsequent API requests — but the standard `ChatDeepSeek` drops it. This class overrides `_get_request_payload` and injects it before the HTTP call.

**Behavior:**
- For each assistant message in the outbound payload, if the corresponding LangChain `AIMessage` carries `additional_kwargs['reasoning_content']`, it is injected into the message dict sent to DeepSeek.
- Applies to both regular text responses and tool-call assistant messages.
- All other providers are unaffected.

---

## DTO Changes

### `ChatCompletionMessage` — response (MODIFIED)

**Changes:**
```diff
+ reasoning_content: string | null  (added)
```

| Field | Type | Description |
|-------|------|-------------|
| `role` | string | `"assistant"` |
| `content` | string \| null | Model's text reply |
| `reasoning_content` **NEW** | string \| null | DeepSeek chain-of-thought reasoning. Present only when the model returns it. `null` / absent for all other providers. |
| `tool_calls` | object[] \| null | Tool calls, unchanged |
| `finish_reason` | string | `"stop"`, `"tool_calls"`, `"length"`, etc. |

**Example response — regular turn:**
```json
{
  "id": "chatcmpl-abc123",
  "object": "chat.completion",
  "model": "my-project/deepseek-reasoner-route",
  "choices": [
    {
      "index": 0,
      "finish_reason": "stop",
      "message": {
        "role": "assistant",
        "content": "2 + 2 equals 4.",
        "reasoning_content": "The user is asking a basic arithmetic question. 2+2=4."
      }
    }
  ],
  "usage": {
    "prompt_tokens": 17,
    "completion_tokens": 29,
    "total_tokens": 46
  }
}
```

**Example response — tool call turn:**
```json
{
  "id": "chatcmpl-abc456",
  "object": "chat.completion",
  "model": "my-project/deepseek-reasoner-route",
  "choices": [
    {
      "index": 0,
      "finish_reason": "tool_calls",
      "message": {
        "role": "assistant",
        "content": null,
        "reasoning_content": "I need to call the weather API to answer this question.",
        "tool_calls": [
          {
            "id": "call_1",
            "type": "function",
            "function": {
              "name": "get_weather",
              "arguments": "{\"city\": \"Paris\"}"
            }
          }
        ]
      }
    }
  ]
}
```

---

### `ChatCompletionMessageParam` — request (MODIFIED)

**Changes:**
```diff
+ reasoning_content: string | null  (added, optional, assistant role only)
```

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `role` | string | yes | `"user"`, `"assistant"`, `"system"`, `"tool"` |
| `content` | string \| null | yes | Message text |
| `reasoning_content` **NEW** | string \| null | no | DeepSeek chain-of-thought from a prior assistant turn. Must be echoed back verbatim in multi-turn conversations. Ignored for non-assistant roles and non-DeepSeek models. |
| `tool_calls` | object[] \| null | no | Tool calls, unchanged |

**Example multi-turn request (regular):**
```json
{
  "model": "my-project/deepseek-reasoner-route",
  "messages": [
    {"role": "user", "content": "What is 2+2?"},
    {
      "role": "assistant",
      "content": "4",
      "reasoning_content": "The user is asking what 2+2 is. The answer is 4."
    },
    {"role": "user", "content": "And 3+3?"}
  ]
}
```

**Example multi-turn request (tool-call flow):**
```json
{
  "model": "my-project/deepseek-reasoner-route",
  "messages": [
    {"role": "user", "content": "What's the weather in Paris?"},
    {
      "role": "assistant",
      "content": null,
      "reasoning_content": "I need to call the weather API to answer this question.",
      "tool_calls": [
        {
          "id": "call_1",
          "type": "function",
          "function": {"name": "get_weather", "arguments": "{\"city\": \"Paris\"}"}
        }
      ]
    },
    {"role": "tool", "content": "Sunny, 22°C", "tool_call_id": "call_1"},
    {"role": "user", "content": "Is it hot?"}
  ]
}
```

---

## Affected Endpoints

### `POST /v1/chat/completions` (MODIFIED)

No new parameters. Behavioral changes only:

| Scenario | Before | After |
|----------|--------|-------|
| DeepSeek reasoning model, single turn | `reasoning_content` absent from response | `reasoning_content` included in response message |
| DeepSeek reasoning model, tool-call Turn 1 | `reasoning_content` absent from response | `reasoning_content` included in response message (required for Turn 2 to work) |
| DeepSeek multi-turn with `reasoning_content` in assistant message | `reasoning_content` dropped, DeepSeek returns 400 | `reasoning_content` correctly injected into outbound payload |
| All other providers | unchanged | unchanged |

---

## Other Changes

| File | Change |
|------|--------|
| `invocation/chat_model_invoker.py` | Routes `deepseek` provider to `GatewayDeepSeekChatModel` instead of generic `init_chat_model` |
| `models/chat_request.py` — `convert_openai_messages()` | Reads `reasoning_content` from incoming assistant messages and stores it in `AIMessage.additional_kwargs` |
| `utils/chat_utils.py` — `ChatUtils.to_openai_chat_completion()` | Writes `reasoning_content` from `AIMessage.additional_kwargs` to outbound response — for both `stop` and `tool_calls` finish reasons |
| `tests/models/test_chat_request.py` | 3 new unit tests for `reasoning_content` handling in `convert_openai_messages` |
| `tests/models/test_deepseek_reasoning.py` | 5 unit tests for `GatewayDeepSeekChatModel._get_request_payload` injection logic, including the tool-call scenario |
| `tests/utils/test_chat_utils.py` | 3 unit tests for `ChatUtils.to_openai_chat_completion` with/without `reasoning_content`, including the tool-call response case |
