### PR TITLE
feat: add projects filter status

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
@@ -44,6 +44,10 @@ class ProjectDAO:
                 stmt = stmt.where(Project.config_file.is_not(None))
             elif project_filter == ProjectFilter.WITH_USAGE:
                 stmt = stmt.where(Project.first_served_at.is_not(None))
+            elif project_filter == ProjectFilter.DEV:
+                stmt = stmt.where(Project.config_file.is_(None))
+            elif project_filter == ProjectFilter.PROD:
+                stmt = stmt.where(Project.config_file.is_not(None))
             return session.scalars(stmt).all()
 
     def get_all_with_config(self) -> Sequence[Project]:

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -14,6 +14,16 @@ from radicalbit_ai_gateway.utils.yaml_utils import get_default_config_template
 class ProjectFilter(str, Enum):
     ACTIVE = 'active'
     WITH_USAGE = 'with_usage'
+    DEV = 'dev'
+    PROD = 'prod'
+
+    @classmethod
+    def _missing_(cls, value: object):
+        if isinstance(value, str):
+            for member in cls:
+                if member.value == value.lower():
+                    return member
+        return None
 
 
 class ProjectIn(BaseModel, validate_assignment=True):

--- a/gateway/tests/dao/project_dao_test.py
+++ b/gateway/tests/dao/project_dao_test.py
@@ -166,6 +166,36 @@ class ProjectDAOTest(DatabaseIntegration):
         assert len(result) == 1
         assert result[0].name == 'was-served'
 
+    def test_get_all_filtered_dev_returns_only_without_config_file(self):
+        self.project_dao.insert(
+            db_mock.get_sample_project(
+                uuid=uuid.uuid4(), name='no-config', config_file=None
+            )
+        )
+        self.project_dao.insert(
+            db_mock.get_sample_project(
+                uuid=uuid.uuid4(), name='with-config', config_file='yaml'
+            )
+        )
+        result = self.project_dao.get_all_filtered(ProjectFilter.DEV)
+        assert len(result) == 1
+        assert result[0].name == 'no-config'
+
+    def test_get_all_filtered_prod_returns_only_with_config_file(self):
+        self.project_dao.insert(
+            db_mock.get_sample_project(
+                uuid=uuid.uuid4(), name='no-config', config_file=None
+            )
+        )
+        self.project_dao.insert(
+            db_mock.get_sample_project(
+                uuid=uuid.uuid4(), name='with-config', config_file='yaml'
+            )
+        )
+        result = self.project_dao.get_all_filtered(ProjectFilter.PROD)
+        assert len(result) == 1
+        assert result[0].name == 'with-config'
+
     # --- soft_delete ---
 
     def test_soft_delete(self):

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -479,3 +479,27 @@ routes:
         result = self.project_service.get_all_filtered(None)
         self.project_dao.get_all_filtered.assert_called_once_with(None)
         assert len(result) == 2
+
+    def test_get_all_filtered_dev_delegates_to_dao(self):
+        projects = [
+            db_mock.get_sample_project(
+                uuid=uuid.uuid4(), name='no-config', config_file=None
+            ),
+        ]
+        self.project_dao.get_all_filtered = MagicMock(return_value=projects)
+        result = self.project_service.get_all_filtered(ProjectFilter.DEV)
+        self.project_dao.get_all_filtered.assert_called_once_with(ProjectFilter.DEV)
+        assert len(result) == 1
+        assert result == [ProjectOut.from_project(p) for p in projects]
+
+    def test_get_all_filtered_prod_delegates_to_dao(self):
+        projects = [
+            db_mock.get_sample_project(
+                uuid=uuid.uuid4(), name='with-config', config_file='yaml'
+            ),
+        ]
+        self.project_dao.get_all_filtered = MagicMock(return_value=projects)
+        result = self.project_service.get_all_filtered(ProjectFilter.PROD)
+        self.project_dao.get_all_filtered.assert_called_once_with(ProjectFilter.PROD)
+        assert len(result) == 1
+        assert result == [ProjectOut.from_project(p) for p in projects]


### PR DESCRIPTION
# PR Summary: feat/ag-753-get-projects-by-status

Adds `dev` and `prod` filter values to `GET /projects`, allowing callers to retrieve only projects in DEV state (no served config) or PROD state (active served config). The filter is case-insensitive.

---

## DTO Changes

### `ProjectFilter` (MODIFIED)

**Changes:**
```diff
+ DEV = 'dev'   (added)
+ PROD = 'prod'  (added)
+ _missing_ classmethod for case-insensitive matching (added)
```

| Value | Description |
|-------|-------------|
| `active` | Projects with a served config (`config_file IS NOT NULL`) |
| `with_usage` | Projects that have been served at least once |
| `dev` **NEW** | Projects without a served config (`config_file IS NULL`) |
| `prod` **NEW** | Projects with a served config (`config_file IS NOT NULL`) |

> All values are case-insensitive: `PROD`, `Prod`, `prod` are equivalent.

---

## Affected Endpoints

### `GET /projects` (MODIFIED)

**Changes:**
```diff
+ filter=dev   (added)
+ filter=prod  (added)
? filter values are now case-insensitive (was case-sensitive)
```

**Example requests:**
```
GET /public/api/v1/projects?filter=dev
GET /public/api/v1/projects?filter=prod
GET /public/api/v1/projects?filter=PROD   ← also valid (case-insensitive)
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `filter` | string | no | One of: `active`, `with_usage`, `dev`, `prod` (case-insensitive). Omit to return all projects. |

**Example response (`filter=dev`):**
```json
[
  {
    "uuid": "550e8400-e29b-41d4-a716-446655440000",
    "name": "my-project",
    "description": null,
    "configFile": null,
    "draftConfigFile": "# Minimal gateway configuration template...",
    "configStatus": "DRAFT",
    "projectStatus": "DEV",
    "createdAt": "2026-05-25T10:00:00Z",
    "updatedAt": "2026-05-25T10:00:00Z"
  }
]
```

**Example response (`filter=prod`):**
```json
[
  {
    "uuid": "661f9511-f3ac-52e5-b827-557766551111",
    "name": "my-served-project",
    "description": "A production project",
    "configFile": "chat_models:\n  - model_id: ...",
    "draftConfigFile": null,
    "configStatus": "SERVED",
    "projectStatus": "PROD",
    "createdAt": "2026-05-20T08:00:00Z",
    "updatedAt": "2026-05-25T12:00:00Z"
  }
]
```

**Invalid filter returns 422:**
```json
{
  "detail": [
    {
      "type": "enum",
      "loc": ["query", "filter"],
      "msg": "Input should be 'active', 'with_usage', 'dev' or 'prod'",
      "input": "invalid_value"
    }
  ]
}
```

---

## Other Changes

- `db/dao/project_dao.py` — extended `get_all_filtered` with two new `elif` branches: `DEV` filters `config_file IS NULL`, `PROD` filters `config_file IS NOT NULL`
- `tests/dao/project_dao_test.py` — added integration tests for `filter=dev` and `filter=prod`
- `tests/services/project_service_test.py` — added unit tests verifying delegation to DAO for `DEV` and `PROD` filters
- `scripts/test_project_filter.sh` — manual E2E test script against a running Docker Compose stack (creates projects, asserts filters, cleans up)
