### PR TITLE
feat: add cancel-approval

### DIFF
--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -107,6 +107,17 @@ class ProjectRoute:
             return project
 
         @router.patch(
+            '/projects/{project_uuid}/cancel-approval',
+            status_code=200,
+            response_model=ProjectOut,
+        )
+        @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
+        def cancel_approval(project_uuid: UUID):
+            project = project_service.cancel_approval(project_uuid)
+            logger.info('Cancelled approval for project %s', project_uuid)
+            return project
+
+        @router.patch(
             '/projects/{project_uuid}/serve-config',
             status_code=200,
             response_model=ProjectOut,

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -70,6 +70,18 @@ class ProjectService:
             raise ProjectNotFoundError(f'Project with UUID {project_uuid} not found')
         return ProjectOut.from_project(updated_project)
 
+    def cancel_approval(self, project_uuid: UUID) -> ProjectOut:
+        project = self._get_project_or_raise(project_uuid)
+
+        if project.config_status != ConfigStatus.READY_TO_SERVE.value:
+            raise ProjectConfigValidationError(
+                f'Project {project_uuid} is not in READY_TO_SERVE state'
+            )
+
+        self.project_dao.set_config_status(project_uuid, ConfigStatus.DRAFT)
+
+        return self._get_updated_or_raise(project_uuid)
+
     def approve_config(self, project_uuid: UUID) -> ProjectOut:
         project = self._get_project_or_raise(project_uuid)
 

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -222,6 +222,62 @@ class TestProjectRoute(unittest.TestCase):
             ).error
         )
 
