### PR TITLE
fix: return empty is project exists

### DIFF
--- a/gateway/radicalbit_ai_gateway/routes/dashboard_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/dashboard_route.py
@@ -125,9 +125,7 @@ class DashboardRoute:
             project = project_service.get_by_uuid(project_uuid)
             project_entry = request.app.state.project_configs.get(project.name)
             if not project_entry:
-                raise GatewayNotFoundError(
-                    f'No active configuration for project {project.name}'
-                )
+                return EventsDTO(request_error_percentage=0.0)
             return event_service.get_total_counter(
                 project_uuid=project_uuid,
                 config=project_entry.config,
@@ -151,9 +149,7 @@ class DashboardRoute:
             project = project_service.get_by_uuid(project_uuid)
             project_entry = request.app.state.project_configs.get(project.name)
             if not project_entry:
-                raise GatewayNotFoundError(
-                    f'No active configuration for project {project.name}'
-                )
+                return []
             return event_service.get_total_counter_per_route(
                 project_uuid=project_uuid,
                 project_name=project.name,

--- a/gateway/radicalbit_ai_gateway/routes/usage_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/usage_route.py
@@ -7,7 +7,6 @@ from fastapi import APIRouter, Query, Request
 from radicalbit_ai_gateway.models.event_dto import UsageCostsDTO
 from radicalbit_ai_gateway.services.event_service import EventService
 from radicalbit_ai_gateway.services.project_service import ProjectService
-from radicalbit_ai_gateway.utils.exceptions import GatewayNotFoundError
 
 
 class UsageRoute:
@@ -34,9 +33,7 @@ class UsageRoute:
             project = project_service.get_by_uuid(project_uuid)
             project_entry = request.app.state.project_configs.get(project.name)
             if not project_entry:
-                raise GatewayNotFoundError(
-                    f'No active configuration for project {project.name}'
-                )
+                return UsageCostsDTO(total=0.0, routes=[])
             return event_service.get_all_routes_costs(
                 project_uuid=project_uuid,
                 config=project_entry.config,

--- a/gateway/tests/routes/test_dashboard_route.py
+++ b/gateway/tests/routes/test_dashboard_route.py
@@ -1351,3 +1351,49 @@ class TestDashboardRoute(unittest.TestCase):
             granularity='months',
             routes=None,
         )
+
+
+class TestDashboardRouteNoActiveConfig(unittest.TestCase):
+    """Endpoints that return lists or aggregates must return empty data (not 404)
+    when the project exists in the DB but has no actively served config.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.prefix = '/public/api/v1'
+        cls.event_service: EventService = MagicMock(spec_set=EventService)
+        cls.request_event_service: RequestEventService = MagicMock(
+            spec_set=RequestEventService
+        )
+        cls.project_service: ProjectService = MagicMock(spec_set=ProjectService)
+        os.environ['ENABLED_PLUGINS'] = 'registry_oidc_auth,keycloak_idp'
+        router = DashboardRoute.get_dashboard_router(
+            event_service=cls.event_service,
+            request_event_service=cls.request_event_service,
+            project_service=cls.project_service,
+        )
+        app = FastAPI(title='AI Gateway', debug=True)
+        app.add_exception_handler(GatewayError, gateway_exception_handler)
+        app.include_router(router, prefix=cls.prefix)
+        app.state.project_configs = {}
+        app.state.routes = {}
+        cls.client = TestClient(app)
+        cls.project_path = f'{cls.prefix}/projects/{PROJECT_UUID}'
+
+    def setUp(self):
+        project_mock = MagicMock()
+        project_mock.name = PROJECT_NAME
+        self.project_service.get_by_uuid = MagicMock(return_value=project_mock)
+
+    def test_routes_returns_empty_list_when_no_active_config(self):
+        response = self.client.get(f'{self.project_path}/routes')
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_metrics_returns_empty_dto_when_no_active_config(self):
+        response = self.client.get(f'{self.project_path}/metrics')
+        assert response.status_code == 200
+        data = response.json()
+        assert data['totalRequests'] == 0
+        assert data['totalInputTokenProcessed'] == 0
+        assert data['totalOutputTokenProcessed'] == 0

--- a/gateway/tests/routes/test_usage_route.py
+++ b/gateway/tests/routes/test_usage_route.py
@@ -157,3 +157,14 @@ class TestUsageRoute(unittest.TestCase):
         summary = response.json()['routes'][0]['summary']
         assert 'cache_triggered' not in summary
         assert 'saved_amount_input' not in summary
+
+    def test_usage_costs_returns_empty_when_no_active_config(self):
+        app = self.client.app
+        original = app.state.project_configs
+        app.state.project_configs = {}
+        try:
+            response = self.client.get(f'{self.project_path}/usage/costs')
+            assert response.status_code == 200
+            assert response.json() == {'total': 0.0, 'routes': []}
+        finally:
+            app.state.project_configs = original


### PR DESCRIPTION
## Summary

When project exists but has no served config, three read endpoints returned 404. Fix returns empty data — callers can now distinguish "project not found" from "project has no data yet".

Fixed:

GET /projects/{uuid}/routes → [] instead of 404
GET /projects/{uuid}/metrics → empty EventsDTO (all zeros) instead of 404
GET /projects/{uuid}/usage/costs → {"total": 0.0, "routes": []} instead of 404
404 still fires correctly when project UUID doesn't exist in DB.

Other: removed unused import, added 3 test cases.

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
