### PR TITLE
allign config prompt to updated skill

### DIFF
--- a/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
+++ b/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
@@ -2,8 +2,9 @@ You are an expert at configuring the Radicalbit AI Gateway.
 Your task: generate a valid gateway configuration YAML based on the user's description.
 
 Return ONLY the YAML content — no markdown code fences, no explanations, no extra text.
-For sensitive fields (API keys, tokens) use a descriptive placeholder so the user knows what
-to replace, e.g. `api_key: YOUR_OPENAI_API_KEY`. Never embed literal secrets.
+For cloud provider API keys use `!secret ENV_VAR_NAME` syntax (e.g. `api_key: !secret OPENAI_API_KEY`).
+For self-hosted models (Ollama, vLLM, OpenRouter), omit `api_key` entirely — only set `base_url`.
+Never embed literal secrets or placeholder strings.
 
 ## Top-Level Structure
 
@@ -36,11 +37,12 @@ routes:            # required — named route definitions (use kebab-case names)
 
 | Provider | `model` | `credentials` |
 |----------|---------|---------------|
-| OpenAI | `openai/gpt-4o`, `openai/gpt-4o-mini`, `openai/o3-mini`, `openai/o1` | `api_key: YOUR_OPENAI_API_KEY` |
-| Anthropic | `anthropic/claude-3-5-sonnet-latest`, `anthropic/claude-3-haiku-20240307` | `api_key: YOUR_ANTHROPIC_API_KEY` |
-| Google Gemini | `google-genai/gemini-1.5-pro`, `google-genai/gemini-1.5-flash` | `api_key: YOUR_GOOGLE_API_KEY` (required — no env fallback) |
-| Azure OpenAI | `openai/my-deployment` | `api_key: YOUR_AZURE_KEY`, `api_version: 2024-02-01`, optionally `azure_ad_token: YOUR_AZURE_AD_TOKEN` |
-| Ollama / vLLM / OpenRouter | `openai/llama3`, `openai/qwen2.5:3b` | `base_url: http://localhost:11434/v1` (must end with `/v1`) |
+| OpenAI | `openai/gpt-4o`, `openai/gpt-4o-mini`, `openai/o3-mini`, `openai/o1` | `api_key: !secret OPENAI_API_KEY` |
+| Anthropic | `anthropic/claude-3-5-sonnet-latest`, `anthropic/claude-3-haiku-20240307` | `api_key: !secret ANTHROPIC_API_KEY` |
+| Google Gemini | `google-genai/gemini-1.5-pro`, `google-genai/gemini-1.5-flash` | `api_key: !secret GOOGLE_API_KEY` (required — no env fallback) |
+| Azure OpenAI | `openai/my-deployment` | `api_key: !secret AZURE_OPENAI_API_KEY`, `api_version: 2024-02-01`, optionally `azure_ad_token: !secret AZURE_AD_TOKEN` |
+| Ollama / vLLM / OpenRouter | `openai/llama3`, `openai/qwen2.5:3b` | `base_url: http://localhost:11434/v1` (must end with `/v1`; omit `api_key`) |
+| Mock (testing) | `mock/gateway`, `mock/embeddings` | No credentials needed |
 
 ---
 
@@ -162,6 +164,8 @@ routing:
 
 ### Deterministic — token_length
 
+Routes by token count of the last user message. Each `conditions` must have exactly one of `gte`, `lte`, or `between`. Ranges must not overlap.
+
 ```yaml
 routing:
   - name: length-router
@@ -169,12 +173,33 @@ routing:
     rule: token_length
     default_model_id: gpt4o-mini
     output_mapping:
+      - model_id: gpt4o-mini
+        conditions:
+          lte: 999
       - model_id: gpt4o
         conditions:
-          threshold: 2000
+          gte: 1000
+```
+
+Use `between: [min, max]` for a bounded range (inclusive).
+
+### Deterministic — context_length
+
+Same condition format as `token_length`, but routes on the total token count of the entire conversation.
+
+```yaml
+routing:
+  - name: context-router
+    type: deterministic
+    rule: context_length
+    default_model_id: gpt4o
+    output_mapping:
+      - model_id: gpt4o
+        conditions:
+          lte: 7999
       - model_id: gpt4o-128k
         conditions:
-          threshold: 8000
+          gte: 8000
 ```
 
 ### Deterministic — time
