### PR TITLE
feat: two config model for project

### DIFF
--- a/gateway/alembic/env.py
+++ b/gateway/alembic/env.py
@@ -9,6 +9,8 @@ from radicalbit_ai_gateway.db.database import Database, BaseTable
 from radicalbit_ai_gateway.db.tables.group_route_table import *
 from radicalbit_ai_gateway.db.tables.group_table import *
 from radicalbit_ai_gateway.db.tables.key_table import *
+from radicalbit_ai_gateway.db.tables.project_config_table import *
+from radicalbit_ai_gateway.db.tables.project_table import *
 from radicalbit_ai_gateway.utils.app_config import get_app_config
 
 

--- a/gateway/alembic/versions/b3c4d5e6f7a8_add_project_config_table.py
+++ b/gateway/alembic/versions/b3c4d5e6f7a8_add_project_config_table.py
@@ -1,10 +1,5 @@
 """add_project_config_table
 
-Splits project configurations into a dedicated ``project_config`` table
-(two permanent slots A/B per project, at most one SERVED) and migrates the
-legacy ``CONFIG_FILE`` / ``DRAFT_CONFIG_FILE`` / ``CONFIG_STATUS`` columns of
-``project`` into it. See AG-778.
-
 Revision ID: b3c4d5e6f7a8
 Revises: a2b3c4d5e6f7
 Create Date: 2026-06-10 00:00:00.000000
@@ -12,52 +7,22 @@ Create Date: 2026-06-10 00:00:00.000000
 """
 
 from collections.abc import Sequence
-import datetime
-from importlib.resources import files
 from typing import Union
-import uuid
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-
-def _default_config_template() -> str:
-    # Read the template directly from resources so this migration stays
-    # self-contained: the migrations image installs only the `migrations`
-    # dependency group, which has no PyYAML, and importing
-    # radicalbit_ai_gateway.utils.yaml_utils would pull `import yaml`.
-    return (
-        files('radicalbit_ai_gateway.resources')
-        .joinpath('default_config.yaml')
-        .read_text()
-    )
-
-# revision identifiers, used by Alembic.
 revision: str = 'b3c4d5e6f7a8'
 down_revision: Union[str, None] = 'a2b3c4d5e6f7'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
-
-_INSERT_CONFIG = sa.text(
-    'INSERT INTO project_config '
-    '("UUID", "PROJECT_UUID", "SLOT", "CONFIG_FILE", "CONFIG_STATUS", '
-    '"CREATED_AT", "UPDATED_AT", "DELETED_AT") '
-    'VALUES (:uuid, :project_uuid, CAST(:slot AS project_config_slot), '
-    ':config_file, CAST(:status AS project_config_status), '
-    ':created_at, :updated_at, :deleted_at)'
-)
-
 
 def upgrade() -> None:
     bind = op.get_bind()
 
-    # 1. Enums: create the new slot enum explicitly; the config_status enum
-    #    already exists and is reused. Both are passed to create_table with
-    #    create_type=False so it does not (re)emit CREATE TYPE.
     slot_enum = postgresql.ENUM(
         'A', 'B', name='project_config_slot', create_type=False
     )
@@ -70,7 +35,6 @@ def upgrade() -> None:
         create_type=False,
     )
 
-    # 2. project_config table.
     op.create_table(
         'project_config',
         sa.Column('UUID', sa.UUID(), nullable=False),
@@ -97,7 +61,6 @@ def upgrade() -> None:
             'PROJECT_UUID', 'SLOT', name='uq_project_config_PROJECT_UUID_SLOT'
         ),
     )
-    # At most one SERVED config per project.
     op.create_index(
         'uq_project_config_served',
         'project_config',
@@ -106,7 +69,6 @@ def upgrade() -> None:
         postgresql_where=sa.text('"CONFIG_STATUS" = \'SERVED\''),
     )
 
-    # 3. Reference to the served config on the project row.
     op.add_column(
         'project',
         sa.Column('SERVED_CONFIG_UUID', sa.UUID(), nullable=True),
@@ -120,77 +82,6 @@ def upgrade() -> None:
         ondelete='SET NULL',
     )
 
-    # 4. Data migration: every project ends up with exactly 2 slots (A, B).
-    template = _default_config_template()
-    projects = bind.execute(
-        sa.text(
-            'SELECT "UUID", "CONFIG_FILE", "DRAFT_CONFIG_FILE", "CONFIG_STATUS", '
-            '"UPDATED_AT", "DELETED_AT" FROM project'
-        )
-    ).fetchall()
-
-    for row in projects:
-        project_uuid = row[0]
-        config_file = row[1]
-        draft_config_file = row[2]
-        config_status = row[3]
-        updated_at = row[4]
-        deleted_at = row[5]
-
-        has_served = config_file is not None
-
-        # Slot A: the served config, or an empty template draft.
-        slot_a_uuid = uuid.uuid4()
-        bind.execute(
-            _INSERT_CONFIG,
-            {
-                'uuid': slot_a_uuid,
-                'project_uuid': project_uuid,
-                'slot': 'A',
-                'config_file': config_file if has_served else template,
-                'status': 'SERVED' if has_served else 'DRAFT',
-                'created_at': updated_at,
-                'updated_at': updated_at,
-                'deleted_at': deleted_at,
-            },
-        )
-
-        # Slot B: the editable draft, or an empty template draft.
-        if draft_config_file is not None:
-            slot_b_file = draft_config_file
-            slot_b_status = (
-                config_status
-                if config_status in ('DRAFT', 'READY_TO_SERVE')
-                else 'DRAFT'
-            )
-        else:
-            slot_b_file = template
-            slot_b_status = 'DRAFT'
-
-        bind.execute(
-            _INSERT_CONFIG,
-            {
-                'uuid': uuid.uuid4(),
-                'project_uuid': project_uuid,
-                'slot': 'B',
-                'config_file': slot_b_file,
-                'status': slot_b_status,
-                'created_at': updated_at,
-                'updated_at': updated_at,
-                'deleted_at': deleted_at,
-            },
-        )
-
-        if has_served:
-            bind.execute(
-                sa.text(
-                    'UPDATE project SET "SERVED_CONFIG_UUID" = :served '
-                    'WHERE "UUID" = :project_uuid'
-                ),
-                {'served': slot_a_uuid, 'project_uuid': project_uuid},
-            )
-
-    # 5. Drop legacy columns (keep FIRST_SERVED_AT).
     op.drop_column('project', 'CONFIG_STATUS')
     op.drop_column('project', 'DRAFT_CONFIG_FILE')
     op.drop_column('project', 'CONFIG_FILE')
@@ -199,7 +90,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     bind = op.get_bind()
 
-    # 1. Re-add legacy columns.
     op.add_column('project', sa.Column('CONFIG_FILE', sa.TEXT(), nullable=True))
     op.add_column(
         'project', sa.Column('DRAFT_CONFIG_FILE', sa.TEXT(), nullable=True)
@@ -220,47 +110,6 @@ def downgrade() -> None:
         ),
     )
 
-    # 2. Best-effort reconstruction of the single-row model.
-    #    config_file <- SERVED slot; draft_config_file <- the non-served slot
-    #    (prefer B). config_status is SERVED whenever a served slot exists,
-    #    else the non-served slot's status. The two-slot split is lossy, so a
-    #    parallel draft's pending status is not preserved on downgrade.
-    projects = bind.execute(sa.text('SELECT "UUID" FROM project')).fetchall()
-    for (project_uuid,) in projects:
-        configs = bind.execute(
-            sa.text(
-                'SELECT "SLOT", "CONFIG_FILE", "CONFIG_STATUS" FROM project_config '
-                'WHERE "PROJECT_UUID" = :project_uuid'
-            ),
-            {'project_uuid': project_uuid},
-        ).fetchall()
-
-        served = next((c for c in configs if c[2] == 'SERVED'), None)
-        non_served = [c for c in configs if c[2] != 'SERVED']
-        # Prefer slot B as the draft carrier, else the first non-served slot.
-        draft = next(
-            (c for c in non_served if c[0] == 'B'),
-            non_served[0] if non_served else None,
-        )
-
-        bind.execute(
-            sa.text(
-                'UPDATE project SET "CONFIG_FILE" = :config_file, '
-                '"DRAFT_CONFIG_FILE" = :draft_file, '
-                '"CONFIG_STATUS" = CAST(:status AS project_config_status) '
-                'WHERE "UUID" = :project_uuid'
-            ),
-            {
-                'config_file': served[1] if served else None,
-                'draft_file': draft[1] if draft else None,
-                'status': 'SERVED'
-                if served
-                else (draft[2] if draft else 'DRAFT'),
-                'project_uuid': project_uuid,
-            },
-        )
-
-    # 3. Drop the served reference, then the table, then the slot enum.
     op.drop_constraint(
         'fk_project_SERVED_CONFIG_UUID_project_config', 'project', type_='foreignkey'
     )

