### PR TITLE
fix: remove client caching

### DIFF
--- a/gateway/radicalbit_ai_gateway/guardrails/presidio.py
+++ b/gateway/radicalbit_ai_gateway/guardrails/presidio.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(get_app_config().log_config.logger_name)
 class PresidioEngine:
     def __init__(self, languages: list[str] = ['en', 'it']):
         self._analyzer_local = None
-        self._analyzer_ahds_cache = {}
         self._anonymizer = None
         self._nlp_engine = None
         self._languages = languages
@@ -96,10 +95,6 @@ class PresidioEngine:
         endpoint, api_version, tenant_id, client_id, client_secret = (
             self._resolve_ahds_settings(ahds)
         )
-        cache_key = (endpoint, api_version, tenant_id, client_id)
-        analyzer = self._analyzer_ahds_cache.get(cache_key)
-        if analyzer is not None:
-            return analyzer
 
         logger.info(
             'Presidio Analyzer (AHDS) initialization... endpoint=%s api_version=%s',
@@ -129,7 +124,6 @@ class PresidioEngine:
         )
         analyzer.registry.add_recognizer(recognizer)
         logger.info('AHDS recognizer registered on AnalyzerEngine')
-        self._analyzer_ahds_cache[cache_key] = analyzer
         return analyzer
 
     @property


### PR DESCRIPTION
## Summary

Remove the AHDS analyzer cache from `PresidioEngine` to fix intermittent 500 errors caused by stale TCP connections to Azure Health Data Services.

## Description

`PresidioEngine` cached the `DeidentificationClient` (and its wrapping `AnalyzerEngine`) in `_analyzer_ahds_cache` for the lifetime of the process. The fix removes the cache entirely so each request builds a fresh client. This is safe because client construction is cheap (no network call until actual deidentification), and the expensive part - loading spaCy NLP models - remains cached in `_nlp_engine`.

## Key Changes

- **`gateway/radicalbit_ai_gateway/guardrails/presidio.py`**: Removed `_analyzer_ahds_cache` dict from `__init__`, removed cache-key construction and lookup/early-return in `_get_ahds_analyzer`, and removed the cache-store after building the analyzer. Each call now returns a freshly constructed `DeidentificationClient` + `AnalyzerEngine`.


## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