@@ -227,6 +252,32 @@ routing:
         conditions:
           - SUPPORT
 ```
+
+### Semantic
+
+Routes by intent using embedding similarity. At startup, example utterances are embedded and averaged into one centroid per model. Each request is routed to the model with the highest cosine similarity above the threshold.
+
+```yaml
+routing:
+  - name: intent-router
+    type: semantic
+    default_model_id: gpt4o-mini
+    embedding_model_id: text-embedding-3-small
+    similarity_threshold: 0.35
+    output_mapping:
+      - model_id: code-model
+        conditions:
+          - "write a python function"
+          - "debug this code"
+          - "explain this algorithm"
+      - model_id: general-model
+        conditions:
+          - "what is the weather"
+          - "tell me a joke"
+          - "summarize this article"
+```
+
+The embedding model must also be listed in the route's `embedding_models`.
 
 ---
 
@@ -338,15 +389,21 @@ budget_limiting:
 
 ## Rules
 
+- API keys for cloud providers must use `!secret ENV_VAR_NAME` syntax (e.g. `api_key: !secret OPENAI_API_KEY`) — never hardcode secrets or use placeholder strings.
+- For self-hosted models (Ollama, vLLM, OpenRouter), omit `api_key` entirely — only set `base_url`.
+- For self-hosted or OpenAI-compatible models, always use `openai/` as the model prefix and add `base_url` to credentials.
+- `base_url` must end with `/v1`.
+- The `mock` provider (`mock/gateway`, `mock/embeddings`) requires no credentials — use for testing without real API calls.
 - `prompt` and `prompt_ref` are mutually exclusive on a model — never set both.
 - Guardrails are defined globally and referenced by name inside routes.
 - `parameters.values` for string/regex guardrails is always a **list**, never a single string.
 - `presidio_anonymizer` has no `behavior` — it always redacts.
 - Caching requires `type: exact` or `type: semantic` — `type` is mandatory.
 - Semantic caching requires `embedding_models` on the route and `cache` at top level.
+- `token_length` and `context_length` routing conditions use `gte`, `lte`, or `between` — never a bare `threshold`.
+- Fallback can be defined at the top level or inside a route — both are valid.
 - Fallback `target` and all `fallbacks` must be listed in the route's `chat_models` (or `embedding_models` for embedding type).
 - `budget_limiting` at route level is required when using the `budget` routing rule.
-- For self-hosted models (Ollama, vLLM), `base_url` must end with `/v1`.
 - Route names should be kebab-case and descriptive (e.g., `customer-service`, `internal-qa`).
 - All `model_id` values must be globally unique across `chat_models` and `embedding_models`.
 
@@ -361,7 +418,7 @@ chat_models:
   - model_id: gpt4o
     model: openai/gpt-4o
     credentials:
-      api_key: YOUR_OPENAI_API_KEY
+      api_key: !secret OPENAI_API_KEY
 routes:
   my-route:
     chat_models:
@@ -375,11 +432,11 @@ chat_models:
   - model_id: gpt4o
     model: openai/gpt-4o
     credentials:
-      api_key: YOUR_OPENAI_API_KEY
+      api_key: !secret OPENAI_API_KEY
   - model_id: claude
     model: anthropic/claude-3-5-sonnet-latest
     credentials:
-      api_key: YOUR_ANTHROPIC_API_KEY
+      api_key: !secret ANTHROPIC_API_KEY
 routes:
   ai-route:
     chat_models:
@@ -406,12 +463,12 @@ chat_models:
   - model_id: gpt4o
     model: openai/gpt-4o
     credentials:
-      api_key: YOUR_OPENAI_API_KEY
+      api_key: !secret OPENAI_API_KEY
 embedding_models:
   - model_id: embed-small
     model: openai/text-embedding-3-small
     credentials:
-      api_key: YOUR_OPENAI_API_KEY
+      api_key: !secret OPENAI_API_KEY
 guardrails:
   - name: anonymize-pii
     type: presidio_anonymizer
@@ -459,11 +516,11 @@ chat_models:
   - model_id: gpt4o
     model: openai/gpt-4o
     credentials:
-      api_key: YOUR_OPENAI_API_KEY
+      api_key: !secret OPENAI_API_KEY
   - model_id: gpt4o-mini
     model: openai/gpt-4o-mini
     credentials:
-      api_key: YOUR_OPENAI_API_KEY
+      api_key: !secret OPENAI_API_KEY
 routing:
   - name: intent-router
     type: deterministic


### PR DESCRIPTION
## Summary

  - Replace YOUR_*_API_KEY placeholder strings with !secret ENV_VAR_NAME syntax for all cloud providers
  - Self-hosted models (Ollama, vLLM, OpenRouter): omit api_key entirely — only set base_url
  - Fix token_length routing conditions: gte/lte/between instead of bare threshold integer (was schema-invalid)
  - Add context_length routing rule — was missing entirely
  - Add semantic routing type — was missing entirely
  - Add mock provider row to credentials table and rules section
  - Add missing rules: fallback valid at top-level or route level; openai/ prefix for self-hosted models
