### PR TITLE
feat: track whether a project config slot has ever been saved by the frontend

### DIFF
--- a/gateway/alembic/versions/b4c5d6e7f8a9_make_project_config_updated_at_nullable.py
+++ b/gateway/alembic/versions/b4c5d6e7f8a9_make_project_config_updated_at_nullable.py
@@ -1,0 +1,46 @@
+"""make_project_config_updated_at_nullable
+
+Revision ID: b4c5d6e7f8a9
+Revises: c4d5e6f7a8b9
+Create Date: 2026-06-15 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b4c5d6e7f8a9'
+down_revision: Union[str, None] = 'c4d5e6f7a8b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'project_config',
+        'UPDATED_AT',
+        existing_type=sa.TIMESTAMP(timezone=True),
+        nullable=True,
+    )
+    op.execute(
+        'UPDATE project_config SET "UPDATED_AT" = NULL '
+        'WHERE "UPDATED_AT" = "CREATED_AT"'
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        'UPDATE project_config SET "UPDATED_AT" = "CREATED_AT" '
+        'WHERE "UPDATED_AT" IS NULL'
+    )
+    op.alter_column(
+        'project_config',
+        'UPDATED_AT',
+        existing_type=sa.TIMESTAMP(timezone=True),
+        nullable=False,
+    )

--- a/gateway/radicalbit_ai_gateway/db/dao/project_config_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_config_dao.py
@@ -64,7 +64,6 @@ class ProjectConfigDAO:
             return session.execute(query).rowcount
 
     def set_status(self, config_uuid: UUID, status: ConfigStatus) -> int:
-        now = datetime.datetime.now(tz=_UTC)
         with self.db.begin_session() as session:
             query = (
                 update(ProjectConfig)
@@ -72,7 +71,7 @@ class ProjectConfigDAO:
                     ProjectConfig.uuid == config_uuid,
                     ProjectConfig.deleted_at.is_(None),
                 )
-                .values(config_status=status.value, updated_at=now)
+                .values(config_status=status.value)
             )
             return session.execute(query).rowcount
 
@@ -102,12 +101,12 @@ class ProjectConfigDAO:
                     ProjectConfig.config_status == ConfigStatus.SERVED.value,
                     ProjectConfig.deleted_at.is_(None),
                 )
-                .values(config_status=ConfigStatus.DRAFT.value, updated_at=now)
+                .values(config_status=ConfigStatus.DRAFT.value)
             )
             session.execute(
                 update(ProjectConfig)
                 .where(ProjectConfig.uuid == config_uuid)
-                .values(config_status=ConfigStatus.SERVED.value, updated_at=now)
+                .values(config_status=ConfigStatus.SERVED.value)
             )
             session.execute(
                 update(Project)
@@ -139,7 +138,7 @@ class ProjectConfigDAO:
             session.execute(
                 update(ProjectConfig)
                 .where(ProjectConfig.uuid == config_uuid)
-                .values(config_status=ConfigStatus.DRAFT.value, updated_at=now)
+                .values(config_status=ConfigStatus.DRAFT.value)
             )
             session.execute(
                 update(Project)
@@ -160,6 +159,6 @@ class ProjectConfigDAO:
                     ProjectConfig.project_uuid == project_uuid,
                     ProjectConfig.deleted_at.is_(None),
                 )
-                .values(deleted_at=now, updated_at=now)
+                .values(deleted_at=now)
             )
             return session.execute(query).rowcount

--- a/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
@@ -45,7 +45,7 @@ class ProjectDAO:
                         config_file=config_file,
                         config_status=status.value,
                         created_at=now,
-                        updated_at=now,
+                        updated_at=None,
                     )
                 )
             session.flush()

--- a/gateway/radicalbit_ai_gateway/db/tables/project_config_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/project_config_table.py
@@ -59,5 +59,5 @@ class ProjectConfig(Reflected, BaseTable, BaseDAO):
         server_default='DRAFT',
     )
     created_at = Column('CREATED_AT', TIMESTAMP(timezone=True), nullable=False)
-    updated_at = Column('UPDATED_AT', TIMESTAMP(timezone=True), nullable=False)
+    updated_at = Column('UPDATED_AT', TIMESTAMP(timezone=True), nullable=True)
     deleted_at = Column('DELETED_AT', TIMESTAMP(timezone=True), nullable=True)

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -75,7 +75,8 @@ class ConfigSlotOut(BaseModel):
     slot: str
     config_file: str | None
     config_status: ConfigStatus
-    updated_at: str
+    created_at: str
+    updated_at: str | None
 
     model_config = ConfigDict(
         populate_by_name=True, alias_generator=to_camel, protected_namespaces=()
@@ -88,7 +89,8 @@ class ConfigSlotOut(BaseModel):
             slot=config.slot,
             config_file=config.config_file,
             config_status=ConfigStatus(config.config_status),
-            updated_at=str(config.updated_at),
+            created_at=str(config.created_at),
+            updated_at=str(config.updated_at) if config.updated_at else None,
         )
 
 

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -343,6 +343,7 @@ def get_sample_config_slot_out(
         slot=slot.value,
         config_file=config_file,
         config_status=config_status,
+        created_at=str(now),
         updated_at=str(now),
     )
 

--- a/gateway/tests/dao/project_config_dao_test.py
+++ b/gateway/tests/dao/project_config_dao_test.py
@@ -34,7 +34,7 @@ class ProjectConfigDAOTest(DatabaseIntegration):
                 config_file='# a',
                 config_status=ConfigStatus.DRAFT.value,
                 created_at=now,
-                updated_at=now,
+                updated_at=None,
             )
         )
         b = self.insert(
@@ -44,7 +44,7 @@ class ProjectConfigDAOTest(DatabaseIntegration):
                 config_file='# b',
                 config_status=ConfigStatus.DRAFT.value,
                 created_at=now,
-                updated_at=now,
+                updated_at=None,
             )
         )
         return a.uuid, b.uuid
@@ -70,6 +70,30 @@ class ProjectConfigDAOTest(DatabaseIntegration):
         updated = self.dao.get_by_uuid(a_id)
         assert updated.config_file == 'new'
         assert updated.config_status == ConfigStatus.DRAFT.value
+
+    def test_seeded_configs_have_null_updated_at(self):
+        p = self._project()
+        a_id, b_id = self._seed_two(p.uuid)
+        assert self.dao.get_by_uuid(a_id).updated_at is None
+        assert self.dao.get_by_uuid(b_id).updated_at is None
+
+    def test_update_config_file_sets_updated_at(self):
+        p = self._project()
+        a_id, _ = self._seed_two(p.uuid)
+        self.dao.update_config_file(a_id, 'saved')
+        assert self.dao.get_by_uuid(a_id).updated_at is not None
+
+    def test_set_status_keeps_updated_at_null(self):
+        p = self._project()
+        a_id, _ = self._seed_two(p.uuid)
+        self.dao.set_status(a_id, ConfigStatus.READY_TO_SERVE)
+        assert self.dao.get_by_uuid(a_id).updated_at is None
+
+    def test_serve_keeps_config_updated_at_null(self):
+        p = self._project()
+        a_id, _ = self._seed_two(p.uuid)
+        self.dao.serve(a_id)
+        assert self.dao.get_by_uuid(a_id).updated_at is None
 
     def test_serve_sets_served_ref_and_first_served_at(self):
         p = self._project()

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -46,6 +46,18 @@ class ProjectServiceTest(DatabaseIntegration):
         assert out.project_status == ProjectStatus.DEV
         assert out.served_config_uuid is None
 
+    def test_create_project_leaves_updated_at_null(self):
+        out, _, _ = self._create()
+        assert all(c.created_at is not None for c in out.configs)
+        assert all(c.updated_at is None for c in out.configs)
+
+    def test_update_config_sets_updated_at(self):
+        out, a, _ = self._create()
+        res = self.svc.update_config(
+            out.uuid, a, ProjectConfigFileIn(config_file=_VALID)
+        )
+        assert next(c for c in res.configs if c.uuid == a).updated_at is not None
+
     def test_create_project_already_exists(self):
         # IntegrityError -> ProjectAlreadyExistsError mapping is a unit concern,
         # tested with a mocked DAO to stay independent of create_all metadata.


### PR DESCRIPTION
# PR Summary: feat/recognize-save-status-config

Track whether a project config slot has ever been saved by the frontend. On project creation the two seeded slots now have `updatedAt = null`; the field is populated only on the config-file `PATCH` (the FE "save"). `createdAt` is now also exposed so the FE can compare the two timestamps.

---

## DTO Changes

### `ConfigSlotOut` (MODIFIED)

**Changes:**
```diff
+ createdAt: string                      (added)
? updatedAt: string -> string | null     (now nullable; null until first save)
```

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Config slot UUID |
| `slot` | string | Slot identifier: `A` or `B` |
| `configFile` | string \| null | YAML config content |
| `configStatus` | string | One of: `DRAFT`, `READY_TO_SERVE`, `SERVED` |
| `createdAt` **NEW** | datetime | Slot creation timestamp |
| `updatedAt` | datetime \| null | Last content save; `null` until the first `PATCH` save |

**Example response (freshly created slot — never saved):**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "slot": "A",
  "configFile": "# default template",
  "configStatus": "DRAFT",
  "createdAt": "2026-06-15T10:30:00Z",
  "updatedAt": null
}
```

**Example response (after the FE saved the config):**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "slot": "A",
  "configFile": "# edited config",
  "configStatus": "DRAFT",
  "createdAt": "2026-06-15T10:30:00Z",
  "updatedAt": "2026-06-15T11:05:00Z"
}
```

**Used by:** nested under `ProjectOut.configs`, returned by all project endpoints below.

---

## Affected Endpoints

No request/response signatures changed. The endpoints below now surface `createdAt` and a nullable `updatedAt` inside each `configs[]` entry.

### `POST /projects`
Creates a project with two seeded slots (A, B), both with `updatedAt: null`.

### `PATCH /projects/{project_uuid}/configs/{config_uuid}`
The FE "save": updates the config YAML and is the **only** operation that sets `updatedAt`.

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `config_uuid` | string | yes | Config slot UUID (path) |
| `configFile` | string | yes | YAML config content (body) |

### Other endpoints returning `ProjectOut` (unchanged behavior, now expose the fields)
- `GET /projects` · `GET /projects/{project_uuid}`
- `PATCH /projects/{project_uuid}/configs/{config_uuid}/approve` · `/cancel-approval`
- `PATCH /projects/{project_uuid}/configs/{config_uuid}/serve` · `/unserve`

> Note: status changes (`serve`, `unserve`, `approve`/`cancel-approval`) and project soft-delete **no longer** touch `updatedAt` — it reflects only content saves.

---

## Other Changes

- `db/tables/project_config_table.py` — `UPDATED_AT` column is now nullable.
- `db/dao/project_dao.py` — `insert_with_configs` seeds slots with `updated_at = None`.
- `db/dao/project_config_dao.py` — only `update_config_file` sets `updated_at`; removed from `set_status`, `serve`, `unserve`, `soft_delete_by_project`.
- `alembic/versions/b4c5d6e7f8a9_make_project_config_updated_at_nullable.py` (NEW) — makes `UPDATED_AT` nullable and backfills `NULL` where `UPDATED_AT = CREATED_AT` (existing never-saved slots); head moves to `b4c5d6e7f8a9`.
- `tests/` — updated `db_mock`, `project_config_dao_test`, `project_service_test` to cover null-on-create and set-on-save behavior.