+    # --- cancel-approval ---
+
+    def test_cancel_approval_ok(self):
+        config_in = db_mock.get_sample_project_config_file_in()
+        project = db_mock.get_sample_project(
+            draft_config_file=config_in.config_file,
+        )
+        project_out = ProjectOut.from_project(project)
+        self.project_service.cancel_approval = MagicMock(return_value=project_out)
+        res = self.client.patch(
+            f'{self.prefix}/projects/{project.uuid}/cancel-approval'
+        )
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder(project_out)
+        self.project_service.cancel_approval.assert_called_once_with(project.uuid)
+
+    def test_cancel_approval_not_found(self):
+        unknown_uuid = uuid.uuid4()
+        self.project_service.cancel_approval = MagicMock(
+            side_effect=ProjectNotFoundError('error')
+        )
+        res = self.client.patch(
+            f'{self.prefix}/projects/{unknown_uuid}/cancel-approval'
+        )
+        assert res.status_code == 404
+        assert (
+            res.json()['error']
+            == ErrorOut(
+                'error',
+                'auth_registry_error',
+                code='project_not_found',
+                param=None,
+            ).error
+        )
+
+    def test_cancel_approval_wrong_status(self):
+        project_uuid = uuid.uuid4()
+        self.project_service.cancel_approval = MagicMock(
+            side_effect=ProjectConfigValidationError('error')
+        )
+        res = self.client.patch(
+            f'{self.prefix}/projects/{project_uuid}/cancel-approval'
+        )
+        assert res.status_code == 400
+        assert (
+            res.json()['error']
+            == ErrorOut(
+                'error',
+                'auth_registry_error',
+                code='project_config_validation_error',
+                param=None,
+            ).error
+        )
+
+    # --- serve-config ---
+
     def test_serve_config_ok(self):
         config_in = db_mock.get_sample_project_config_file_in()
         project = db_mock.get_sample_project(

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -164,6 +164,51 @@ routes:
         saved_content = self.project_dao.update_draft_config_file.call_args[0][1]
         assert '!secret OPENAI_API_KEY' in saved_content
 
+    # --- cancel_approval ---
+
+    def test_cancel_approval_ok(self):
+        config_in = db_mock.get_sample_project_config_file_in()
+        project = db_mock.get_sample_project(
+            draft_config_file=config_in.config_file,
+            config_status=ConfigStatus.READY_TO_SERVE,
+        )
+        cancelled_project = db_mock.get_sample_project(
+            draft_config_file=config_in.config_file,
+            config_status=ConfigStatus.DRAFT,
+        )
+        self.project_dao.get_by_uuid = MagicMock(
+            side_effect=[project, cancelled_project]
+        )
+        self.project_dao.set_config_status = MagicMock(return_value=1)
+        result = self.project_service.cancel_approval(project.uuid)
+        self.project_dao.set_config_status.assert_called_once_with(
+            project.uuid, ConfigStatus.DRAFT
+        )
+        assert result.config_status == ConfigStatus.DRAFT
+
+    def test_cancel_approval_project_not_found(self):
+        self.project_dao.get_by_uuid = MagicMock(return_value=None)
+        with pytest.raises(ProjectNotFoundError):
+            self.project_service.cancel_approval(uuid.uuid4())
+
+    def test_cancel_approval_wrong_status_draft(self):
+        project = db_mock.get_sample_project(
+            config_status=ConfigStatus.DRAFT,
+        )
+        self.project_dao.get_by_uuid = MagicMock(return_value=project)
+        with pytest.raises(ProjectConfigValidationError):
+            self.project_service.cancel_approval(project.uuid)
+
+    def test_cancel_approval_wrong_status_served(self):
+        config_in = db_mock.get_sample_project_config_file_in()
+        project = db_mock.get_sample_project(
+            config_file=config_in.config_file,
+            config_status=ConfigStatus.SERVED,
+        )
+        self.project_dao.get_by_uuid = MagicMock(return_value=project)
+        with pytest.raises(ProjectConfigValidationError):
+            self.project_service.cancel_approval(project.uuid)
+
     # --- approve_config ---
 
     def test_approve_config_ok(self):


### PR DESCRIPTION
## Summary
# PR Summary: feat/add-cancel-approval

Adds a new endpoint to revert a project's config approval, transitioning `config_status` from `READY_TO_SERVE` back to `DRAFT` without requiring a new config upload via `load-config`.

---

## DTO Changes

No DTO changes. The endpoint reuses the existing `ProjectOut` response model.

---

## Affected Endpoints

### `PATCH /projects/{project_uuid}/cancel-approval` (NEW)

Cancels a previously approved configuration, resetting `configStatus` to `DRAFT`. Only valid when the project is in `READY_TO_SERVE` state. Has no effect on `draftConfigFile` or `configFile`.

**Example request:**
```
PATCH /projects/550e8400-e29b-41d4-a716-446655440000/cancel-approval
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string (UUID) | yes | Project identifier (path) |

**Example response (200):**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "name": "my-project",
  "description": "Example project",
  "configFile": null,
  "draftConfigFile": "chat_models:\n  - model_id: gpt4o\n    model: openai/gpt-4o\nroutes:\n  default:\n    chat_models:\n      - gpt4o\n",
  "configStatus": "DRAFT",
  "projectStatus": "DEV",
  "createdAt": "2024-01-15T10:30:00Z",
  "updatedAt": "2024-01-15T11:00:00Z"
}
```

**Error responses:**

| Status | Code | When |
|--------|------|------|
| 400 | `project_config_validation_error` | Project is not in `READY_TO_SERVE` state |
| 404 | `project_not_found` | Project UUID does not exist |

**Lifecycle context:**
```
DRAFT → [approve-config] → READY_TO_SERVE → [serve-config] → SERVED
                              ↓
                     [cancel-approval]
                              ↓
                            DRAFT
```

---

## Other Changes

- `services/project_service.py` — New `cancel_approval` method: validates `READY_TO_SERVE` state, calls existing `set_config_status` DAO method
- `tests/services/project_service_test.py` — 4 test cases (happy path, not found, wrong status DRAFT, wrong status SERVED)
- `tests/routes/test_project_route.py` — 3 test cases (happy path, not found, wrong status)


## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