--- a/gateway/alembic/versions/b3c4d5e6f7a8_add_project_config_table.py
+++ b/gateway/alembic/versions/b3c4d5e6f7a8_add_project_config_table.py
@@ -1,0 +1,259 @@
+"""add_project_config_table
+
+Splits project configurations into a dedicated ``project_config`` table
+(two permanent slots A/B per project, at most one SERVED) and migrates the
+legacy ``CONFIG_FILE`` / ``DRAFT_CONFIG_FILE`` / ``CONFIG_STATUS`` columns of
+``project`` into it. See AG-778.
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2b3c4d5e6f7
+Create Date: 2026-06-10 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+import datetime
+from typing import Union
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+from radicalbit_ai_gateway.utils.yaml_utils import get_default_config_template
+
+# revision identifiers, used by Alembic.
+revision: str = 'b3c4d5e6f7a8'
+down_revision: Union[str, None] = 'a2b3c4d5e6f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
+
+_INSERT_CONFIG = sa.text(
+    'INSERT INTO project_config '
+    '("UUID", "PROJECT_UUID", "SLOT", "CONFIG_FILE", "CONFIG_STATUS", '
+    '"CREATED_AT", "UPDATED_AT", "DELETED_AT") '
+    'VALUES (:uuid, :project_uuid, CAST(:slot AS project_config_slot), '
+    ':config_file, CAST(:status AS project_config_status), '
+    ':created_at, :updated_at, :deleted_at)'
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. Enums: create the new slot enum explicitly; the config_status enum
+    #    already exists and is reused. Both are passed to create_table with
+    #    create_type=False so it does not (re)emit CREATE TYPE.
+    slot_enum = postgresql.ENUM(
+        'A', 'B', name='project_config_slot', create_type=False
+    )
+    slot_enum.create(bind, checkfirst=True)
+    status_enum = postgresql.ENUM(
+        'DRAFT',
+        'READY_TO_SERVE',
+        'SERVED',
+        name='project_config_status',
+        create_type=False,
+    )
+
+    # 2. project_config table.
+    op.create_table(
+        'project_config',
+        sa.Column('UUID', sa.UUID(), nullable=False),
+        sa.Column('PROJECT_UUID', sa.UUID(), nullable=False),
+        sa.Column('SLOT', slot_enum, nullable=False),
+        sa.Column('CONFIG_FILE', sa.TEXT(), nullable=True),
+        sa.Column(
+            'CONFIG_STATUS',
+            status_enum,
+            nullable=False,
+            server_default='DRAFT',
+        ),
+        sa.Column('CREATED_AT', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('UPDATED_AT', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('DELETED_AT', sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('UUID', name='pk_project_config'),
+        sa.ForeignKeyConstraint(
+            ['PROJECT_UUID'],
+            ['project.UUID'],
+            name='fk_project_config_PROJECT_UUID_project',
+            ondelete='CASCADE',
+        ),
+        sa.UniqueConstraint(
+            'PROJECT_UUID', 'SLOT', name='uq_project_config_PROJECT_UUID_SLOT'
+        ),
+    )
+    # At most one SERVED config per project.
+    op.create_index(
+        'uq_project_config_served',
+        'project_config',
+        ['PROJECT_UUID'],
+        unique=True,
+        postgresql_where=sa.text('"CONFIG_STATUS" = \'SERVED\''),
+    )
+
+    # 3. Reference to the served config on the project row.
+    op.add_column(
+        'project',
+        sa.Column('SERVED_CONFIG_UUID', sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        'fk_project_SERVED_CONFIG_UUID_project_config',
+        'project',
+        'project_config',
+        ['SERVED_CONFIG_UUID'],
+        ['UUID'],
+        ondelete='SET NULL',
+    )
+
+    # 4. Data migration: every project ends up with exactly 2 slots (A, B).
+    template = get_default_config_template()
+    projects = bind.execute(
+        sa.text(
+            'SELECT "UUID", "CONFIG_FILE", "DRAFT_CONFIG_FILE", "CONFIG_STATUS", '
+            '"UPDATED_AT", "DELETED_AT" FROM project'
+        )
+    ).fetchall()
+
+    for row in projects:
+        project_uuid = row[0]
+        config_file = row[1]
+        draft_config_file = row[2]
+        config_status = row[3]
+        updated_at = row[4]
+        deleted_at = row[5]
+
+        has_served = config_file is not None
+
+        # Slot A: the served config, or an empty template draft.
+        slot_a_uuid = uuid.uuid4()
+        bind.execute(
+            _INSERT_CONFIG,
+            {
+                'uuid': slot_a_uuid,
+                'project_uuid': project_uuid,
+                'slot': 'A',
+                'config_file': config_file if has_served else template,
+                'status': 'SERVED' if has_served else 'DRAFT',
+                'created_at': updated_at,
+                'updated_at': updated_at,
+                'deleted_at': deleted_at,
+            },
+        )
+
+        # Slot B: the editable draft, or an empty template draft.
+        if draft_config_file is not None:
+            slot_b_file = draft_config_file
+            slot_b_status = (
+                config_status
+                if config_status in ('DRAFT', 'READY_TO_SERVE')
+                else 'DRAFT'
+            )
+        else:
+            slot_b_file = template
+            slot_b_status = 'DRAFT'
+
+        bind.execute(
+            _INSERT_CONFIG,
+            {
+                'uuid': uuid.uuid4(),
+                'project_uuid': project_uuid,
+                'slot': 'B',
+                'config_file': slot_b_file,
+                'status': slot_b_status,
+                'created_at': updated_at,
+                'updated_at': updated_at,
+                'deleted_at': deleted_at,
+            },
+        )
+
+        if has_served:
+            bind.execute(
+                sa.text(
+                    'UPDATE project SET "SERVED_CONFIG_UUID" = :served '
+                    'WHERE "UUID" = :project_uuid'
+                ),
+                {'served': slot_a_uuid, 'project_uuid': project_uuid},
+            )
+
+    # 5. Drop legacy columns (keep FIRST_SERVED_AT).
+    op.drop_column('project', 'CONFIG_STATUS')
+    op.drop_column('project', 'DRAFT_CONFIG_FILE')
+    op.drop_column('project', 'CONFIG_FILE')
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. Re-add legacy columns.
+    op.add_column('project', sa.Column('CONFIG_FILE', sa.TEXT(), nullable=True))
+    op.add_column(
+        'project', sa.Column('DRAFT_CONFIG_FILE', sa.TEXT(), nullable=True)
+    )
+    op.add_column(
+        'project',
+        sa.Column(
+            'CONFIG_STATUS',
+            postgresql.ENUM(
+                'DRAFT',
+                'READY_TO_SERVE',
+                'SERVED',
+                name='project_config_status',
+                create_type=False,
+            ),
+            nullable=False,
+            server_default='DRAFT',
+        ),
+    )
+
+    # 2. Best-effort reconstruction of the single-row model.
+    #    config_file <- SERVED slot; draft_config_file <- the non-served slot
+    #    (prefer B). config_status is SERVED whenever a served slot exists,
+    #    else the non-served slot's status. The two-slot split is lossy, so a
+    #    parallel draft's pending status is not preserved on downgrade.
+    projects = bind.execute(sa.text('SELECT "UUID" FROM project')).fetchall()
+    for (project_uuid,) in projects:
+        configs = bind.execute(
+            sa.text(
+                'SELECT "SLOT", "CONFIG_FILE", "CONFIG_STATUS" FROM project_config '
+                'WHERE "PROJECT_UUID" = :project_uuid'
+            ),
+            {'project_uuid': project_uuid},
+        ).fetchall()
+
+        served = next((c for c in configs if c[2] == 'SERVED'), None)
+        non_served = [c for c in configs if c[2] != 'SERVED']
+        # Prefer slot B as the draft carrier, else the first non-served slot.
+        draft = next(
+            (c for c in non_served if c[0] == 'B'),
+            non_served[0] if non_served else None,
+        )
+
+        bind.execute(
+            sa.text(
+                'UPDATE project SET "CONFIG_FILE" = :config_file, '
+                '"DRAFT_CONFIG_FILE" = :draft_file, '
+                '"CONFIG_STATUS" = CAST(:status AS project_config_status) '
+                'WHERE "UUID" = :project_uuid'
+            ),
+            {
+                'config_file': served[1] if served else None,
+                'draft_file': draft[1] if draft else None,
+                'status': 'SERVED'
+                if served
+                else (draft[2] if draft else 'DRAFT'),
+                'project_uuid': project_uuid,
+            },
+        )
+
+    # 3. Drop the served reference, then the table, then the slot enum.
+    op.drop_constraint(
+        'fk_project_SERVED_CONFIG_UUID_project_config', 'project', type_='foreignkey'
+    )
+    op.drop_column('project', 'SERVED_CONFIG_UUID')
+    op.drop_index('uq_project_config_served', table_name='project_config')
+    op.drop_table('project_config')
+    sa.Enum(name='project_config_slot').drop(bind, checkfirst=True)

--- a/gateway/alembic/versions/b3c4d5e6f7a8_add_project_config_table.py
+++ b/gateway/alembic/versions/b3c4d5e6f7a8_add_project_config_table.py
@@ -13,6 +13,7 @@ Create Date: 2026-06-10 00:00:00.000000
 
 from collections.abc import Sequence
 import datetime
+from importlib.resources import files
 from typing import Union
 import uuid
 
@@ -21,7 +22,17 @@ from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-from radicalbit_ai_gateway.utils.yaml_utils import get_default_config_template
+
+def _default_config_template() -> str:
+    # Read the template directly from resources so this migration stays
+    # self-contained: the migrations image installs only the `migrations`
+    # dependency group, which has no PyYAML, and importing
+    # radicalbit_ai_gateway.utils.yaml_utils would pull `import yaml`.
+    return (
+        files('radicalbit_ai_gateway.resources')
+        .joinpath('default_config.yaml')
+        .read_text()
+    )
 
 # revision identifiers, used by Alembic.
 revision: str = 'b3c4d5e6f7a8'
@@ -110,7 +121,7 @@ def upgrade() -> None:
     )
 
     # 4. Data migration: every project ends up with exactly 2 slots (A, B).
-    template = get_default_config_template()
+    template = _default_config_template()
     projects = bind.execute(
         sa.text(
             'SELECT "UUID", "CONFIG_FILE", "DRAFT_CONFIG_FILE", "CONFIG_STATUS", '

--- a/gateway/radicalbit_ai_gateway/db/dao/project_config_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_config_dao.py
@@ -7,7 +7,6 @@ from sqlalchemy import func, select, update
 from radicalbit_ai_gateway.db.database import Database
 from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
-from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 
 _UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
@@ -16,27 +15,6 @@ _UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
 class ProjectConfigDAO:
     def __init__(self, database: Database):
         self.db = database
-
-    def create(
-        self,
-        project_uuid: UUID,
-        slot: Slot,
-        config_file: str | None,
-        status: ConfigStatus = ConfigStatus.DRAFT,
-    ) -> ProjectConfig:
-        now = datetime.datetime.now(tz=_UTC)
-        with self.db.begin_session() as session:
-            config = ProjectConfig(
-                project_uuid=project_uuid,
-                slot=slot.value,
-                config_file=config_file,
-                config_status=status.value,
-                created_at=now,
-                updated_at=now,
-            )
-            session.add(config)
-            session.flush()
-            return config
 
     def get_by_uuid(self, config_uuid: UUID) -> ProjectConfig | None:
         with self.db.begin_session() as session:

--- a/gateway/radicalbit_ai_gateway/db/dao/project_config_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_config_dao.py
@@ -1,0 +1,187 @@
+from collections.abc import Sequence
+import datetime
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+
+from radicalbit_ai_gateway.db.database import Database
+from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
+from radicalbit_ai_gateway.db.tables.project_table import Project
+from radicalbit_ai_gateway.models.config_slot import Slot
+from radicalbit_ai_gateway.models.config_status import ConfigStatus
+
+_UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
+
+
+class ProjectConfigDAO:
+    def __init__(self, database: Database):
+        self.db = database
+
+    def create(
+        self,
+        project_uuid: UUID,
+        slot: Slot,
+        config_file: str | None,
+        status: ConfigStatus = ConfigStatus.DRAFT,
+    ) -> ProjectConfig:
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            config = ProjectConfig(
+                project_uuid=project_uuid,
+                slot=slot.value,
+                config_file=config_file,
+                config_status=status.value,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(config)
+            session.flush()
+            return config
+
+    def get_by_uuid(self, config_uuid: UUID) -> ProjectConfig | None:
+        with self.db.begin_session() as session:
+            stmt = select(ProjectConfig).where(
+                ProjectConfig.uuid == config_uuid,
+                ProjectConfig.deleted_at.is_(None),
+            )
+            return session.scalar(stmt)
+
+    def list_by_project(self, project_uuid: UUID) -> Sequence[ProjectConfig]:
+        with self.db.begin_session() as session:
+            stmt = (
+                select(ProjectConfig)
+                .where(
+                    ProjectConfig.project_uuid == project_uuid,
+                    ProjectConfig.deleted_at.is_(None),
+                )
+                .order_by(ProjectConfig.slot)
+            )
+            return session.scalars(stmt).all()
+
+    def get_served_by_project(self, project_uuid: UUID) -> ProjectConfig | None:
+        with self.db.begin_session() as session:
+            stmt = select(ProjectConfig).where(
+                ProjectConfig.project_uuid == project_uuid,
+                ProjectConfig.config_status == ConfigStatus.SERVED.value,
+                ProjectConfig.deleted_at.is_(None),
+            )
+            return session.scalar(stmt)
+
+    def update_config_file(self, config_uuid: UUID, config_file: str) -> int:
+        """Update the YAML content of a config and reset it to DRAFT."""
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            query = (
+                update(ProjectConfig)
+                .where(
+                    ProjectConfig.uuid == config_uuid,
+                    ProjectConfig.deleted_at.is_(None),
+                )
+                .values(
+                    config_file=config_file,
+                    config_status=ConfigStatus.DRAFT.value,
+                    updated_at=now,
+                )
+            )
+            return session.execute(query).rowcount
+
+    def set_status(self, config_uuid: UUID, status: ConfigStatus) -> int:
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            query = (
+                update(ProjectConfig)
+                .where(
+                    ProjectConfig.uuid == config_uuid,
+                    ProjectConfig.deleted_at.is_(None),
+                )
+                .values(config_status=status.value, updated_at=now)
+            )
+            return session.execute(query).rowcount
+
+    def serve(self, config_uuid: UUID) -> ProjectConfig | None:
+        """Atomically serve a config: demote any currently SERVED config of the
+        same project back to DRAFT, promote this one to SERVED, and update the
+        project's served reference and first_served_at.
+        """
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            config = session.scalar(
+                select(ProjectConfig).where(
+                    ProjectConfig.uuid == config_uuid,
+                    ProjectConfig.deleted_at.is_(None),
+                )
+            )
+            if config is None:
+                return None
+
+            # Demote the sibling first so the single-SERVED index is never
+            # violated mid-transaction.
+            session.execute(
+                update(ProjectConfig)
+                .where(
+                    ProjectConfig.project_uuid == config.project_uuid,
+                    ProjectConfig.uuid != config_uuid,
+                    ProjectConfig.config_status == ConfigStatus.SERVED.value,
+                    ProjectConfig.deleted_at.is_(None),
+                )
+                .values(config_status=ConfigStatus.DRAFT.value, updated_at=now)
+            )
+            session.execute(
+                update(ProjectConfig)
+                .where(ProjectConfig.uuid == config_uuid)
+                .values(config_status=ConfigStatus.SERVED.value, updated_at=now)
+            )
+            session.execute(
+                update(Project)
+                .where(Project.uuid == config.project_uuid)
+                .values(
+                    served_config_uuid=config_uuid,
+                    first_served_at=func.coalesce(Project.first_served_at, now),
+                    updated_at=now,
+                )
+            )
+            return session.scalar(
+                select(ProjectConfig).where(ProjectConfig.uuid == config_uuid)
+            )
+
+    def unserve(self, config_uuid: UUID) -> int:
+        """Unserve a config (back to DRAFT) and clear the project's served
+        reference when it points to this config.
+        """
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            config = session.scalar(
+                select(ProjectConfig).where(
+                    ProjectConfig.uuid == config_uuid,
+                    ProjectConfig.deleted_at.is_(None),
+                )
+            )
+            if config is None:
+                return 0
+            session.execute(
+                update(ProjectConfig)
+                .where(ProjectConfig.uuid == config_uuid)
+                .values(config_status=ConfigStatus.DRAFT.value, updated_at=now)
+            )
+            session.execute(
+                update(Project)
+                .where(
+                    Project.uuid == config.project_uuid,
+                    Project.served_config_uuid == config_uuid,
+                )
+                .values(served_config_uuid=None, updated_at=now)
+            )
+            return 1
+
+    def soft_delete_by_project(self, project_uuid: UUID) -> int:
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            query = (
+                update(ProjectConfig)
+                .where(
+                    ProjectConfig.project_uuid == project_uuid,
+                    ProjectConfig.deleted_at.is_(None),
+                )
+                .values(deleted_at=now, updated_at=now)
+            )
+            return session.execute(query).rowcount

--- a/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
@@ -5,7 +5,10 @@ from uuid import UUID
 from sqlalchemy import select, update
 
 from radicalbit_ai_gateway.db.database import Database
+from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
+from radicalbit_ai_gateway.models.config_slot import Slot
+from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import ProjectFilter
 
 _UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
@@ -18,6 +21,33 @@ class ProjectDAO:
     def insert(self, project: Project) -> Project:
         with self.db.begin_session() as session:
             session.add(project)
+            session.flush()
+            return project
+
+    def insert_with_configs(
+        self,
+        project: Project,
+        slots: Sequence[tuple[Slot, str | None, ConfigStatus]],
+    ) -> Project:
+        """Insert a project and its initial config slots in a single
+        transaction, so a project is never left with a partial set of slots
+        (the "always 2 slots" invariant holds even on a mid-creation crash).
+        """
+        now = datetime.datetime.now(tz=_UTC)
+        with self.db.begin_session() as session:
+            session.add(project)
+            session.flush()  # assign project.uuid before linking the configs
+            for slot, config_file, status in slots:
+                session.add(
+                    ProjectConfig(
+                        project_uuid=project.uuid,
+                        slot=slot.value,
+                        config_file=config_file,
+                        config_status=status.value,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
             session.flush()
             return project
 

--- a/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
@@ -2,11 +2,10 @@ from collections.abc import Sequence
 import datetime
 from uuid import UUID
 
-from sqlalchemy import func, select, update
+from sqlalchemy import select, update
 
 from radicalbit_ai_gateway.db.database import Database
 from radicalbit_ai_gateway.db.tables.project_table import Project
-from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import ProjectFilter
 
 _UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
@@ -40,65 +39,22 @@ class ProjectDAO:
     ) -> Sequence[Project]:
         with self.db.begin_session() as session:
             stmt = select(Project).where(Project.deleted_at.is_(None))
-            if project_filter == ProjectFilter.ACTIVE:
-                stmt = stmt.where(Project.config_file.is_not(None))
+            if project_filter in (ProjectFilter.ACTIVE, ProjectFilter.PROD):
+                stmt = stmt.where(Project.served_config_uuid.is_not(None))
+            elif project_filter == ProjectFilter.DEV:
+                stmt = stmt.where(Project.served_config_uuid.is_(None))
             elif project_filter == ProjectFilter.WITH_USAGE:
                 stmt = stmt.where(Project.first_served_at.is_not(None))
-            elif project_filter == ProjectFilter.DEV:
-                stmt = stmt.where(Project.config_file.is_(None))
-            elif project_filter == ProjectFilter.PROD:
-                stmt = stmt.where(Project.config_file.is_not(None))
             return session.scalars(stmt).all()
 
     def get_all_with_config(self) -> Sequence[Project]:
+        """Projects that currently have a served config (used at startup)."""
         with self.db.begin_session() as session:
             stmt = select(Project).where(
-                Project.config_file.is_not(None),
+                Project.served_config_uuid.is_not(None),
                 Project.deleted_at.is_(None),
             )
             return session.scalars(stmt).all()
-
-    def update_draft_config_file(
-        self, project_uuid: UUID, draft_config_file: str
-    ) -> int:
-        now = datetime.datetime.now(tz=_UTC)
-        with self.db.begin_session() as session:
-            query = (
-                update(Project)
-                .where(Project.uuid == project_uuid)
-                .values(
-                    draft_config_file=draft_config_file,
-                    config_status=ConfigStatus.DRAFT.value,
-                    updated_at=now,
-                )
-            )
-            return session.execute(query).rowcount
-
-    def promote_draft_to_config(self, project_uuid: UUID, config_file: str) -> int:
-        now = datetime.datetime.now(tz=_UTC)
-        with self.db.begin_session() as session:
-            query = (
-                update(Project)
-                .where(Project.uuid == project_uuid)
-                .values(
-                    config_file=config_file,
-                    draft_config_file=None,
-                    config_status=ConfigStatus.SERVED.value,
-                    updated_at=now,
-                    first_served_at=func.coalesce(Project.first_served_at, now),
-                )
-            )
-            return session.execute(query).rowcount
-
-    def set_config_status(self, project_uuid: UUID, status: ConfigStatus) -> int:
-        now = datetime.datetime.now(tz=_UTC)
-        with self.db.begin_session() as session:
-            query = (
-                update(Project)
-                .where(Project.uuid == project_uuid)
-                .values(config_status=status.value, updated_at=now)
-            )
-            return session.execute(query).rowcount
 
     def soft_delete(self, project_uuid: UUID) -> int:
         now = datetime.datetime.now(tz=_UTC)
@@ -108,25 +64,4 @@ class ProjectDAO:
                 .where(Project.uuid == project_uuid)
                 .values(deleted_at=now, updated_at=now)
             )
-            return session.execute(query).rowcount
-
-    def unserve_config(self, project_uuid: UUID, restore_draft: bool) -> int:
-        now = datetime.datetime.now(tz=_UTC)
-        with self.db.begin_session() as session:
-            project = session.scalar(
-                select(Project).where(
-                    Project.uuid == project_uuid,
-                    Project.deleted_at.is_(None),
-                )
-            )
-            if project is None:
-                return 0
-            values: dict = {
-                'config_status': ConfigStatus.DRAFT.value,
-                'config_file': None,
-                'updated_at': now,
-            }
-            if restore_draft:
-                values['draft_config_file'] = project.config_file
-            query = update(Project).where(Project.uuid == project_uuid).values(**values)
             return session.execute(query).rowcount

--- a/gateway/radicalbit_ai_gateway/db/tables/project_config_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/project_config_table.py
@@ -1,0 +1,63 @@
+import uuid
+
+from sqlalchemy import (
+    TEXT,
+    TIMESTAMP,
+    UUID,
+    Column,
+    Enum as SAEnum,
+    ForeignKey,
+    Index,
+    UniqueConstraint,
+    text,
+)
+
+from radicalbit_ai_gateway.db.dao.base_dao import BaseDAO
+from radicalbit_ai_gateway.db.database import BaseTable, Reflected
+from radicalbit_ai_gateway.models.config_slot import Slot
+from radicalbit_ai_gateway.models.config_status import ConfigStatus
+
+
+class ProjectConfig(Reflected, BaseTable, BaseDAO):
+    __tablename__ = 'project_config'
+    __table_args__ = (
+        # A project has at most two slots (A/B).
+        UniqueConstraint(
+            'PROJECT_UUID', 'SLOT', name='uq_project_config_PROJECT_UUID_SLOT'
+        ),
+        # At most one SERVED config per project (partial unique index).
+        Index(
+            'uq_project_config_served',
+            'PROJECT_UUID',
+            unique=True,
+            postgresql_where=text('"CONFIG_STATUS" = \'SERVED\''),
+        ),
+    )
+    uuid = Column(
+        'UUID',
+        UUID(as_uuid=True),
+        nullable=False,
+        default=uuid.uuid4,
+        primary_key=True,
+    )
+    project_uuid = Column(
+        'PROJECT_UUID',
+        UUID(as_uuid=True),
+        ForeignKey('project.UUID', ondelete='CASCADE'),
+        nullable=False,
+    )
+    slot = Column(
+        'SLOT',
+        SAEnum(Slot, name='project_config_slot', create_type=True),
+        nullable=False,
+    )
+    config_file = Column('CONFIG_FILE', TEXT(), nullable=True)
+    config_status = Column(
+        'CONFIG_STATUS',
+        SAEnum(ConfigStatus, name='project_config_status', create_type=False),
+        nullable=False,
+        server_default='DRAFT',
+    )
+    created_at = Column('CREATED_AT', TIMESTAMP(timezone=True), nullable=False)
+    updated_at = Column('UPDATED_AT', TIMESTAMP(timezone=True), nullable=False)
+    deleted_at = Column('DELETED_AT', TIMESTAMP(timezone=True), nullable=True)

--- a/gateway/radicalbit_ai_gateway/db/tables/project_config_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/project_config_table.py
@@ -54,7 +54,7 @@ class ProjectConfig(Reflected, BaseTable, BaseDAO):
     config_file = Column('CONFIG_FILE', TEXT(), nullable=True)
     config_status = Column(
         'CONFIG_STATUS',
-        SAEnum(ConfigStatus, name='project_config_status', create_type=False),
+        SAEnum(ConfigStatus, name='project_config_status', create_type=True),
         nullable=False,
         server_default='DRAFT',
     )

--- a/gateway/radicalbit_ai_gateway/db/tables/project_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/project_table.py
@@ -6,13 +6,12 @@ from sqlalchemy import (
     UUID,
     VARCHAR,
     Column,
-    Enum as SAEnum,
+    ForeignKey,
     UniqueConstraint,
 )
 
 from radicalbit_ai_gateway.db.dao.base_dao import BaseDAO
 from radicalbit_ai_gateway.db.database import BaseTable, Reflected
-from radicalbit_ai_gateway.models.config_status import ConfigStatus
 
 
 class Project(Reflected, BaseTable, BaseDAO):
@@ -27,15 +26,23 @@ class Project(Reflected, BaseTable, BaseDAO):
     )
     name = Column('NAME', VARCHAR(), nullable=False)
     description = Column('DESCRIPTION', TEXT(), nullable=True)
-    config_file = Column('CONFIG_FILE', TEXT(), nullable=True)
-    draft_config_file = Column('DRAFT_CONFIG_FILE', TEXT(), nullable=True)
-    config_status = Column(
-        'CONFIG_STATUS',
-        SAEnum(ConfigStatus, name='project_config_status', create_type=True),
-        nullable=False,
-        server_default='DRAFT',
+    served_config_uuid = Column(
+        'SERVED_CONFIG_UUID',
+        UUID(as_uuid=True),
+        ForeignKey(
+            'project_config.UUID',
+            ondelete='SET NULL',
+            use_alter=True,
+            name='fk_project_SERVED_CONFIG_UUID_project_config',
+        ),
+        nullable=True,
     )
     created_at = Column('CREATED_AT', TIMESTAMP(timezone=True), nullable=False)
     updated_at = Column('UPDATED_AT', TIMESTAMP(timezone=True), nullable=False)
     first_served_at = Column('FIRST_SERVED_AT', TIMESTAMP(timezone=True), nullable=True)
     deleted_at = Column('DELETED_AT', TIMESTAMP(timezone=True), nullable=True)
+
+
+# Register the referenced table in the shared metadata so the
+# SERVED_CONFIG_UUID foreign key can always be resolved (e.g. on create_all).
+from radicalbit_ai_gateway.db.tables import project_config_table  # noqa: E402, F401

--- a/gateway/radicalbit_ai_gateway/models/config_slot.py
+++ b/gateway/radicalbit_ai_gateway/models/config_slot.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class Slot(str, Enum):
+    A = 'A'
+    B = 'B'

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -107,9 +107,7 @@ class ProjectOut(BaseModel):
     )
 
     @staticmethod
-    def from_project(
-        project: Project, configs: list[ProjectConfig]
-    ) -> 'ProjectOut':
+    def from_project(project: Project, configs: list[ProjectConfig]) -> 'ProjectOut':
         ordered = sorted(configs, key=lambda c: c.slot)
         served = next(
             (c for c in ordered if c.config_status == ConfigStatus.SERVED.value),

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -5,10 +5,10 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
+from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_status import ProjectStatus
-from radicalbit_ai_gateway.utils.yaml_utils import get_default_config_template
 
 
 class ProjectFilter(str, Enum):
@@ -41,8 +41,6 @@ class ProjectIn(BaseModel, validate_assignment=True):
         return Project(
             name=self.name,
             description=self.description,
-            config_status=ConfigStatus.DRAFT.value,
-            draft_config_file=get_default_config_template(),
             created_at=now,
             updated_at=now,
         )
@@ -72,14 +70,35 @@ class GenerateConfigOut(BaseModel):
     )
 
 
+class ConfigSlotOut(BaseModel):
+    uuid: UUID
+    slot: str
+    config_file: str | None
+    config_status: ConfigStatus
+    updated_at: str
+
+    model_config = ConfigDict(
+        populate_by_name=True, alias_generator=to_camel, protected_namespaces=()
+    )
+
+    @staticmethod
+    def from_config(config: ProjectConfig) -> 'ConfigSlotOut':
+        return ConfigSlotOut(
+            uuid=config.uuid,
+            slot=config.slot,
+            config_file=config.config_file,
+            config_status=ConfigStatus(config.config_status),
+            updated_at=str(config.updated_at),
+        )
+
+
 class ProjectOut(BaseModel):
     uuid: UUID
     name: str
     description: str | None
-    config_file: str | None
-    draft_config_file: str | None
-    config_status: ConfigStatus
     project_status: ProjectStatus
+    served_config_uuid: UUID | None
+    configs: list[ConfigSlotOut]
     created_at: str
     updated_at: str
 
@@ -88,17 +107,21 @@ class ProjectOut(BaseModel):
     )
 
     @staticmethod
-    def from_project(project: Project) -> 'ProjectOut':
+    def from_project(
+        project: Project, configs: list[ProjectConfig]
+    ) -> 'ProjectOut':
+        ordered = sorted(configs, key=lambda c: c.slot)
+        served = next(
+            (c for c in ordered if c.config_status == ConfigStatus.SERVED.value),
+            None,
+        )
         return ProjectOut(
             uuid=project.uuid,
             name=project.name,
             description=project.description,
-            config_file=project.config_file,
-            draft_config_file=project.draft_config_file,
-            config_status=ConfigStatus(project.config_status),
-            project_status=ProjectStatus.PROD
-            if project.config_file is not None
-            else ProjectStatus.DEV,
+            project_status=ProjectStatus.PROD if served else ProjectStatus.DEV,
+            served_config_uuid=served.uuid if served else None,
+            configs=[ConfigSlotOut.from_config(c) for c in ordered],
             created_at=str(project.created_at),
             updated_at=str(project.updated_at),
         )

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -85,78 +85,98 @@ class ProjectRoute:
             return get_project_fn(request, project_uuid)
 
         @router.patch(
-            '/projects/{project_uuid}/load-config',
+            '/projects/{project_uuid}/configs/{config_uuid}',
             status_code=200,
             response_model=ProjectOut,
         )
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
-        def load_config(project_uuid: UUID, config_in: ProjectConfigFileIn):
-            project = project_service.load_config(project_uuid, config_in)
-            logger.info('Loaded config for project %s', project_uuid)
+        def update_config(
+            project_uuid: UUID, config_uuid: UUID, config_in: ProjectConfigFileIn
+        ):
+            project = project_service.update_config(
+                project_uuid, config_uuid, config_in
+            )
+            logger.info('Updated config %s for project %s', config_uuid, project_uuid)
             return project
 
         @router.patch(
-            '/projects/{project_uuid}/approve-config',
+            '/projects/{project_uuid}/configs/{config_uuid}/approve',
             status_code=200,
             response_model=ProjectOut,
         )
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
-        def approve_config(project_uuid: UUID):
-            project = project_service.approve_config(project_uuid)
-            logger.info('Approved config for project %s', project_uuid)
+        def approve_config(project_uuid: UUID, config_uuid: UUID):
+            project = project_service.approve_config(project_uuid, config_uuid)
+            logger.info('Approved config %s for project %s', config_uuid, project_uuid)
             return project
 
         @router.patch(
-            '/projects/{project_uuid}/cancel-approval',
+            '/projects/{project_uuid}/configs/{config_uuid}/cancel-approval',
             status_code=200,
             response_model=ProjectOut,
         )
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
-        def cancel_approval(project_uuid: UUID):
-            project = project_service.cancel_approval(project_uuid)
-            logger.info('Cancelled approval for project %s', project_uuid)
+        def cancel_approval(project_uuid: UUID, config_uuid: UUID):
+            project = project_service.cancel_approval(project_uuid, config_uuid)
+            logger.info(
+                'Cancelled approval for config %s of project %s',
+                config_uuid,
+                project_uuid,
+            )
             return project
 
         @router.patch(
-            '/projects/{project_uuid}/serve-config',
+            '/projects/{project_uuid}/configs/{config_uuid}/serve',
             status_code=200,
             response_model=ProjectOut,
         )
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
-        async def serve_config(project_uuid: UUID):
-            project = project_service.serve_config(project_uuid)
-            if register_project_routes and project.config_file:
+        async def serve_config(project_uuid: UUID, config_uuid: UUID):
+            project = project_service.serve_config(project_uuid, config_uuid)
+            # Swap: drop any routes from the previously served config, then
+            # register the newly served one.
+            if deregister_project_routes:
+                await deregister_project_routes(project_uuid)
+            served = next(
+                (c for c in project.configs if c.uuid == project.served_config_uuid),
+                None,
+            )
+            if register_project_routes and served and served.config_file:
                 await register_project_routes(
-                    project_uuid, project.name, project.config_file
+                    project_uuid, project.name, served.config_file
                 )
-            logger.info('Served config for project %s', project_uuid)
+            logger.info('Served config %s for project %s', config_uuid, project_uuid)
             return project
 
         @router.post(
-            '/projects/{project_uuid}/generate-config',
+            '/projects/{project_uuid}/configs/{config_uuid}/generate-config',
             status_code=200,
             response_model=GenerateConfigOut,
         )
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
-        async def generate_config(project_uuid: UUID, gen_in: GenerateConfigIn):
-            project = project_service.get_by_uuid(project_uuid)
+        async def generate_config(
+            project_uuid: UUID, config_uuid: UUID, gen_in: GenerateConfigIn
+        ):
+            config = project_service.get_config(project_uuid, config_uuid)
             yaml_str = await config_generator_service.generate_config(
-                gen_in.description, project.draft_config_file
+                gen_in.description, config.config_file
             )
-            logger.info('Generated config for project %s', project_uuid)
+            logger.info(
+                'Generated config %s for project %s', config_uuid, project_uuid
+            )
             return GenerateConfigOut(config_file=yaml_str)
 
         @router.patch(
-            '/projects/{project_uuid}/unserve-config',
+            '/projects/{project_uuid}/configs/{config_uuid}/unserve',
             status_code=200,
             response_model=ProjectOut,
         )
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
-        async def unserve_config(project_uuid: UUID):
-            project = project_service.unserve_config(project_uuid)
+        async def unserve_config(project_uuid: UUID, config_uuid: UUID):
+            project = project_service.unserve_config(project_uuid, config_uuid)
             if deregister_project_routes:
                 await deregister_project_routes(project_uuid)
-            logger.info('Unserved config for project %s', project_uuid)
+            logger.info('Unserved config %s for project %s', config_uuid, project_uuid)
             return project
 
         @router.delete(
@@ -167,7 +187,7 @@ class ProjectRoute:
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
         async def delete_project(project_uuid: UUID):
             project = project_service.delete_project(project_uuid)
-            if deregister_project_routes and project.config_file:
+            if deregister_project_routes and project.served_config_uuid:
                 await deregister_project_routes(project_uuid)
             logger.info('Deleted project %s', project_uuid)
             return project

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -11,6 +11,7 @@ from radicalbit_ai_gateway.models.auth_dto import (
     GroupsRouteOut,
     RouteGroupsIn,
 )
+from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import (
     GenerateConfigIn,
     GenerateConfigOut,
@@ -26,6 +27,7 @@ from radicalbit_ai_gateway.services.config_generator_service import (
 from radicalbit_ai_gateway.services.group_service import GroupService
 from radicalbit_ai_gateway.services.project_service import ProjectService
 from radicalbit_ai_gateway.utils.app_config import get_app_config
+from radicalbit_ai_gateway.utils.exceptions import ProjectConfigValidationError
 
 app_config = get_app_config()
 
@@ -157,13 +159,18 @@ class ProjectRoute:
         async def generate_config(
             project_uuid: UUID, config_uuid: UUID, gen_in: GenerateConfigIn
         ):
-            config = project_service.get_config(project_uuid, config_uuid)
+            config_slot = project_service.get_config(project_uuid, config_uuid)
+            # A served slot is read-only: generating against it is pointless
+            # since the result could not be saved back (see update_config).
+            if config_slot.config_status == ConfigStatus.SERVED:
+                raise ProjectConfigValidationError(
+                    f'Config {config_uuid} is served and cannot be used to '
+                    'generate a new configuration'
+                )
             yaml_str = await config_generator_service.generate_config(
-                gen_in.description, config.config_file
+                gen_in.description, config_slot.config_file
             )
-            logger.info(
-                'Generated config %s for project %s', config_uuid, project_uuid
-            )
+            logger.info('Generated config %s for project %s', config_uuid, project_uuid)
             return GenerateConfigOut(config_file=yaml_str)
 
         @router.patch(

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -31,6 +31,7 @@ from radicalbit_ai_gateway.db.dao.group_dao import GroupDAO
 from radicalbit_ai_gateway.db.dao.group_route_dao import GroupRouteDAO
 from radicalbit_ai_gateway.db.dao.key_dao import KeyDAO
 from radicalbit_ai_gateway.db.dao.otel_traces_dao import OtelTracesDAO
+from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.db.dao.request_event_dao import RequestEventDAO
 from radicalbit_ai_gateway.db.database import Database
@@ -154,6 +155,7 @@ key_dao = KeyDAO(database)
 group_dao = GroupDAO(database)
 group_route_dao = GroupRouteDAO(database)
 project_dao = ProjectDAO(database)
+project_config_dao = ProjectConfigDAO(database)
 event_dao = EventDAO(ch_database)
 request_event_dao = RequestEventDAO(ch_database)
 otel_traces_dao = OtelTracesDAO(ch_database)
@@ -171,7 +173,9 @@ group_service = GroupService(
     key_service=key_service,
     project_configs=project_configs,
 )
-project_service = ProjectService(project_dao=project_dao)
+project_service = ProjectService(
+    project_dao=project_dao, project_config_dao=project_config_dao
+)
 config_generator_service = ConfigGeneratorService()
 event_service = EventService(
     event_dao=event_dao,
@@ -201,16 +205,25 @@ async def lifespan(app: FastAPI):
 
     async def _safe_register(project_out: ProjectOut) -> None:
         try:
-            if project_out.config_file:
+            served = next(
+                (
+                    c
+                    for c in project_out.configs
+                    if c.uuid == project_out.served_config_uuid
+                ),
+                None,
+            )
+            if served and served.config_file:
                 await register_fn(
                     project_out.uuid,
                     project_out.name,
-                    project_out.config_file,
+                    served.config_file,
                 )
                 logger.info('Loaded project routes at startup: %s', project_out.name)
             else:
                 logger.info(
-                    'Skipping project %s at startup — no config file', project_out.name
+                    'Skipping project %s at startup — no served config',
+                    project_out.name,
                 )
         except Exception:
             logger.exception(

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -28,9 +28,7 @@ from radicalbit_ai_gateway.utils.yaml_utils import (
 
 
 class ProjectService:
-    def __init__(
-        self, project_dao: ProjectDAO, project_config_dao: ProjectConfigDAO
-    ):
+    def __init__(self, project_dao: ProjectDAO, project_config_dao: ProjectConfigDAO):
         self.project_dao = project_dao
         self.project_config_dao = project_config_dao
 
@@ -63,9 +61,18 @@ class ProjectService:
         return self._build_out(project)
 
     def create_project(self, project_in: ProjectIn) -> ProjectOut:
+        template = get_default_config_template()
         try:
             project = project_in.to_project()
-            inserted = self.project_dao.insert(project)
+            # Seed both slots atomically with the project so the response
+            # always carries exactly 2 configs (never a partial project).
+            inserted = self.project_dao.insert_with_configs(
+                project,
+                [
+                    (Slot.A, template, ConfigStatus.DRAFT),
+                    (Slot.B, template, ConfigStatus.DRAFT),
+                ],
+            )
         except IntegrityError as e:
             if 'uq_project_NAME' in str(e.orig) or 'NAME' in str(e.orig):
                 raise ProjectAlreadyExistsError(
@@ -75,11 +82,6 @@ class ProjectService:
                 f'An error occurred while creating the project: {e}'
             ) from e
 
-        template = get_default_config_template()
-        for slot in (Slot.A, Slot.B):
-            self.project_config_dao.create(
-                inserted.uuid, slot, template, ConfigStatus.DRAFT
-            )
         return self._build_out_or_raise(inserted.uuid)
 
     def update_config(
@@ -148,15 +150,11 @@ class ProjectService:
         config = self._get_config_or_raise(project_uuid, config_uuid)
 
         if config.config_status != ConfigStatus.SERVED.value:
-            raise ProjectConfigValidationError(
-                f'Config {config_uuid} is not served'
-            )
+            raise ProjectConfigValidationError(f'Config {config_uuid} is not served')
 
         rows_updated = self.project_config_dao.unserve(config_uuid)
         if rows_updated == 0:
-            raise ProjectInternalError(
-                f'Failed to unserve config {config_uuid}'
-            )
+            raise ProjectInternalError(f'Failed to unserve config {config_uuid}')
         return self._build_out_or_raise(project_uuid)
 
     def delete_project(self, project_uuid: UUID) -> ProjectOut:

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -2,10 +2,14 @@ from uuid import UUID
 
 from sqlalchemy.exc import IntegrityError
 
+from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
+from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
+from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import (
+    ConfigSlotOut,
     ProjectConfigFileIn,
     ProjectFilter,
     ProjectIn,
@@ -17,12 +21,18 @@ from radicalbit_ai_gateway.utils.exceptions import (
     ProjectInternalError,
     ProjectNotFoundError,
 )
-from radicalbit_ai_gateway.utils.yaml_utils import validate_gateway_config
+from radicalbit_ai_gateway.utils.yaml_utils import (
+    get_default_config_template,
+    validate_gateway_config,
+)
 
 
 class ProjectService:
-    def __init__(self, project_dao: ProjectDAO):
+    def __init__(
+        self, project_dao: ProjectDAO, project_config_dao: ProjectConfigDAO
+    ):
         self.project_dao = project_dao
+        self.project_config_dao = project_config_dao
 
     def _get_project_or_raise(self, project_uuid: UUID) -> Project:
         project = self.project_dao.get_by_uuid(project_uuid)
@@ -30,19 +40,32 @@ class ProjectService:
             raise ProjectNotFoundError(f'Project with UUID {project_uuid} not found')
         return project
 
-    def _get_updated_or_raise(self, project_uuid: UUID) -> ProjectOut:
-        updated_project = self.project_dao.get_by_uuid(project_uuid)
-        if not updated_project:
+    def _get_config_or_raise(
+        self, project_uuid: UUID, config_uuid: UUID
+    ) -> ProjectConfig:
+        config = self.project_config_dao.get_by_uuid(config_uuid)
+        if not config or config.project_uuid != project_uuid:
+            raise ProjectNotFoundError(
+                f'Config {config_uuid} not found for project {project_uuid}'
+            )
+        return config
+
+    def _build_out(self, project: Project) -> ProjectOut:
+        configs = list(self.project_config_dao.list_by_project(project.uuid))
+        return ProjectOut.from_project(project, configs)
+
+    def _build_out_or_raise(self, project_uuid: UUID) -> ProjectOut:
+        project = self.project_dao.get_by_uuid(project_uuid)
+        if not project:
             raise ProjectInternalError(
                 f'Failed to fetch updated project {project_uuid}'
             )
-        return ProjectOut.from_project(updated_project)
+        return self._build_out(project)
 
     def create_project(self, project_in: ProjectIn) -> ProjectOut:
         try:
             project = project_in.to_project()
             inserted = self.project_dao.insert(project)
-            return ProjectOut.from_project(inserted)
         except IntegrityError as e:
             if 'uq_project_NAME' in str(e.orig) or 'NAME' in str(e.orig):
                 raise ProjectAlreadyExistsError(
@@ -52,120 +75,126 @@ class ProjectService:
                 f'An error occurred while creating the project: {e}'
             ) from e
 
-    def load_config(
-        self, project_uuid: UUID, config_in: ProjectConfigFileIn
+        template = get_default_config_template()
+        for slot in (Slot.A, Slot.B):
+            self.project_config_dao.create(
+                inserted.uuid, slot, template, ConfigStatus.DRAFT
+            )
+        return self._build_out_or_raise(inserted.uuid)
+
+    def update_config(
+        self, project_uuid: UUID, config_uuid: UUID, config_in: ProjectConfigFileIn
     ) -> ProjectOut:
         validate_gateway_config(config_in.config_file, check_secrets=True)
 
-        _ = self._get_project_or_raise(project_uuid)
+        config = self._get_config_or_raise(project_uuid, config_uuid)
+        if config.config_status == ConfigStatus.SERVED.value:
+            raise ProjectConfigValidationError(
+                f'Config {config_uuid} is served and cannot be edited'
+            )
 
-        rows_updated = self.project_dao.update_draft_config_file(
-            project_uuid, config_in.config_file
+        rows_updated = self.project_config_dao.update_config_file(
+            config_uuid, config_in.config_file
         )
         if rows_updated == 0:
-            raise ProjectNotFoundError(f'Project with UUID {project_uuid} not found')
+            raise ProjectNotFoundError(f'Config {config_uuid} not found')
 
-        updated_project = self.project_dao.get_by_uuid(project_uuid)
-        if not updated_project:
-            raise ProjectNotFoundError(f'Project with UUID {project_uuid} not found')
-        return ProjectOut.from_project(updated_project)
+        return self._build_out_or_raise(project_uuid)
 
-    def cancel_approval(self, project_uuid: UUID) -> ProjectOut:
-        project = self._get_project_or_raise(project_uuid)
+    def approve_config(self, project_uuid: UUID, config_uuid: UUID) -> ProjectOut:
+        config = self._get_config_or_raise(project_uuid, config_uuid)
 
-        if project.config_status != ConfigStatus.READY_TO_SERVE.value:
+        if config.config_status != ConfigStatus.DRAFT.value or not config.config_file:
             raise ProjectConfigValidationError(
-                f'Project {project_uuid} is not in READY_TO_SERVE state'
+                f'Config {config_uuid} has no draft configuration to approve'
             )
 
-        self.project_dao.set_config_status(project_uuid, ConfigStatus.DRAFT)
+        validate_gateway_config(config.config_file, check_secrets=True)
 
-        return self._get_updated_or_raise(project_uuid)
+        self.project_config_dao.set_status(config_uuid, ConfigStatus.READY_TO_SERVE)
+        return self._build_out_or_raise(project_uuid)
 
-    def approve_config(self, project_uuid: UUID) -> ProjectOut:
-        project = self._get_project_or_raise(project_uuid)
+    def cancel_approval(self, project_uuid: UUID, config_uuid: UUID) -> ProjectOut:
+        config = self._get_config_or_raise(project_uuid, config_uuid)
 
-        if (
-            project.config_status != ConfigStatus.DRAFT.value
-            or not project.draft_config_file
-        ):
+        if config.config_status != ConfigStatus.READY_TO_SERVE.value:
             raise ProjectConfigValidationError(
-                f'Project {project_uuid} has no draft configuration to approve'
+                f'Config {config_uuid} is not in READY_TO_SERVE state'
             )
 
-        validate_gateway_config(project.draft_config_file, check_secrets=True)
+        self.project_config_dao.set_status(config_uuid, ConfigStatus.DRAFT)
+        return self._build_out_or_raise(project_uuid)
 
-        self.project_dao.set_config_status(project_uuid, ConfigStatus.READY_TO_SERVE)
+    def serve_config(self, project_uuid: UUID, config_uuid: UUID) -> ProjectOut:
+        config = self._get_config_or_raise(project_uuid, config_uuid)
 
-        return self._get_updated_or_raise(project_uuid)
-
-    def serve_config(self, project_uuid: UUID) -> ProjectOut:
-        project = self._get_project_or_raise(project_uuid)
-
-        if not project.draft_config_file:
+        if not config.config_file:
             raise ProjectConfigValidationError(
-                f'Project {project_uuid} has no configuration to serve'
+                f'Config {config_uuid} has no configuration to serve'
+            )
+        if config.config_status != ConfigStatus.READY_TO_SERVE.value:
+            raise ProjectConfigValidationError(
+                f'Config {config_uuid} must be approved before serving'
             )
 
-        if project.config_status != ConfigStatus.READY_TO_SERVE.value:
+        served = self.project_config_dao.serve(config_uuid)
+        if served is None:
+            raise ProjectInternalError(
+                f'Failed to serve config {config_uuid} for project {project_uuid}'
+            )
+        return self._build_out_or_raise(project_uuid)
+
+    def unserve_config(self, project_uuid: UUID, config_uuid: UUID) -> ProjectOut:
+        config = self._get_config_or_raise(project_uuid, config_uuid)
+
+        if config.config_status != ConfigStatus.SERVED.value:
             raise ProjectConfigValidationError(
-                f'Project {project_uuid} config must be approved before serving'
+                f'Config {config_uuid} is not served'
             )
 
-        rows_updated = self.project_dao.promote_draft_to_config(
-            project_uuid, project.draft_config_file
-        )
+        rows_updated = self.project_config_dao.unserve(config_uuid)
         if rows_updated == 0:
             raise ProjectInternalError(
-                f'Failed to promote draft config for project {project_uuid}'
+                f'Failed to unserve config {config_uuid}'
             )
-
-        return self._get_updated_or_raise(project_uuid)
-
-    def unserve_config(self, project_uuid: UUID) -> ProjectOut:
-        project = self._get_project_or_raise(project_uuid)
-
-        if not project.config_file:
-            raise ProjectConfigValidationError(
-                f'Project {project_uuid} has no served configuration to unserve'
-            )
-
-        restore_draft = project.draft_config_file is None
-        rows_updated = self.project_dao.unserve_config(project_uuid, restore_draft)
-        if rows_updated == 0:
-            raise ProjectInternalError(
-                f'Failed to unserve config for project {project_uuid}'
-            )
-
-        return self._get_updated_or_raise(project_uuid)
+        return self._build_out_or_raise(project_uuid)
 
     def delete_project(self, project_uuid: UUID) -> ProjectOut:
         project = self._get_project_or_raise(project_uuid)
 
-        if project.config_file is not None:
-            restore_draft = project.draft_config_file is None
-            self.project_dao.unserve_config(project_uuid, restore_draft)
+        # Build the response before deletion so the caller can still see the
+        # served config (e.g. to deregister its routes).
+        out = self._build_out(project)
 
+        served = self.project_config_dao.get_served_by_project(project_uuid)
+        if served is not None:
+            self.project_config_dao.unserve(served.uuid)
+
+        self.project_config_dao.soft_delete_by_project(project_uuid)
         self.project_dao.soft_delete(project_uuid)
-        return ProjectOut.from_project(project)
+        return out
 
     def get_by_uuid(self, project_uuid: UUID) -> ProjectOut:
-        return ProjectOut.from_project(self._get_project_or_raise(project_uuid))
+        return self._build_out(self._get_project_or_raise(project_uuid))
+
+    def get_config(self, project_uuid: UUID, config_uuid: UUID) -> ConfigSlotOut:
+        return ConfigSlotOut.from_config(
+            self._get_config_or_raise(project_uuid, config_uuid)
+        )
 
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):
             raise ProjectNotFoundError(f'Project with UUID {project_uuid} not found')
 
     def get_all(self) -> list[ProjectOut]:
-        projects = self.project_dao.get_all()
-        return [ProjectOut.from_project(project) for project in projects]
+        return [self._build_out(project) for project in self.project_dao.get_all()]
 
     def get_all_filtered(
         self, project_filter: ProjectFilter | None = None
     ) -> list[ProjectOut]:
         projects = self.project_dao.get_all_filtered(project_filter)
-        return [ProjectOut.from_project(project) for project in projects]
+        return [self._build_out(project) for project in projects]
 
     def get_all_active(self) -> list[ProjectOut]:
         projects = self.project_dao.get_all_with_config()
-        return [ProjectOut.from_project(project) for project in projects]
+        return [self._build_out(project) for project in projects]

--- a/gateway/tests/common/db_integration.py
+++ b/gateway/tests/common/db_integration.py
@@ -58,6 +58,16 @@ class DatabaseIntegration(unittest.TestCase):
             for c in to_remove:
                 table.constraints.remove(c)
 
+            # Remove duplicate indexes (by name) that reflection may have
+            # re-added alongside model-declared ones (e.g. partial unique
+            # indexes), which would make a later create_all emit them twice.
+            seen_idx: set[str] = set()
+            for index in list(table.indexes):
+                if index.name in seen_idx:
+                    table.indexes.discard(index)
+                else:
+                    seen_idx.add(index.name)
+
     def tearDown(self):
         with self.db.begin_session() as session:
             for table in reversed(database.BaseTable.metadata.sorted_tables):

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from radicalbit_ai_gateway.db.models.event import EventDetails
 from radicalbit_ai_gateway.db.tables.event_table import Event
@@ -8,6 +8,7 @@ from radicalbit_ai_gateway.db.tables.group_route_table import GroupRoute
 from radicalbit_ai_gateway.db.tables.group_table import Group
 from radicalbit_ai_gateway.db.tables.key_table import Key
 from radicalbit_ai_gateway.db.tables.otel_traces_table import OtelTraces
+from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
 from radicalbit_ai_gateway.db.tables.request_event_table import RequestEvent
 from radicalbit_ai_gateway.models.api_key_dto import ApiKeySec
@@ -24,8 +25,10 @@ from radicalbit_ai_gateway.models.auth_dto import (
     KeysUuidIn,
     RouteGroupsIn,
 )
+from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import (
+    ConfigSlotOut,
     ProjectConfigFileIn,
     ProjectIn,
     ProjectOut,
@@ -137,7 +140,6 @@ def get_sample_group_route_plain(
         project=Project(
             uuid=project_uuid,
             name=project_name,
-            config_status='DRAFT',
             created_at=datetime.datetime.now(tz=UTC),
             updated_at=datetime.datetime.now(tz=UTC),
             deleted_at=None,
@@ -167,7 +169,6 @@ def get_sample_group_route(
         project=Project(
             uuid=project_uuid,
             name=project_name,
-            config_status='DRAFT',
             created_at=datetime.datetime.now(tz=UTC),
             updated_at=datetime.datetime.now(tz=UTC),
             deleted_at=None,
@@ -282,9 +283,7 @@ def get_sample_project(
     uuid: uuid.UUID = RANDOM_UUID,
     name: str = 'my-project',
     description: str | None = None,
-    config_file: str | None = None,
-    draft_config_file: str | None = None,
-    config_status: ConfigStatus = ConfigStatus.DRAFT,
+    served_config_uuid: uuid.UUID | None = None,
     first_served_at: datetime.datetime | None = None,
     deleted_at: datetime.datetime | None = None,
 ) -> Project:
@@ -293,12 +292,31 @@ def get_sample_project(
         uuid=uuid,
         name=name,
         description=description,
-        config_file=config_file,
-        draft_config_file=draft_config_file,
-        config_status=config_status.value,
+        served_config_uuid=served_config_uuid,
         created_at=now,
         updated_at=now,
         first_served_at=first_served_at,
+        deleted_at=deleted_at,
+    )
+
+
+def get_sample_project_config(
+    project_uuid: uuid.UUID,
+    slot: Slot = Slot.A,
+    config_file: str | None = None,
+    config_status: ConfigStatus = ConfigStatus.DRAFT,
+    uuid: uuid.UUID | None = None,
+    deleted_at: datetime.datetime | None = None,
+) -> ProjectConfig:
+    now = datetime.datetime.now(tz=UTC)
+    return ProjectConfig(
+        uuid=uuid or uuid4(),
+        project_uuid=project_uuid,
+        slot=slot.value,
+        config_file=config_file,
+        config_status=config_status.value,
+        created_at=now,
+        updated_at=now,
         deleted_at=deleted_at,
     )
 
@@ -313,25 +331,44 @@ def get_sample_project_in(
     )
 
 
+def get_sample_config_slot_out(
+    uuid: uuid.UUID = RANDOM_UUID,
+    slot: Slot = Slot.A,
+    config_file: str | None = None,
+    config_status: ConfigStatus = ConfigStatus.DRAFT,
+) -> ConfigSlotOut:
+    now = datetime.datetime.now(tz=UTC)
+    return ConfigSlotOut(
+        uuid=uuid,
+        slot=slot.value,
+        config_file=config_file,
+        config_status=config_status,
+        updated_at=str(now),
+    )
+
+
 def get_sample_project_out(
     uuid: uuid.UUID = RANDOM_UUID,
     name: str = 'my-project',
     description: str | None = None,
-    config_file: str | None = None,
-    draft_config_file: str | None = None,
-    config_status: ConfigStatus = ConfigStatus.DRAFT,
+    served_config_uuid: uuid.UUID | None = None,
+    configs: list[ConfigSlotOut] | None = None,
 ) -> ProjectOut:
     now = datetime.datetime.now(tz=UTC)
+    if configs is None:
+        configs = [
+            get_sample_config_slot_out(uuid=uuid4(), slot=Slot.A),
+            get_sample_config_slot_out(uuid=uuid4(), slot=Slot.B),
+        ]
     return ProjectOut(
         uuid=uuid,
         name=name,
         description=description,
-        config_file=config_file,
-        draft_config_file=draft_config_file,
-        config_status=config_status,
         project_status=ProjectStatus.PROD
-        if config_file is not None
+        if served_config_uuid is not None
         else ProjectStatus.DEV,
+        served_config_uuid=served_config_uuid,
+        configs=configs,
         created_at=str(now),
         updated_at=str(now),
     )

--- a/gateway/tests/dao/project_config_dao_test.py
+++ b/gateway/tests/dao/project_config_dao_test.py
@@ -1,12 +1,16 @@
+import datetime
 import uuid
 
 from tests.common import db_mock
 from tests.common.db_integration import DatabaseIntegration
 
 from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
+from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
 from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
+
+_UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
 
 
 class ProjectConfigDAOTest(DatabaseIntegration):
@@ -16,15 +20,36 @@ class ProjectConfigDAOTest(DatabaseIntegration):
         cls.dao = ProjectConfigDAO(cls.db)
 
     def _project(self) -> Project:
-        project = db_mock.get_sample_project(uuid=uuid.uuid4(), name=f'p-{uuid.uuid4()}')
+        project = db_mock.get_sample_project(
+            uuid=uuid.uuid4(), name=f'p-{uuid.uuid4()}'
+        )
         return self.insert(project)
 
     def _seed_two(self, project_uuid):
-        a = self.dao.create(project_uuid, Slot.A, '# a', ConfigStatus.DRAFT)
-        b = self.dao.create(project_uuid, Slot.B, '# b', ConfigStatus.DRAFT)
+        now = datetime.datetime.now(tz=_UTC)
+        a = self.insert(
+            ProjectConfig(
+                project_uuid=project_uuid,
+                slot=Slot.A.value,
+                config_file='# a',
+                config_status=ConfigStatus.DRAFT.value,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        b = self.insert(
+            ProjectConfig(
+                project_uuid=project_uuid,
+                slot=Slot.B.value,
+                config_file='# b',
+                config_status=ConfigStatus.DRAFT.value,
+                created_at=now,
+                updated_at=now,
+            )
+        )
         return a.uuid, b.uuid
 
-    def test_create_and_list_ordered(self):
+    def test_seed_and_list_ordered(self):
         p = self._project()
         self._seed_two(p.uuid)
         configs = self.dao.list_by_project(p.uuid)

--- a/gateway/tests/dao/project_config_dao_test.py
+++ b/gateway/tests/dao/project_config_dao_test.py
@@ -1,0 +1,99 @@
+import uuid
+
+from tests.common import db_mock
+from tests.common.db_integration import DatabaseIntegration
+
+from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
+from radicalbit_ai_gateway.db.tables.project_table import Project
+from radicalbit_ai_gateway.models.config_slot import Slot
+from radicalbit_ai_gateway.models.config_status import ConfigStatus
+
+
+class ProjectConfigDAOTest(DatabaseIntegration):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.dao = ProjectConfigDAO(cls.db)
+
+    def _project(self) -> Project:
+        project = db_mock.get_sample_project(uuid=uuid.uuid4(), name=f'p-{uuid.uuid4()}')
+        return self.insert(project)
+
+    def _seed_two(self, project_uuid):
+        a = self.dao.create(project_uuid, Slot.A, '# a', ConfigStatus.DRAFT)
+        b = self.dao.create(project_uuid, Slot.B, '# b', ConfigStatus.DRAFT)
+        return a.uuid, b.uuid
+
+    def test_create_and_list_ordered(self):
+        p = self._project()
+        self._seed_two(p.uuid)
+        configs = self.dao.list_by_project(p.uuid)
+        assert [c.slot for c in configs] == ['A', 'B']
+        assert self.dao.get_served_by_project(p.uuid) is None
+
+    def test_get_by_uuid(self):
+        p = self._project()
+        a_id, _ = self._seed_two(p.uuid)
+        assert self.dao.get_by_uuid(a_id).uuid == a_id
+        assert self.dao.get_by_uuid(uuid.uuid4()) is None
+
+    def test_update_config_file_resets_to_draft(self):
+        p = self._project()
+        a_id, _ = self._seed_two(p.uuid)
+        self.dao.set_status(a_id, ConfigStatus.READY_TO_SERVE)
+        assert self.dao.update_config_file(a_id, 'new') == 1
+        updated = self.dao.get_by_uuid(a_id)
+        assert updated.config_file == 'new'
+        assert updated.config_status == ConfigStatus.DRAFT.value
+
+    def test_serve_sets_served_ref_and_first_served_at(self):
+        p = self._project()
+        a_id, _ = self._seed_two(p.uuid)
+        served = self.dao.serve(a_id)
+        assert served.config_status == ConfigStatus.SERVED.value
+        with self.db.begin_session() as s:
+            proj = s.get(Project, p.uuid)
+            assert str(proj.served_config_uuid) == str(a_id)
+            assert proj.first_served_at is not None
+
+    def test_serve_swaps_and_keeps_single_served(self):
+        p = self._project()
+        a_id, b_id = self._seed_two(p.uuid)
+        self.dao.serve(a_id)
+        with self.db.begin_session() as s:
+            first_served = s.get(Project, p.uuid).first_served_at
+        self.dao.serve(b_id)
+        by = {c.uuid: c.config_status for c in self.dao.list_by_project(p.uuid)}
+        assert by[b_id] == ConfigStatus.SERVED.value
+        assert by[a_id] == ConfigStatus.DRAFT.value
+        served_rows = [
+            c
+            for c in self.dao.list_by_project(p.uuid)
+            if c.config_status == ConfigStatus.SERVED.value
+        ]
+        assert len(served_rows) == 1
+        with self.db.begin_session() as s:
+            proj = s.get(Project, p.uuid)
+            assert str(proj.served_config_uuid) == str(b_id)
+            assert proj.first_served_at == first_served
+
+    def test_serve_not_found(self):
+        assert self.dao.serve(uuid.uuid4()) is None
+
+    def test_unserve_clears_ref(self):
+        p = self._project()
+        a_id, _ = self._seed_two(p.uuid)
+        self.dao.serve(a_id)
+        assert self.dao.unserve(a_id) == 1
+        assert self.dao.get_served_by_project(p.uuid) is None
+        with self.db.begin_session() as s:
+            assert s.get(Project, p.uuid).served_config_uuid is None
+
+    def test_unserve_not_found(self):
+        assert self.dao.unserve(uuid.uuid4()) == 0
+
+    def test_soft_delete_by_project(self):
+        p = self._project()
+        self._seed_two(p.uuid)
+        assert self.dao.soft_delete_by_project(p.uuid) == 2
+        assert list(self.dao.list_by_project(p.uuid)) == []

--- a/gateway/tests/dao/project_dao_test.py
+++ b/gateway/tests/dao/project_dao_test.py
@@ -1,10 +1,14 @@
 import datetime
 import uuid
 
+from sqlalchemy import update
+
 from tests.common import db_mock
 from tests.common.db_integration import DatabaseIntegration
 
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
+from radicalbit_ai_gateway.db.tables.project_table import Project
+from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import ProjectFilter
 
 
@@ -13,6 +17,24 @@ class ProjectDAOTest(DatabaseIntegration):
     def setUpClass(cls):
         super().setUpClass()
         cls.project_dao = ProjectDAO(cls.db)
+
+    def _insert_served_project(self, name: str) -> Project:
+        """Insert a project plus a SERVED config and wire served_config_uuid."""
+        project = db_mock.get_sample_project(uuid=uuid.uuid4(), name=name)
+        self.project_dao.insert(project)
+        config = db_mock.get_sample_project_config(
+            project_uuid=project.uuid,
+            config_file='served-yaml',
+            config_status=ConfigStatus.SERVED,
+        )
+        self.insert(config)
+        with self.db.begin_session() as session:
+            session.execute(
+                update(Project)
+                .where(Project.uuid == project.uuid)
+                .values(served_config_uuid=config.uuid)
+            )
+        return self.project_dao.get_by_uuid(project.uuid)
 
     def test_insert(self):
         project = db_mock.get_sample_project()
@@ -26,207 +48,104 @@ class ProjectDAOTest(DatabaseIntegration):
         result = self.project_dao.get_by_uuid(project.uuid)
         assert result is not None
         assert result.uuid == project.uuid
-        assert result.name == project.name
 
     def test_get_by_uuid_not_found(self):
-        result = self.project_dao.get_by_uuid(uuid.uuid4())
-        assert result is None
+        assert self.project_dao.get_by_uuid(uuid.uuid4()) is None
 
     def test_get_all(self):
-        projects = [
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='one'),
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='two'),
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='three'),
-        ]
-        for p in projects:
-            self.project_dao.insert(p)
-        result = self.project_dao.get_all()
-        assert len(result) == 3
+        for n in ('one', 'two', 'three'):
+            self.project_dao.insert(
+                db_mock.get_sample_project(uuid=uuid.uuid4(), name=n)
+            )
+        assert len(self.project_dao.get_all()) == 3
 
     def test_get_all_empty(self):
-        result = self.project_dao.get_all()
-        assert list(result) == []
+        assert list(self.project_dao.get_all()) == []
 
-    def test_get_all_with_config_only_returns_projects_with_config(self):
+    def test_get_all_with_config_only_returns_served(self):
+        self._insert_served_project('active')
         self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='active', config_file='some-yaml'
-            )
-        )
-        self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='inactive', config_file=None
-            )
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='inactive')
         )
         result = self.project_dao.get_all_with_config()
         assert len(result) == 1
-        assert result[0].config_file == 'some-yaml'
         assert result[0].name == 'active'
 
     def test_get_all_with_config_empty(self):
         self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='no-config', config_file=None
-            )
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='no-config')
         )
-        result = self.project_dao.get_all_with_config()
-        assert list(result) == []
-
-    def test_update_draft_config_file(self):
-        project = db_mock.get_sample_project()
-        self.project_dao.insert(project)
-        rows = self.project_dao.update_draft_config_file(project.uuid, 'draft-yaml')
-        assert rows == 1
-        updated = self.project_dao.get_by_uuid(project.uuid)
-        assert updated.draft_config_file == 'draft-yaml'
-        assert updated.config_file is None
-
-    def test_update_draft_config_file_not_found(self):
-        rows = self.project_dao.update_draft_config_file(uuid.uuid4(), 'draft-yaml')
-        assert rows == 0
-
-    def test_promote_draft_to_config(self):
-        project = db_mock.get_sample_project(draft_config_file='draft-yaml')
-        self.project_dao.insert(project)
-        rows = self.project_dao.promote_draft_to_config(project.uuid, 'draft-yaml')
-        assert rows == 1
-        updated = self.project_dao.get_by_uuid(project.uuid)
-        assert updated.config_file == 'draft-yaml'
-        assert updated.draft_config_file is None
-
-    def test_promote_draft_to_config_not_found(self):
-        rows = self.project_dao.promote_draft_to_config(uuid.uuid4(), 'some-yaml')
-        assert rows == 0
-
-    def test_promote_draft_to_config_sets_first_served_at(self):
-        project = db_mock.get_sample_project(draft_config_file='draft-yaml')
-        self.project_dao.insert(project)
-        assert project.first_served_at is None
-        self.project_dao.promote_draft_to_config(project.uuid, 'draft-yaml')
-        updated = self.project_dao.get_by_uuid(project.uuid)
-        assert updated.first_served_at is not None
-
-    def test_promote_draft_to_config_preserves_first_served_at_on_re_serve(self):
-        UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
-        original_time = datetime.datetime(2025, 1, 1, tzinfo=UTC)
-        project = db_mock.get_sample_project(
-            draft_config_file='draft-yaml',
-            first_served_at=original_time,
-        )
-        self.project_dao.insert(project)
-        self.project_dao.promote_draft_to_config(project.uuid, 'draft-yaml')
-        updated = self.project_dao.get_by_uuid(project.uuid)
-        assert updated.first_served_at == original_time
+        assert list(self.project_dao.get_all_with_config()) == []
 
     def test_get_all_filtered_no_filter_returns_all(self):
-        self.project_dao.insert(
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='a', config_file='yaml')
-        )
-        self.project_dao.insert(
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='b', config_file=None)
-        )
-        result = self.project_dao.get_all_filtered(None)
-        assert len(result) == 2
+        self._insert_served_project('a')
+        self.project_dao.insert(db_mock.get_sample_project(uuid=uuid.uuid4(), name='b'))
+        assert len(self.project_dao.get_all_filtered(None)) == 2
 
     def test_get_all_filtered_active_returns_only_served(self):
+        self._insert_served_project('served')
         self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='served', config_file='yaml'
-            )
-        )
-        self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='not-served', config_file=None
-            )
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='not-served')
         )
         result = self.project_dao.get_all_filtered(ProjectFilter.ACTIVE)
-        assert len(result) == 1
-        assert result[0].name == 'served'
+        assert len(result) == 1 and result[0].name == 'served'
+
+    def test_get_all_filtered_prod_returns_only_served(self):
+        self._insert_served_project('with-config')
+        self.project_dao.insert(
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='no-config')
+        )
+        result = self.project_dao.get_all_filtered(ProjectFilter.PROD)
+        assert len(result) == 1 and result[0].name == 'with-config'
+
+    def test_get_all_filtered_dev_returns_only_without_served(self):
+        self._insert_served_project('with-config')
+        self.project_dao.insert(
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='no-config')
+        )
+        result = self.project_dao.get_all_filtered(ProjectFilter.DEV)
+        assert len(result) == 1 and result[0].name == 'no-config'
 
     def test_get_all_filtered_with_usage_returns_ever_served(self):
         UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
         now = datetime.datetime.now(tz=UTC)
         self.project_dao.insert(
             db_mock.get_sample_project(
-                uuid=uuid.uuid4(),
-                name='was-served',
-                config_file=None,
-                first_served_at=now,
+                uuid=uuid.uuid4(), name='was-served', first_served_at=now
             )
         )
         self.project_dao.insert(
             db_mock.get_sample_project(
-                uuid=uuid.uuid4(),
-                name='never-served',
-                config_file=None,
-                first_served_at=None,
+                uuid=uuid.uuid4(), name='never-served', first_served_at=None
             )
         )
         result = self.project_dao.get_all_filtered(ProjectFilter.WITH_USAGE)
-        assert len(result) == 1
-        assert result[0].name == 'was-served'
-
-    def test_get_all_filtered_dev_returns_only_without_config_file(self):
-        self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='no-config', config_file=None
-            )
-        )
-        self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='with-config', config_file='yaml'
-            )
-        )
-        result = self.project_dao.get_all_filtered(ProjectFilter.DEV)
-        assert len(result) == 1
-        assert result[0].name == 'no-config'
-
-    def test_get_all_filtered_prod_returns_only_with_config_file(self):
-        self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='no-config', config_file=None
-            )
-        )
-        self.project_dao.insert(
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='with-config', config_file='yaml'
-            )
-        )
-        result = self.project_dao.get_all_filtered(ProjectFilter.PROD)
-        assert len(result) == 1
-        assert result[0].name == 'with-config'
-
-    # --- soft_delete ---
+        assert len(result) == 1 and result[0].name == 'was-served'
 
     def test_soft_delete(self):
         project = db_mock.get_sample_project()
         self.project_dao.insert(project)
-        rows = self.project_dao.soft_delete(project.uuid)
-        assert rows == 1
+        assert self.project_dao.soft_delete(project.uuid) == 1
 
     def test_soft_delete_not_found(self):
-        rows = self.project_dao.soft_delete(uuid.uuid4())
-        assert rows == 0
+        assert self.project_dao.soft_delete(uuid.uuid4()) == 0
 
     def test_get_by_uuid_excludes_deleted(self):
         project = db_mock.get_sample_project()
         self.project_dao.insert(project)
         self.project_dao.soft_delete(project.uuid)
-        result = self.project_dao.get_by_uuid(project.uuid)
-        assert result is None
+        assert self.project_dao.get_by_uuid(project.uuid) is None
 
     def test_get_all_excludes_deleted(self):
         projects = [
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='one'),
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='two'),
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='three'),
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name=n)
+            for n in ('one', 'two', 'three')
         ]
         for p in projects:
             self.project_dao.insert(p)
         self.project_dao.soft_delete(projects[0].uuid)
         result = self.project_dao.get_all()
-        assert len(result) == 2
-        assert 'one' not in {p.name for p in result}
+        assert len(result) == 2 and 'one' not in {p.name for p in result}
 
     def test_get_all_filtered_excludes_deleted(self):
         self.project_dao.insert(
@@ -236,23 +155,9 @@ class ProjectDAOTest(DatabaseIntegration):
         self.project_dao.insert(deleted)
         self.project_dao.soft_delete(deleted.uuid)
         result = self.project_dao.get_all_filtered(None)
-        assert len(result) == 1
-        assert result[0].name == 'live'
+        assert len(result) == 1 and result[0].name == 'live'
 
     def test_get_all_with_config_excludes_deleted(self):
-        served = db_mock.get_sample_project(
-            uuid=uuid.uuid4(), name='served', config_file='some-yaml'
-        )
-        self.project_dao.insert(served)
+        served = self._insert_served_project('served')
         self.project_dao.soft_delete(served.uuid)
-        result = self.project_dao.get_all_with_config()
-        assert list(result) == []
-
-    def test_unserve_config_noop_on_deleted_project(self):
-        project = db_mock.get_sample_project(
-            uuid=uuid.uuid4(), name='served', config_file='some-yaml'
-        )
-        self.project_dao.insert(project)
-        self.project_dao.soft_delete(project.uuid)
-        rows = self.project_dao.unserve_config(project.uuid, restore_draft=False)
-        assert rows == 0
+        assert list(self.project_dao.get_all_with_config()) == []

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -127,9 +127,7 @@ class TestProjectRoute(unittest.TestCase):
         self.project_service.approve_config = MagicMock(
             return_value=db_mock.get_sample_project_out(uuid=pid)
         )
-        res = self.client.patch(
-            f'{self.prefix}/projects/{pid}/configs/{cid}/approve'
-        )
+        res = self.client.patch(f'{self.prefix}/projects/{pid}/configs/{cid}/approve')
         assert res.status_code == 200
         self.project_service.approve_config.assert_called_once_with(pid, cid)
 
@@ -185,6 +183,23 @@ class TestProjectRoute(unittest.TestCase):
         assert res.status_code == 200
         assert res.json()['configFile'] == '# generated'
         self.project_service.get_config.assert_called_once_with(pid, cid)
+
+    def test_generate_config_rejected_when_served(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.get_config = MagicMock(
+            return_value=db_mock.get_sample_config_slot_out(
+                uuid=cid, config_file='# x', config_status=ConfigStatus.SERVED
+            )
+        )
+        self.config_generator_service.generate_config = AsyncMock(
+            return_value='# generated'
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/configs/{cid}/generate-config',
+            json={'description': 'make it'},
+        )
+        assert res.status_code == 400
+        self.config_generator_service.generate_config.assert_not_awaited()
 
     def test_delete_project_deregisters_when_served(self):
         pid = uuid.uuid4()

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -8,12 +8,9 @@ from starlette.testclient import TestClient
 
 from tests.common import db_mock
 
-from radicalbit_ai_gateway.models.auth_dto import GroupFullOut, GroupOut
-from radicalbit_ai_gateway.models.project_dto import (
-    GenerateConfigIn,
-    ProjectFilter,
-    ProjectOut,
-)
+from radicalbit_ai_gateway.models.config_slot import Slot
+from radicalbit_ai_gateway.models.config_status import ConfigStatus
+from radicalbit_ai_gateway.models.project_dto import ProjectFilter
 from radicalbit_ai_gateway.routes.project_route import ProjectRoute
 from radicalbit_ai_gateway.services.config_generator_service import (
     ConfigGeneratorService,
@@ -22,13 +19,13 @@ from radicalbit_ai_gateway.services.group_service import GroupService
 from radicalbit_ai_gateway.services.project_service import ProjectService
 from radicalbit_ai_gateway.utils.exceptions import (
     AuthRegistryError,
-    ErrorOut,
     ProjectAlreadyExistsError,
     ProjectConfigValidationError,
-    ProjectInternalError,
     ProjectNotFoundError,
     auth_registry_exception_handler,
 )
+
+_VALID = db_mock.VALID_CONFIG_YAML
 
 
 class TestProjectRoute(unittest.TestCase):
@@ -37,602 +34,171 @@ class TestProjectRoute(unittest.TestCase):
         self.project_service = MagicMock(spec_set=ProjectService)
         self.group_service = MagicMock(spec_set=GroupService)
         self.config_generator_service = MagicMock(spec_set=ConfigGeneratorService)
+        self.register = AsyncMock()
+        self.deregister = AsyncMock()
         router = ProjectRoute.get_project_router(
             self.project_service,
             self.group_service,
+            register_project_routes=self.register,
+            deregister_project_routes=self.deregister,
             config_generator_service=self.config_generator_service,
         )
         app = FastAPI(title='AI Gateway', debug=True)
         app.add_exception_handler(AuthRegistryError, auth_registry_exception_handler)
         app.include_router(router, prefix=self.prefix)
-
         self.client = TestClient(app)
+
+    # --- create / list / get ---
 
     def test_create_project(self):
         project_in = db_mock.get_sample_project_in()
-        project = db_mock.get_sample_project()
-        project_out = ProjectOut.from_project(project)
-        self.project_service.create_project = MagicMock(return_value=project_out)
+        out = db_mock.get_sample_project_out()
+        self.project_service.create_project = MagicMock(return_value=out)
         res = self.client.post(
             f'{self.prefix}/projects', json=jsonable_encoder(project_in)
         )
         assert res.status_code == 201
-        assert res.json() == jsonable_encoder(project_out)
+        assert res.json() == jsonable_encoder(out)
         self.project_service.create_project.assert_called_once_with(project_in)
 
     def test_create_project_already_exists(self):
-        project_in = db_mock.get_sample_project_in()
         self.project_service.create_project = MagicMock(
             side_effect=ProjectAlreadyExistsError('error')
         )
         res = self.client.post(
-            f'{self.prefix}/projects', json=jsonable_encoder(project_in)
+            f'{self.prefix}/projects',
+            json=jsonable_encoder(db_mock.get_sample_project_in()),
         )
         assert res.status_code == 400
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_already_exists_bad_request',
-                param=None,
-            ).error
-        )
-        self.project_service.create_project.assert_called_once_with(project_in)
 
-    def test_create_project_internal_error(self):
-        project_in = db_mock.get_sample_project_in()
-        self.project_service.create_project = MagicMock(
-            side_effect=ProjectInternalError('error')
-        )
-        res = self.client.post(
-            f'{self.prefix}/projects', json=jsonable_encoder(project_in)
-        )
-        assert res.status_code == 500
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_internal_error',
-                param=None,
-            ).error
-        )
-        self.project_service.create_project.assert_called_once_with(project_in)
-
-    def test_get_all(self):
-        projects = [
-            ProjectOut.from_project(
-                db_mock.get_sample_project(uuid=uuid.uuid4(), name='one')
-            ),
-            ProjectOut.from_project(
-                db_mock.get_sample_project(uuid=uuid.uuid4(), name='two')
-            ),
-            ProjectOut.from_project(
-                db_mock.get_sample_project(uuid=uuid.uuid4(), name='three')
-            ),
-        ]
-        self.project_service.get_all_filtered = MagicMock(return_value=projects)
-        res = self.client.get(f'{self.prefix}/projects')
+    def test_get_all_with_filter(self):
+        out = db_mock.get_sample_project_out()
+        self.project_service.get_all_filtered = MagicMock(return_value=[out])
+        res = self.client.get(f'{self.prefix}/projects', params={'filter': 'prod'})
         assert res.status_code == 200
-        assert jsonable_encoder(projects) == res.json()
-        self.project_service.get_all_filtered.assert_called_once_with(None)
-
-    def test_get_all_empty(self):
-        self.project_service.get_all_filtered = MagicMock(return_value=[])
-        res = self.client.get(f'{self.prefix}/projects')
-        assert res.status_code == 200
-        assert res.json() == []
-        self.project_service.get_all_filtered.assert_called_once_with(None)
-
-    def test_get_all_with_active_filter(self):
-        projects = [
-            ProjectOut.from_project(
-                db_mock.get_sample_project(
-                    uuid=uuid.uuid4(), name='served', config_file='some: yaml'
-                )
-            ),
-        ]
-        self.project_service.get_all_filtered = MagicMock(return_value=projects)
-        res = self.client.get(f'{self.prefix}/projects?filter=active')
-        assert res.status_code == 200
-        assert jsonable_encoder(projects) == res.json()
         self.project_service.get_all_filtered.assert_called_once_with(
-            ProjectFilter.ACTIVE
+            ProjectFilter.PROD
         )
 
-    def test_get_all_with_usage_filter(self):
-        projects = [
-            ProjectOut.from_project(
-                db_mock.get_sample_project(uuid=uuid.uuid4(), name='ever-served')
-            ),
-        ]
-        self.project_service.get_all_filtered = MagicMock(return_value=projects)
-        res = self.client.get(f'{self.prefix}/projects?filter=with_usage')
+    def test_get_by_uuid(self):
+        pid = uuid.uuid4()
+        out = db_mock.get_sample_project_out(uuid=pid)
+        self.project_service.get_by_uuid = MagicMock(return_value=out)
+        res = self.client.get(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
-        assert jsonable_encoder(projects) == res.json()
-        self.project_service.get_all_filtered.assert_called_once_with(
-            ProjectFilter.WITH_USAGE
-        )
+        self.project_service.get_by_uuid.assert_called_once_with(pid)
 
-    def test_get_all_invalid_filter_returns_422(self):
-        res = self.client.get(f'{self.prefix}/projects?filter=invalid')
-        assert res.status_code == 422
-
-    def test_get_project_by_uuid(self):
-        project = db_mock.get_sample_project()
-        project_out = ProjectOut.from_project(project)
-        self.project_service.get_by_uuid = MagicMock(return_value=project_out)
-        res = self.client.get(f'{self.prefix}/projects/{project.uuid}')
-        assert res.status_code == 200
-        assert jsonable_encoder(project_out) == res.json()
-        self.project_service.get_by_uuid.assert_called_once_with(project.uuid)
-
-    def test_get_project_by_uuid_not_found(self):
-        unknown_uuid = uuid.uuid4()
+    def test_get_by_uuid_not_found(self):
+        pid = uuid.uuid4()
         self.project_service.get_by_uuid = MagicMock(
-            side_effect=ProjectNotFoundError('error')
+            side_effect=ProjectNotFoundError('nope')
         )
-        res = self.client.get(f'{self.prefix}/projects/{unknown_uuid}')
+        res = self.client.get(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 404
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_not_found',
-                param=None,
-            ).error
-        )
-        self.project_service.get_by_uuid.assert_called_once_with(unknown_uuid)
 
-    def test_load_config_ok(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(draft_config_file=config_in.config_file)
-        project_out = ProjectOut.from_project(project)
-        self.project_service.load_config = MagicMock(return_value=project_out)
+    # --- config mutations ---
+
+    def test_update_config(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        out = db_mock.get_sample_project_out(uuid=pid)
+        self.project_service.update_config = MagicMock(return_value=out)
         res = self.client.patch(
-            f'{self.prefix}/projects/{project.uuid}/load-config',
-            json=jsonable_encoder(config_in),
+            f'{self.prefix}/projects/{pid}/configs/{cid}',
+            json={'configFile': _VALID},
         )
         assert res.status_code == 200
-        assert res.json() == jsonable_encoder(project_out)
-        self.project_service.load_config.assert_called_once_with(
-            project.uuid, config_in
-        )
+        args = self.project_service.update_config.call_args.args
+        assert args[0] == pid and args[1] == cid
+        assert args[2].config_file == _VALID
 
-    def test_load_config_project_not_found(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        unknown_uuid = uuid.uuid4()
-        self.project_service.load_config = MagicMock(
-            side_effect=ProjectNotFoundError('error')
+    def test_update_config_validation_error(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.update_config = MagicMock(
+            side_effect=ProjectConfigValidationError('served read-only')
         )
         res = self.client.patch(
-            f'{self.prefix}/projects/{unknown_uuid}/load-config',
-            json=jsonable_encoder(config_in),
+            f'{self.prefix}/projects/{pid}/configs/{cid}',
+            json={'configFile': _VALID},
         )
-        assert res.status_code == 404
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_not_found',
-                param=None,
-            ).error
-        )
+        assert res.status_code == 400
 
-    # --- cancel-approval ---
-
-    def test_cancel_approval_ok(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
+    def test_approve_config(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.approve_config = MagicMock(
+            return_value=db_mock.get_sample_project_out(uuid=pid)
         )
-        project_out = ProjectOut.from_project(project)
-        self.project_service.cancel_approval = MagicMock(return_value=project_out)
         res = self.client.patch(
-            f'{self.prefix}/projects/{project.uuid}/cancel-approval'
+            f'{self.prefix}/projects/{pid}/configs/{cid}/approve'
         )
         assert res.status_code == 200
-        assert res.json() == jsonable_encoder(project_out)
-        self.project_service.cancel_approval.assert_called_once_with(project.uuid)
+        self.project_service.approve_config.assert_called_once_with(pid, cid)
 
-    def test_cancel_approval_not_found(self):
-        unknown_uuid = uuid.uuid4()
+    def test_cancel_approval(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
         self.project_service.cancel_approval = MagicMock(
-            side_effect=ProjectNotFoundError('error')
+            return_value=db_mock.get_sample_project_out(uuid=pid)
         )
         res = self.client.patch(
-            f'{self.prefix}/projects/{unknown_uuid}/cancel-approval'
-        )
-        assert res.status_code == 404
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_not_found',
-                param=None,
-            ).error
-        )
-
-    def test_cancel_approval_wrong_status(self):
-        project_uuid = uuid.uuid4()
-        self.project_service.cancel_approval = MagicMock(
-            side_effect=ProjectConfigValidationError('error')
-        )
-        res = self.client.patch(
-            f'{self.prefix}/projects/{project_uuid}/cancel-approval'
-        )
-        assert res.status_code == 400
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_config_validation_error',
-                param=None,
-            ).error
-        )
-
-    # --- serve-config ---
-
-    def test_serve_config_ok(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=None,
-            config_file=config_in.config_file,
-        )
-        project_out = ProjectOut.from_project(project)
-        self.project_service.serve_config = MagicMock(return_value=project_out)
-        res = self.client.patch(f'{self.prefix}/projects/{project.uuid}/serve-config')
-        assert res.status_code == 200
-        assert res.json() == jsonable_encoder(project_out)
-        self.project_service.serve_config.assert_called_once_with(project.uuid)
-
-    def test_serve_config_not_found(self):
-        unknown_uuid = uuid.uuid4()
-        self.project_service.serve_config = MagicMock(
-            side_effect=ProjectNotFoundError('error')
-        )
-        res = self.client.patch(f'{self.prefix}/projects/{unknown_uuid}/serve-config')
-        assert res.status_code == 404
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_not_found',
-                param=None,
-            ).error
-        )
-
-    def test_serve_config_no_draft(self):
-        project_uuid = uuid.uuid4()
-        self.project_service.serve_config = MagicMock(
-            side_effect=ProjectConfigValidationError('error')
-        )
-        res = self.client.patch(f'{self.prefix}/projects/{project_uuid}/serve-config')
-        assert res.status_code == 400
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_config_validation_error',
-                param=None,
-            ).error
-        )
-
-    def test_serve_config_internal_error(self):
-        project_uuid = uuid.uuid4()
-        self.project_service.serve_config = MagicMock(
-            side_effect=ProjectInternalError('error')
-        )
-        res = self.client.patch(f'{self.prefix}/projects/{project_uuid}/serve-config')
-        assert res.status_code == 500
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_internal_error',
-                param=None,
-            ).error
-        )
-
-    def test_serve_config_calls_register_fn(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            name='my-project',
-            draft_config_file=None,
-            config_file=config_in.config_file,
-        )
-        project_out = ProjectOut.from_project(project)
-        register_fn = AsyncMock()
-        router = ProjectRoute.get_project_router(
-            self.project_service,
-            self.group_service,
-            register_project_routes=register_fn,
-            config_generator_service=self.config_generator_service,
-        )
-        app = FastAPI(title='AI Gateway', debug=True)
-        app.add_exception_handler(AuthRegistryError, auth_registry_exception_handler)
-        app.include_router(router, prefix=self.prefix)
-        client = TestClient(app)
-
-        self.project_service.serve_config = MagicMock(return_value=project_out)
-        res = client.patch(f'{self.prefix}/projects/{project.uuid}/serve-config')
-        assert res.status_code == 200
-        register_fn.assert_called_once_with(
-            project.uuid,
-            project_out.name,
-            project_out.config_file,
-        )
-
-    def test_unserve_config_calls_deregister_fn(self):
-        project = db_mock.get_sample_project(
-            config_file='some: yaml',
-        )
-        project_out = ProjectOut.from_project(project)
-        deregister_fn = AsyncMock()
-        router = ProjectRoute.get_project_router(
-            self.project_service,
-            self.group_service,
-            deregister_project_routes=deregister_fn,
-        )
-        app = FastAPI(title='AI Gateway', debug=True)
-        app.add_exception_handler(AuthRegistryError, auth_registry_exception_handler)
-        app.include_router(router, prefix=self.prefix)
-        client = TestClient(app)
-
-        self.project_service.unserve_config = MagicMock(return_value=project_out)
-        res = client.patch(f'{self.prefix}/projects/{project.uuid}/unserve-config')
-        assert res.status_code == 200
-        deregister_fn.assert_called_once_with(project.uuid)
-
-    def test_load_config_invalid_config(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project_uuid = uuid.uuid4()
-        self.project_service.load_config = MagicMock(
-            side_effect=ProjectConfigValidationError('error')
-        )
-        res = self.client.patch(
-            f'{self.prefix}/projects/{project_uuid}/load-config',
-            json=jsonable_encoder(config_in),
-        )
-        assert res.status_code == 400
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_config_validation_error',
-                param=None,
-            ).error
-        )
-
-    # -- /projects/{project_uuid}/routes/{route_name}/groups -----------------
-
-    def test_add_groups_to_project_route_success(self):
-        project_uuid = uuid.uuid4()
-        route_name = 'route-A'
-        project_out = db_mock.get_sample_project_out(
-            uuid=project_uuid, name='my-project'
-        )
-        self.project_service.get_by_uuid = MagicMock(return_value=project_out)
-        groups = [db_mock.get_sample_group(), db_mock.get_sample_group()]
-        groups_uuid = [uuid.UUID(str(g.uuid)) for g in groups]
-        groups_route_in = db_mock.get_sample_route_groups_in(groups=groups_uuid)
-        route_groups_out = db_mock.get_sample_route_groups_out(
-            route_name=route_name,
-            project_name='my-project',
-            groups=[GroupOut.from_group(g) for g in groups],
-        )
-        self.group_service.add_groups_to_project_route = MagicMock(
-            return_value=route_groups_out
-        )
-        res = self.client.patch(
-            f'{self.prefix}/projects/{project_uuid}/routes/{route_name}/groups?include_groups=True',
-            json=jsonable_encoder(groups_route_in),
+            f'{self.prefix}/projects/{pid}/configs/{cid}/cancel-approval'
         )
         assert res.status_code == 200
-        assert res.json() == jsonable_encoder(route_groups_out)
-        self.group_service.add_groups_to_project_route.assert_called_once_with(
-            project_uuid, 'my-project', route_name, groups_route_in, True
-        )
+        self.project_service.cancel_approval.assert_called_once_with(pid, cid)
 
-    def test_add_groups_to_project_route_success_no_group(self):
-        project_uuid = uuid.uuid4()
-        route_name = 'route-A'
-        project_out = db_mock.get_sample_project_out(
-            uuid=project_uuid, name='my-project'
+    def test_serve_config_registers_served_routes(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        served = db_mock.get_sample_config_slot_out(
+            uuid=cid, slot=Slot.A, config_file=_VALID, config_status=ConfigStatus.SERVED
         )
-        self.project_service.get_by_uuid = MagicMock(return_value=project_out)
-        groups_uuid = [uuid.uuid4() for _ in range(3)]
-        groups_route_in = db_mock.get_sample_route_groups_in(groups=groups_uuid)
-        route_groups_out = db_mock.get_sample_route_groups_out(
-            route_name=route_name,
-            project_name='my-project',
-            groups=None,
+        other = db_mock.get_sample_config_slot_out(uuid=uuid.uuid4(), slot=Slot.B)
+        out = db_mock.get_sample_project_out(
+            uuid=pid, served_config_uuid=cid, configs=[served, other]
         )
-        self.group_service.add_groups_to_project_route = MagicMock(
-            return_value=route_groups_out
-        )
-        res = self.client.patch(
-            f'{self.prefix}/projects/{project_uuid}/routes/{route_name}/groups?include_groups=False',
-            json=jsonable_encoder(groups_route_in),
-        )
+        self.project_service.serve_config = MagicMock(return_value=out)
+        res = self.client.patch(f'{self.prefix}/projects/{pid}/configs/{cid}/serve')
         assert res.status_code == 200
-        assert res.json() == jsonable_encoder(route_groups_out)
+        self.project_service.serve_config.assert_called_once_with(pid, cid)
+        self.deregister.assert_awaited_once_with(pid)
+        self.register.assert_awaited_once_with(pid, out.name, _VALID)
 
-    def test_get_associable_groups_for_project_route(self):
-        project_uuid = uuid.uuid4()
-        route_name = 'route-A'
-        project_out = db_mock.get_sample_project_out(
-            uuid=project_uuid, name='my-project'
+    def test_unserve_config_deregisters(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.unserve_config = MagicMock(
+            return_value=db_mock.get_sample_project_out(uuid=pid)
         )
-        self.project_service.get_by_uuid = MagicMock(return_value=project_out)
-        groups_out = [
-            GroupFullOut.from_group(
-                db_mock.get_sample_group_plain(uuid=uuid.uuid4(), name='g1')
-            ),
-            GroupFullOut.from_group(
-                db_mock.get_sample_group_plain(uuid=uuid.uuid4(), name='g2')
-            ),
-        ]
-        self.group_service.get_associable_groups_for_project_route = MagicMock(
-            return_value=groups_out
-        )
-        res = self.client.get(
-            f'{self.prefix}/projects/{project_uuid}/routes/{route_name}/associable-groups'
-        )
+        res = self.client.patch(f'{self.prefix}/projects/{pid}/configs/{cid}/unserve')
         assert res.status_code == 200
-        assert res.json() == jsonable_encoder(groups_out)
-        self.group_service.get_associable_groups_for_project_route.assert_called_once_with(
-            'my-project', route_name, False, False
-        )
+        self.project_service.unserve_config.assert_called_once_with(pid, cid)
+        self.deregister.assert_awaited_once_with(pid)
 
-    def test_generate_config_ok(self):
-        project_uuid = uuid.uuid4()
-        gen_in = GenerateConfigIn(description='Create a simple OpenAI route')
-        expected_yaml = 'chat_models:\n  - model_id: gpt4o\n    model: openai/gpt-4o\n'
-        project_out = db_mock.get_sample_project_out(uuid=project_uuid)
-        self.project_service.get_by_uuid = MagicMock(return_value=project_out)
-        self.config_generator_service.generate_config = AsyncMock(
-            return_value=expected_yaml
-        )
-        res = self.client.post(
-            f'{self.prefix}/projects/{project_uuid}/generate-config',
-            json=jsonable_encoder(gen_in),
-        )
-        assert res.status_code == 200
-        assert res.json()['configFile'] == expected_yaml
-        self.config_generator_service.generate_config.assert_called_once_with(
-            gen_in.description, None
-        )
-
-    def test_generate_config_passes_draft_as_context(self):
-        project_uuid = uuid.uuid4()
-        draft = 'chat_models:\n  - model_id: existing\n'
-        gen_in = GenerateConfigIn(description='Add rate limiting')
-        project_out = db_mock.get_sample_project_out(
-            uuid=project_uuid, draft_config_file=draft
-        )
-        self.project_service.get_by_uuid = MagicMock(return_value=project_out)
-        self.config_generator_service.generate_config = AsyncMock(return_value=draft)
-        self.client.post(
-            f'{self.prefix}/projects/{project_uuid}/generate-config',
-            json=jsonable_encoder(gen_in),
-        )
-        self.config_generator_service.generate_config.assert_called_once_with(
-            gen_in.description, draft
-        )
-
-    def test_generate_config_project_not_found(self):
-        project_uuid = uuid.uuid4()
-        gen_in = GenerateConfigIn(description='desc')
-        self.project_service.get_by_uuid = MagicMock(
-            side_effect=ProjectNotFoundError('not found')
-        )
-        res = self.client.post(
-            f'{self.prefix}/projects/{project_uuid}/generate-config',
-            json=jsonable_encoder(gen_in),
-        )
-        assert res.status_code == 404
-
-    def test_generate_config_validation_failure(self):
-        project_uuid = uuid.uuid4()
-        gen_in = GenerateConfigIn(description='desc')
-        self.project_service.get_by_uuid = MagicMock(
-            return_value=db_mock.get_sample_project_out(uuid=project_uuid)
+    def test_generate_config(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.get_config = MagicMock(
+            return_value=db_mock.get_sample_config_slot_out(uuid=cid, config_file='# x')
         )
         self.config_generator_service.generate_config = AsyncMock(
-            side_effect=ProjectConfigValidationError('failed after retries')
+            return_value='# generated'
         )
         res = self.client.post(
-            f'{self.prefix}/projects/{project_uuid}/generate-config',
-            json=jsonable_encoder(gen_in),
+            f'{self.prefix}/projects/{pid}/configs/{cid}/generate-config',
+            json={'description': 'make it'},
         )
-        assert res.status_code == 400
-
-    def test_generate_config_internal_error(self):
-        project_uuid = uuid.uuid4()
-        gen_in = GenerateConfigIn(description='desc')
-        self.project_service.get_by_uuid = MagicMock(
-            return_value=db_mock.get_sample_project_out(uuid=project_uuid)
-        )
-        self.config_generator_service.generate_config = AsyncMock(
-            side_effect=ProjectInternalError('llm down')
-        )
-        res = self.client.post(
-            f'{self.prefix}/projects/{project_uuid}/generate-config',
-            json=jsonable_encoder(gen_in),
-        )
-        assert res.status_code == 500
-
-    # --- DELETE /projects/{project_uuid} ---
-
-    def test_delete_project_ok(self):
-        project = db_mock.get_sample_project()
-        project_out = ProjectOut.from_project(project)
-        self.project_service.delete_project = MagicMock(return_value=project_out)
-        res = self.client.delete(f'{self.prefix}/projects/{project.uuid}')
         assert res.status_code == 200
-        assert res.json() == jsonable_encoder(project_out)
-        self.project_service.delete_project.assert_called_once_with(project.uuid)
+        assert res.json()['configFile'] == '# generated'
+        self.project_service.get_config.assert_called_once_with(pid, cid)
 
-    def test_delete_project_not_found(self):
-        unknown_uuid = uuid.uuid4()
-        self.project_service.delete_project = MagicMock(
-            side_effect=ProjectNotFoundError('error')
-        )
-        res = self.client.delete(f'{self.prefix}/projects/{unknown_uuid}')
-        assert res.status_code == 404
-        assert (
-            res.json()['error']
-            == ErrorOut(
-                'error',
-                'auth_registry_error',
-                code='project_not_found',
-                param=None,
-            ).error
-        )
-
-    def test_delete_project_dev_does_not_call_deregister(self):
-        project = db_mock.get_sample_project(config_file=None)
-        project_out = ProjectOut.from_project(project)
-        deregister_fn = AsyncMock()
-        router = ProjectRoute.get_project_router(
-            self.project_service,
-            self.group_service,
-            deregister_project_routes=deregister_fn,
-        )
-        app = FastAPI(title='AI Gateway', debug=True)
-        app.add_exception_handler(AuthRegistryError, auth_registry_exception_handler)
-        app.include_router(router, prefix=self.prefix)
-        client = TestClient(app)
-        self.project_service.delete_project = MagicMock(return_value=project_out)
-        res = client.delete(f'{self.prefix}/projects/{project.uuid}')
+    def test_delete_project_deregisters_when_served(self):
+        pid = uuid.uuid4()
+        out = db_mock.get_sample_project_out(uuid=pid, served_config_uuid=uuid.uuid4())
+        self.project_service.delete_project = MagicMock(return_value=out)
+        res = self.client.delete(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
-        deregister_fn.assert_not_called()
+        self.project_service.delete_project.assert_called_once_with(pid)
+        self.deregister.assert_awaited_once_with(pid)
 
-    def test_delete_project_prod_calls_deregister(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(config_file=config_in.config_file)
-        project_out = ProjectOut.from_project(project)
-        deregister_fn = AsyncMock()
-        router = ProjectRoute.get_project_router(
-            self.project_service,
-            self.group_service,
-            deregister_project_routes=deregister_fn,
-        )
-        app = FastAPI(title='AI Gateway', debug=True)
-        app.add_exception_handler(AuthRegistryError, auth_registry_exception_handler)
-        app.include_router(router, prefix=self.prefix)
-        client = TestClient(app)
-        self.project_service.delete_project = MagicMock(return_value=project_out)
-        res = client.delete(f'{self.prefix}/projects/{project.uuid}')
+    def test_delete_project_no_deregister_when_dev(self):
+        pid = uuid.uuid4()
+        out = db_mock.get_sample_project_out(uuid=pid, served_config_uuid=None)
+        self.project_service.delete_project = MagicMock(return_value=out)
+        res = self.client.delete(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
-        deregister_fn.assert_called_once_with(project.uuid)
+        self.deregister.assert_not_awaited()

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock
 import uuid
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from tests.common import db_mock
 from tests.common.db_integration import DatabaseIntegration
@@ -47,12 +49,8 @@ class ProjectServiceTest(DatabaseIntegration):
     def test_create_project_already_exists(self):
         # IntegrityError -> ProjectAlreadyExistsError mapping is a unit concern,
         # tested with a mocked DAO to stay independent of create_all metadata.
-        from unittest.mock import MagicMock
-
-        from sqlalchemy.exc import IntegrityError
-
         svc = ProjectService(MagicMock(), MagicMock())
-        svc.project_dao.insert = MagicMock(
+        svc.project_dao.insert_with_configs = MagicMock(
             side_effect=IntegrityError(None, None, BaseException('uq_project_NAME'))
         )
         with pytest.raises(ProjectAlreadyExistsError):
@@ -66,7 +64,9 @@ class ProjectServiceTest(DatabaseIntegration):
 
     def test_update_config_ok(self):
         out, a, _ = self._create()
-        res = self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        res = self.svc.update_config(
+            out.uuid, a, ProjectConfigFileIn(config_file=_VALID)
+        )
         ca = next(c for c in res.configs if c.uuid == a)
         assert ca.config_file == _VALID
         assert ca.config_status == ConfigStatus.DRAFT

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -1,550 +1,196 @@
-import unittest
-from unittest.mock import MagicMock
 import uuid
 
 import pytest
-from sqlalchemy.exc import IntegrityError
 
 from tests.common import db_mock
+from tests.common.db_integration import DatabaseIntegration
 
+from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
-from radicalbit_ai_gateway.models.project_dto import ProjectFilter, ProjectOut
+from radicalbit_ai_gateway.models.project_dto import (
+    ProjectConfigFileIn,
+    ProjectFilter,
+    ProjectIn,
+)
 from radicalbit_ai_gateway.models.project_status import ProjectStatus
 from radicalbit_ai_gateway.services.project_service import ProjectService
 from radicalbit_ai_gateway.utils.exceptions import (
     ProjectAlreadyExistsError,
     ProjectConfigValidationError,
-    ProjectInternalError,
     ProjectNotFoundError,
 )
 
+_VALID = db_mock.VALID_CONFIG_YAML
 
-class ProjectServiceTest(unittest.TestCase):
+
+class ProjectServiceTest(DatabaseIntegration):
     @classmethod
     def setUpClass(cls):
-        cls.project_dao: ProjectDAO = MagicMock(spec_set=ProjectDAO)
-        cls.project_service = ProjectService(project_dao=cls.project_dao)
-        cls.mocks = [cls.project_dao]
+        super().setUpClass()
+        cls.svc = ProjectService(ProjectDAO(cls.db), ProjectConfigDAO(cls.db))
 
-    def setUp(self):
-        for mock in self.mocks:
-            mock.reset_mock()
+    def _create(self, name='proj'):
+        out = self.svc.create_project(ProjectIn(name=name))
+        return out, out.configs[0].uuid, out.configs[1].uuid
 
-    def test_create_project_ok(self):
-        project = db_mock.get_sample_project()
-        self.project_dao.insert = MagicMock(return_value=project)
-        project_in = db_mock.get_sample_project_in()
-        result = self.project_service.create_project(project_in)
-        self.project_dao.insert.assert_called_once()
-        assert result == ProjectOut.from_project(project)
+    # --- create ---
+
+    def test_create_project_seeds_two_draft_slots(self):
+        out, a, b = self._create()
+        assert len(out.configs) == 2
+        assert [c.slot for c in out.configs] == ['A', 'B']
+        assert all(c.config_status == ConfigStatus.DRAFT for c in out.configs)
+        assert out.project_status == ProjectStatus.DEV
+        assert out.served_config_uuid is None
 
     def test_create_project_already_exists(self):
-        self.project_dao.insert = MagicMock(
+        # IntegrityError -> ProjectAlreadyExistsError mapping is a unit concern,
+        # tested with a mocked DAO to stay independent of create_all metadata.
+        from unittest.mock import MagicMock
+
+        from sqlalchemy.exc import IntegrityError
+
+        svc = ProjectService(MagicMock(), MagicMock())
+        svc.project_dao.insert = MagicMock(
             side_effect=IntegrityError(None, None, BaseException('uq_project_NAME'))
         )
-        project_in = db_mock.get_sample_project_in()
         with pytest.raises(ProjectAlreadyExistsError):
-            self.project_service.create_project(project_in)
-
-    def test_create_project_internal_error(self):
-        self.project_dao.insert = MagicMock(
-            side_effect=IntegrityError(
-                None, None, BaseException('some_other_constraint')
-            )
-        )
-        project_in = db_mock.get_sample_project_in()
-        with pytest.raises(ProjectInternalError):
-            self.project_service.create_project(project_in)
-
-    def test_get_by_uuid_ok(self):
-        project = db_mock.get_sample_project()
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        result = self.project_service.get_by_uuid(project.uuid)
-        self.project_dao.get_by_uuid.assert_called_once_with(project.uuid)
-        assert result == ProjectOut.from_project(project)
+            svc.create_project(ProjectIn(name='dup'))
 
     def test_get_by_uuid_not_found(self):
-        self.project_dao.get_by_uuid = MagicMock(return_value=None)
         with pytest.raises(ProjectNotFoundError):
-            self.project_service.get_by_uuid(uuid.uuid4())
+            self.svc.get_by_uuid(uuid.uuid4())
 
-    def test_get_all(self):
-        projects = [
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='one'),
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='two'),
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='three'),
-        ]
-        self.project_dao.get_all = MagicMock(return_value=projects)
-        result = self.project_service.get_all()
-        assert len(result) == 3
-        assert result == [ProjectOut.from_project(p) for p in projects]
+    # --- update ---
 
-    def test_get_all_empty(self):
-        self.project_dao.get_all = MagicMock(return_value=[])
-        result = self.project_service.get_all()
-        assert result == []
+    def test_update_config_ok(self):
+        out, a, _ = self._create()
+        res = self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        ca = next(c for c in res.configs if c.uuid == a)
+        assert ca.config_file == _VALID
+        assert ca.config_status == ConfigStatus.DRAFT
 
-    def test_load_config_ok(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        self.project_dao.update_draft_config_file = MagicMock(return_value=1)
-        result = self.project_service.load_config(project.uuid, config_in)
-        self.project_dao.update_draft_config_file.assert_called_once()
-        assert result.draft_config_file == config_in.config_file
-        assert result.config_status == ConfigStatus.DRAFT
+    def test_update_config_invalid_yaml(self):
+        out, a, _ = self._create()
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.update_config(
+                out.uuid, a, ProjectConfigFileIn(config_file='::not yaml::')
+            )
 
-    def test_load_config_project_not_found(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        self.project_dao.get_by_uuid = MagicMock(return_value=None)
+    def test_update_config_served_is_read_only(self):
+        out, a, _ = self._create()
+        self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        self.svc.approve_config(out.uuid, a)
+        self.svc.serve_config(out.uuid, a)
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+
+    def test_update_config_wrong_project(self):
+        out, a, _ = self._create()
         with pytest.raises(ProjectNotFoundError):
-            self.project_service.load_config(uuid.uuid4(), config_in)
+            self.svc.update_config(
+                uuid.uuid4(), a, ProjectConfigFileIn(config_file=_VALID)
+            )
 
-    def test_load_config_invalid_yaml(self):
-        config_in = db_mock.get_sample_project_config_file_in(
-            config_file='{{invalid yaml'
+    # --- approve / cancel ---
+
+    def test_approve_then_cancel(self):
+        out, a, _ = self._create()
+        self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        res = self.svc.approve_config(out.uuid, a)
+        assert next(c for c in res.configs if c.uuid == a).config_status == (
+            ConfigStatus.READY_TO_SERVE
         )
+        res = self.svc.cancel_approval(out.uuid, a)
+        assert next(c for c in res.configs if c.uuid == a).config_status == (
+            ConfigStatus.DRAFT
+        )
+
+    def test_cancel_when_not_ready_raises(self):
+        out, a, _ = self._create()
         with pytest.raises(ProjectConfigValidationError):
-            self.project_service.load_config(uuid.uuid4(), config_in)
+            self.svc.cancel_approval(out.uuid, a)
 
-    def test_load_config_invalid_gateway_config(self):
-        config_in = db_mock.get_sample_project_config_file_in(
-            config_file='some_key: some_value\n'
-        )
+    # --- serve / swap / unserve ---
+
+    def test_serve_requires_approval(self):
+        out, a, _ = self._create()
+        self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
         with pytest.raises(ProjectConfigValidationError):
-            self.project_service.load_config(uuid.uuid4(), config_in)
+            self.svc.serve_config(out.uuid, a)
 
-    def test_load_config_rejects_literal_secrets(self):
-        yaml_with_literal_key = """\
-chat_models:
-  - model_id: mock-chat
-    model: mock/gateway
-    credentials:
-      api_key: sk-super-secret-key
-    params:
-      latency_ms: 150
-      response_text: "mock response"
-routes:
-  test-route:
-    chat_models:
-      - mock-chat
-"""
-        config_in = db_mock.get_sample_project_config_file_in(
-            config_file=yaml_with_literal_key
+    def test_serve_ok(self):
+        out, a, _ = self._create()
+        self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        self.svc.approve_config(out.uuid, a)
+        res = self.svc.serve_config(out.uuid, a)
+        assert res.project_status == ProjectStatus.PROD
+        assert res.served_config_uuid == a
+        assert next(c for c in res.configs if c.uuid == a).config_status == (
+            ConfigStatus.SERVED
         )
-        with pytest.raises(ProjectConfigValidationError, match='literal secrets'):
-            self.project_service.load_config(uuid.uuid4(), config_in)
 
-    def test_load_config_accepts_secret_refs(self):
-        yaml_with_secret_ref = """\
-chat_models:
-  - model_id: mock-chat
-    model: mock/gateway
-    credentials:
-      api_key: !secret OPENAI_API_KEY
-    params:
-      latency_ms: 150
-      response_text: "mock response"
-routes:
-  test-route:
-    chat_models:
-      - mock-chat
-"""
-        config_in = db_mock.get_sample_project_config_file_in(
-            config_file=yaml_with_secret_ref
-        )
-        project = db_mock.get_sample_project()
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        self.project_dao.update_draft_config_file = MagicMock(return_value=1)
-        self.project_service.load_config(project.uuid, config_in)
-        saved_content = self.project_dao.update_draft_config_file.call_args[0][1]
-        assert '!secret OPENAI_API_KEY' in saved_content
+    def test_serve_swaps_displaced_to_draft(self):
+        out, a, b = self._create()
+        for c in (a, b):
+            self.svc.update_config(out.uuid, c, ProjectConfigFileIn(config_file=_VALID))
+            self.svc.approve_config(out.uuid, c)
+        self.svc.serve_config(out.uuid, a)
+        res = self.svc.serve_config(out.uuid, b)
+        st = {c.uuid: c.config_status for c in res.configs}
+        assert st[b] == ConfigStatus.SERVED
+        assert st[a] == ConfigStatus.DRAFT
+        assert res.served_config_uuid == b
 
-    # --- cancel_approval ---
+    def test_unserve_ok(self):
+        out, a, _ = self._create()
+        self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        self.svc.approve_config(out.uuid, a)
+        self.svc.serve_config(out.uuid, a)
+        res = self.svc.unserve_config(out.uuid, a)
+        assert res.project_status == ProjectStatus.DEV
+        assert res.served_config_uuid is None
 
-    def test_cancel_approval_ok(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.READY_TO_SERVE,
-        )
-        cancelled_project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(
-            side_effect=[project, cancelled_project]
-        )
-        self.project_dao.set_config_status = MagicMock(return_value=1)
-        result = self.project_service.cancel_approval(project.uuid)
-        self.project_dao.set_config_status.assert_called_once_with(
-            project.uuid, ConfigStatus.DRAFT
-        )
-        assert result.config_status == ConfigStatus.DRAFT
+    def test_unserve_when_not_served_raises(self):
+        out, a, _ = self._create()
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.unserve_config(out.uuid, a)
 
-    def test_cancel_approval_project_not_found(self):
-        self.project_dao.get_by_uuid = MagicMock(return_value=None)
+    # --- delete ---
+
+    def test_delete_project(self):
+        out, _, _ = self._create()
+        deleted = self.svc.delete_project(out.uuid)
+        assert deleted.uuid == out.uuid
         with pytest.raises(ProjectNotFoundError):
-            self.project_service.cancel_approval(uuid.uuid4())
+            self.svc.get_by_uuid(out.uuid)
 
-    def test_cancel_approval_wrong_status_draft(self):
-        project = db_mock.get_sample_project(
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.cancel_approval(project.uuid)
+    # --- get_config ---
 
-    def test_cancel_approval_wrong_status_served(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            config_file=config_in.config_file,
-            config_status=ConfigStatus.SERVED,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.cancel_approval(project.uuid)
+    def test_get_config(self):
+        out, a, _ = self._create()
+        slot = self.svc.get_config(out.uuid, a)
+        assert slot.uuid == a and slot.slot == 'A'
 
-    # --- approve_config ---
-
-    def test_approve_config_ok(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.DRAFT,
-        )
-        approved_project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.READY_TO_SERVE,
-        )
-        self.project_dao.get_by_uuid = MagicMock(
-            side_effect=[project, approved_project]
-        )
-        self.project_dao.set_config_status = MagicMock(return_value=1)
-        result = self.project_service.approve_config(project.uuid)
-        self.project_dao.set_config_status.assert_called_once_with(
-            project.uuid, ConfigStatus.READY_TO_SERVE
-        )
-        assert result.config_status == ConfigStatus.READY_TO_SERVE
-
-    def test_approve_config_project_not_found(self):
-        self.project_dao.get_by_uuid = MagicMock(return_value=None)
+    def test_get_config_wrong_project(self):
+        out, a, _ = self._create()
         with pytest.raises(ProjectNotFoundError):
-            self.project_service.approve_config(uuid.uuid4())
+            self.svc.get_config(uuid.uuid4(), a)
 
-    def test_approve_config_no_draft(self):
-        project = db_mock.get_sample_project(
-            config_status=ConfigStatus.READY_TO_SERVE, draft_config_file=None
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.approve_config(project.uuid)
+    # --- listing / filters ---
 
-    def test_approve_config_wrong_status(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.READY_TO_SERVE,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.approve_config(project.uuid)
+    def test_get_all_and_filters(self):
+        served, a, _ = self._create(name='served')
+        self.svc.update_config(served.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        self.svc.approve_config(served.uuid, a)
+        self.svc.serve_config(served.uuid, a)
+        self._create(name='dev')
 
-    def test_approve_config_invalid_yaml(self):
-        project = db_mock.get_sample_project(
-            draft_config_file='{{invalid yaml',
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.approve_config(project.uuid)
-
-    def test_approve_config_invalid_gateway_config(self):
-        project = db_mock.get_sample_project(
-            draft_config_file='some_key: some_value\n',
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.approve_config(project.uuid)
-
-    def test_approve_config_rejects_literal_secrets(self):
-        yaml_with_literal_key = """\
-chat_models:
-  - model_id: mock-chat
-    model: mock/gateway
-    credentials:
-      api_key: sk-super-secret-key
-    params:
-      latency_ms: 150
-      response_text: "mock response"
-routes:
-  test-route:
-    chat_models:
-      - mock-chat
-"""
-        project = db_mock.get_sample_project(
-            draft_config_file=yaml_with_literal_key,
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError, match='literal secrets'):
-            self.project_service.approve_config(project.uuid)
-
-    # --- serve_config ---
-
-    def test_serve_config_ok(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.READY_TO_SERVE,
-        )
-        updated_project = db_mock.get_sample_project(
-            draft_config_file=None,
-            config_file=config_in.config_file,
-            config_status=ConfigStatus.SERVED,
-        )
-        self.project_dao.get_by_uuid = MagicMock(side_effect=[project, updated_project])
-        self.project_dao.promote_draft_to_config = MagicMock(return_value=1)
-        result = self.project_service.serve_config(project.uuid)
-        self.project_dao.promote_draft_to_config.assert_called_once_with(
-            project.uuid, config_in.config_file
-        )
-        assert result.config_file == config_in.config_file
-        assert result.draft_config_file is None
-        assert result.config_status == ConfigStatus.SERVED
-        assert result.project_status == ProjectStatus.PROD
-
-    def test_serve_config_project_not_found(self):
-        self.project_dao.get_by_uuid = MagicMock(return_value=None)
-        with pytest.raises(ProjectNotFoundError):
-            self.project_service.serve_config(uuid.uuid4())
-
-    def test_serve_config_requires_approved_status(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.serve_config(project.uuid)
-
-    def test_serve_config_promote_returns_zero(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.READY_TO_SERVE,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        self.project_dao.promote_draft_to_config = MagicMock(return_value=0)
-        with pytest.raises(ProjectInternalError):
-            self.project_service.serve_config(project.uuid)
-
-    # --- unserve_config ---
-
-    def test_unserve_config_ok_restores_draft(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            config_file=config_in.config_file,
-            draft_config_file=None,
-            config_status=ConfigStatus.SERVED,
-        )
-        unserved_project = db_mock.get_sample_project(
-            config_file=None,
-            draft_config_file=config_in.config_file,
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(
-            side_effect=[project, unserved_project]
-        )
-        self.project_dao.unserve_config = MagicMock(return_value=1)
-        result = self.project_service.unserve_config(project.uuid)
-        self.project_dao.unserve_config.assert_called_once_with(project.uuid, True)
-        assert result.config_file is None
-        assert result.draft_config_file == config_in.config_file
-        assert result.config_status == ConfigStatus.DRAFT
-        assert result.project_status == ProjectStatus.DEV
-
-    def test_unserve_config_ok_keeps_existing_draft(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            config_file=config_in.config_file,
-            draft_config_file='existing-draft',
-            config_status=ConfigStatus.DRAFT,
-        )
-        unserved_project = db_mock.get_sample_project(
-            config_file=None,
-            draft_config_file='existing-draft',
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(
-            side_effect=[project, unserved_project]
-        )
-        self.project_dao.unserve_config = MagicMock(return_value=1)
-        result = self.project_service.unserve_config(project.uuid)
-        self.project_dao.unserve_config.assert_called_once_with(project.uuid, False)
-        assert result.draft_config_file == 'existing-draft'
-
-    def test_unserve_config_project_not_found(self):
-        self.project_dao.get_by_uuid = MagicMock(return_value=None)
-        with pytest.raises(ProjectNotFoundError):
-            self.project_service.unserve_config(uuid.uuid4())
-
-    def test_unserve_config_not_served(self):
-        project = db_mock.get_sample_project(
-            config_file=None,
-            config_status=ConfigStatus.DRAFT,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        with pytest.raises(ProjectConfigValidationError):
-            self.project_service.unserve_config(project.uuid)
-
-    # --- project_status and config_status in responses ---
-
-    def test_new_project_has_draft_status_and_dev(self):
-        project = db_mock.get_sample_project(config_status=ConfigStatus.DRAFT)
-        self.project_dao.insert = MagicMock(return_value=project)
-        result = self.project_service.create_project(db_mock.get_sample_project_in())
-        assert result.config_status == ConfigStatus.DRAFT
-        assert result.project_status == ProjectStatus.DEV
-
-    def test_served_project_has_prod_status(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            config_file=config_in.config_file,
-            config_status=ConfigStatus.SERVED,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        result = self.project_service.get_by_uuid(project.uuid)
-        assert result.project_status == ProjectStatus.PROD
-        assert result.config_status == ConfigStatus.SERVED
-
-    # --- get_all_active ---
-
-    def test_get_all_active_returns_only_active_projects(self):
-        active = db_mock.get_sample_project(
-            config_file='some-yaml',
-            config_status=ConfigStatus.SERVED,
-        )
-        self.project_dao.get_all_with_config = MagicMock(return_value=[active])
-        result = self.project_service.get_all_active()
-        self.project_dao.get_all_with_config.assert_called_once()
-        assert len(result) == 1
-        assert result[0].config_file == 'some-yaml'
-        assert result[0].name == active.name
-
-    def test_get_all_active_empty(self):
-        self.project_dao.get_all_with_config = MagicMock(return_value=[])
-        result = self.project_service.get_all_active()
-        assert result == []
-
-    # --- delete_project ---
-
-    def test_delete_project_ok_dev_state(self):
-        project = db_mock.get_sample_project(
-            config_file=None, config_status=ConfigStatus.DRAFT
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        self.project_dao.soft_delete = MagicMock(return_value=1)
-        result = self.project_service.delete_project(project.uuid)
-        self.project_dao.soft_delete.assert_called_once_with(project.uuid)
-        self.project_dao.unserve_config.assert_not_called()
-        assert result == ProjectOut.from_project(project)
-
-    def test_delete_project_ok_prod_state_restores_draft(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            config_file=config_in.config_file,
-            draft_config_file=None,
-            config_status=ConfigStatus.SERVED,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        self.project_dao.unserve_config = MagicMock(return_value=1)
-        self.project_dao.soft_delete = MagicMock(return_value=1)
-        result = self.project_service.delete_project(project.uuid)
-        self.project_dao.unserve_config.assert_called_once_with(project.uuid, True)
-        self.project_dao.soft_delete.assert_called_once_with(project.uuid)
-        assert result.config_file == config_in.config_file
-
-    def test_delete_project_ok_prod_state_keeps_existing_draft(self):
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            config_file=config_in.config_file,
-            draft_config_file='existing-draft',
-            config_status=ConfigStatus.SERVED,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        self.project_dao.unserve_config = MagicMock(return_value=1)
-        self.project_dao.soft_delete = MagicMock(return_value=1)
-        self.project_service.delete_project(project.uuid)
-        self.project_dao.unserve_config.assert_called_once_with(project.uuid, False)
-
-    def test_delete_project_not_found(self):
-        self.project_dao.get_by_uuid = MagicMock(return_value=None)
-        with pytest.raises(ProjectNotFoundError):
-            self.project_service.delete_project(uuid.uuid4())
-
-    def test_delete_project_returns_pre_deletion_state(self):
-        # DTO must reflect state before deletion so route can call deregister_project_routes.
-        config_in = db_mock.get_sample_project_config_file_in()
-        project = db_mock.get_sample_project(
-            config_file=config_in.config_file,
-            config_status=ConfigStatus.SERVED,
-        )
-        self.project_dao.get_by_uuid = MagicMock(return_value=project)
-        self.project_dao.unserve_config = MagicMock(return_value=1)
-        self.project_dao.soft_delete = MagicMock(return_value=1)
-        result = self.project_service.delete_project(project.uuid)
-        assert result.config_file == config_in.config_file
-        assert result.project_status == ProjectStatus.PROD
-
-    # --- get_all_filtered ---
-
-    def test_get_all_filtered_delegates_to_dao(self):
-        projects = [
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='one'),
-        ]
-        self.project_dao.get_all_filtered = MagicMock(return_value=projects)
-        result = self.project_service.get_all_filtered(ProjectFilter.ACTIVE)
-        self.project_dao.get_all_filtered.assert_called_once_with(ProjectFilter.ACTIVE)
-        assert len(result) == 1
-        assert result == [ProjectOut.from_project(p) for p in projects]
-
-    def test_get_all_filtered_no_filter(self):
-        projects = [
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='a'),
-            db_mock.get_sample_project(uuid=uuid.uuid4(), name='b'),
-        ]
-        self.project_dao.get_all_filtered = MagicMock(return_value=projects)
-        result = self.project_service.get_all_filtered(None)
-        self.project_dao.get_all_filtered.assert_called_once_with(None)
-        assert len(result) == 2
-
-    def test_get_all_filtered_dev_delegates_to_dao(self):
-        projects = [
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='no-config', config_file=None
-            ),
-        ]
-        self.project_dao.get_all_filtered = MagicMock(return_value=projects)
-        result = self.project_service.get_all_filtered(ProjectFilter.DEV)
-        self.project_dao.get_all_filtered.assert_called_once_with(ProjectFilter.DEV)
-        assert len(result) == 1
-        assert result == [ProjectOut.from_project(p) for p in projects]
-
-    def test_get_all_filtered_prod_delegates_to_dao(self):
-        projects = [
-            db_mock.get_sample_project(
-                uuid=uuid.uuid4(), name='with-config', config_file='yaml'
-            ),
-        ]
-        self.project_dao.get_all_filtered = MagicMock(return_value=projects)
-        result = self.project_service.get_all_filtered(ProjectFilter.PROD)
-        self.project_dao.get_all_filtered.assert_called_once_with(ProjectFilter.PROD)
-        assert len(result) == 1
-        assert result == [ProjectOut.from_project(p) for p in projects]
+        assert len(self.svc.get_all()) == 2
+        prod = self.svc.get_all_filtered(ProjectFilter.PROD)
+        assert [p.uuid for p in prod] == [served.uuid]
+        dev = self.svc.get_all_filtered(ProjectFilter.DEV)
+        assert served.uuid not in [p.uuid for p in dev]
+        active = self.svc.get_all_active()
+        assert [p.uuid for p in active] == [served.uuid]


### PR DESCRIPTION
# PR Summary: feat/AG-778-two-config-model-for-project

Moves project configuration from a **single config on the `project` row** to **two permanent configurations per project (Slot A / Slot B)** in a dedicated `project_config` table. Each project always exposes exactly **2 configs**; at most **one is `SERVED`** at a time. Editing the live config is done by editing the *other* slot and serving it (atomic swap). **Breaking change** on `ProjectOut` and on all config-mutation endpoints (now scoped by `configUuid`) — requires a coordinated FE deploy.

Jira: [AG-778](https://radicalbit.atlassian.net/browse/AG-778)

---

## DTO Changes

### `ConfigSlotOut` (NEW)

One configuration slot. `ProjectOut.configs` always contains exactly 2 of these, ordered by `slot`.

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Config identity |
| `slot` | string | One of: `A`, `B` — deterministic tab ordering only |
| `configFile` | string \| null | YAML content |
| `configStatus` | string | One of: `DRAFT`, `READY_TO_SERVE`, `SERVED` |
| `updatedAt` | datetime | Last edited |

**Example:**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "slot": "A",
  "configFile": "chat_models:\n  - model_id: my-model\n    ...",
  "configStatus": "SERVED",
  "updatedAt": "2024-01-15T10:30:00Z"
}
```

---

### `ProjectOut` (MODIFIED)

**Changes:**
```diff
- config_file: string | null          (removed)
- draft_config_file: string | null    (removed)
- config_status: string               (removed)
+ served_config_uuid: string | null   (added — currently served config)
+ configs: ConfigSlotOut[]            (added — always 2, ordered by slot)
```

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Project identity |
| `name` | string | Project name |
| `description` | string \| null | Optional description |
| `projectStatus` | string | Derived: `PROD` if a `SERVED` config exists, else `DEV` |
| `servedConfigUuid` **NEW** | string \| null | UUID of the served config (null if none) |
| `configs` **NEW** | ConfigSlotOut[] | Always 2 elements, ordered by slot |
| `configFile` ~~REMOVED~~ | - | Was: served YAML |
| `draftConfigFile` ~~REMOVED~~ | - | Was: editable draft YAML |
| `configStatus` ~~REMOVED~~ | - | Was: per-project status |
| `createdAt` | datetime | Creation timestamp |
| `updatedAt` | datetime | Last update timestamp |

**Example response (one served + one draft):**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "name": "my-project",
  "description": "internal project only",
  "projectStatus": "PROD",
  "servedConfigUuid": "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
  "configs": [
    {
      "uuid": "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
      "slot": "A",
      "configFile": "chat_models:\n  - model_id: my-model\n    ...",
      "configStatus": "SERVED",
      "updatedAt": "2024-01-15T10:30:00Z"
    },
    {
      "uuid": "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
      "slot": "B",
      "configFile": "# Your YAML configuration will appear here\n# ...",
      "configStatus": "DRAFT",
      "updatedAt": "2024-01-15T10:30:00Z"
    }
  ],
  "createdAt": "2024-01-15T10:30:00Z",
  "updatedAt": "2024-01-15T10:30:00Z"
}
```

**Used by:** `POST /projects`, `GET /projects`, `GET /projects/{projectUuid}`, all config-level mutations, `DELETE /projects/{projectUuid}`.

---

## Affected Endpoints

All config-level mutations are now **scoped by `configUuid`** and return the full `ProjectOut` (so the FE updates both slot tabs + status badge from one response).

### Endpoint path changes

```diff
- PATCH /projects/{projectUuid}/load-config
+ PATCH /projects/{projectUuid}/configs/{configUuid}

- PATCH /projects/{projectUuid}/approve-config
+ PATCH /projects/{projectUuid}/configs/{configUuid}/approve

- PATCH /projects/{projectUuid}/cancel-approval
+ PATCH /projects/{projectUuid}/configs/{configUuid}/cancel-approval

- PATCH /projects/{projectUuid}/serve-config
+ PATCH /projects/{projectUuid}/configs/{configUuid}/serve

- PATCH /projects/{projectUuid}/unserve-config
+ PATCH /projects/{projectUuid}/configs/{configUuid}/unserve

- POST  /projects/{projectUuid}/generate-config
+ POST  /projects/{projectUuid}/configs/{configUuid}/generate-config
```

### `POST /projects`

Creates the project **and seeds both slots** (A and B, both `DRAFT`, with the commented template) in a single transaction.

**Example request:**
```
POST /public/api/v1/projects
{"name": "my-project"}
```
Returns `ProjectOut` with `configs` length 2, `projectStatus: DEV`, `servedConfigUuid: null`.

### `PATCH /projects/{projectUuid}/configs/{configUuid}`

Update the slot's YAML (validated on save) and reset it to `DRAFT`.

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `projectUuid` | string | yes | Project UUID (path) |
| `configUuid` | string | yes | Config UUID (path) |
| `configFile` | string | yes | YAML content (body) |

**Rejected with `400`** if the config is `SERVED` (served slot is read-only).

### `PATCH /projects/{projectUuid}/configs/{configUuid}/approve`
`DRAFT` → `READY_TO_SERVE` (re-validates the YAML).

### `PATCH /projects/{projectUuid}/configs/{configUuid}/cancel-approval`
`READY_TO_SERVE` → `DRAFT`.

### `PATCH /projects/{projectUuid}/configs/{configUuid}/serve`
**Atomic swap**: if the sibling config is `SERVED`, demote it to `DRAFT` and serve this one. Guarantees a single `SERVED` config per project (enforced by a partial unique index). Requires the config to be `READY_TO_SERVE`. At runtime, deregisters the previously served routes before registering the newly served config's routes.

### `PATCH /projects/{projectUuid}/configs/{configUuid}/unserve`
Unserve the served config (back to `DRAFT`), clears `servedConfigUuid`, deregisters its routes.

### `POST /projects/{projectUuid}/configs/{configUuid}/generate-config`
AI generation scoped to this config. **Rejected with `400`** if the config is `SERVED` (a generated result could not be saved back to a read-only slot).

**Example request:**
```
POST /public/api/v1/projects/550e8400-e29b-41d4-a716-446655440000/configs/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa/generate-config
{"description": "a route that answers customer support questions"}
```

### `DELETE /projects/{projectUuid}`
Soft-deletes the project + both configs (unserving first if a config was served) and deregisters its routes. Returns `ProjectOut`.

### Unchanged (route-level) — unaffected by this PR
`PATCH /projects/{projectUuid}/routes/{routeName}/groups`, `GET /projects/{projectUuid}/routes/{routeName}/associable-groups` (these still resolve `routeName` against the served config).

---

## Other Changes

- **DB schema** — new `project_config` table (`uuid`, `project_uuid` FK, `slot` enum, `config_file`, `config_status` enum, timestamps + `deleted_at`) with `UNIQUE(project_uuid, slot)` and a **partial unique index** ensuring at most one `SERVED` config per project. `project` table drops `config_file`/`draft_config_file`/`config_status`, adds `served_config_uuid` (nullable FK), keeps `first_served_at`.
- **`models/config_slot.py`** (NEW) — `Slot` enum (`A`/`B`).
- **`db/dao/project_config_dao.py`** (NEW) — `ProjectConfigDAO` with `get_by_uuid`, `list_by_project`, `get_served_by_project`, `update_config_file`, `set_status`, `serve` (transactional swap), `unserve`, `soft_delete_by_project`.
- **`db/dao/project_dao.py`** — filters (`ACTIVE`/`PROD`/`DEV`/`WITH_USAGE`) rewritten against `served_config_uuid`; legacy config methods removed; new `insert_with_configs` seeds project + 2 slots atomically.
- **`services/project_service.py`** — reworked around `configUuid`; served read-only guard; transactional create.
- **`server.py`** — wires `ProjectConfigDAO`; startup registers the `SERVED` config per project.
- **Alembic migration `b3c4d5e6f7a8`** — pure schema migration: creates the `project_config` table + indexes (reusing the `project_config_status` enum, creating `project_config_slot`), adds `served_config_uuid` (+FK) to `project`, drops the legacy columns. No per-project data backfill — production has no existing project rows (the `project` table exists but is empty). Fully reversible (`downgrade` re-adds the legacy columns and drops the new table/enum). Verified end-to-end in Docker with an `upgrade → downgrade → upgrade` cycle.
- **Tests** — new `project_config_dao_test.py`; `project_service_test.py`, `test_project_route.py`, `project_dao_test.py`, `db_mock.py`, `db_integration.py` updated for the two-config model.

> **Note for FE:** breaking change — `ProjectOut` no longer has `configFile`/`draftConfigFile`/`configStatus`; read per-slot state from `configs[]` and the live config from `servedConfigUuid`. All config mutations moved under `/configs/{configUuid}/…` and return the full `ProjectOut`.
