### PR TITLE
feat: remove orphaned association when swapping configuration

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/group_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/group_dao.py
@@ -104,6 +104,20 @@ class GroupDAO:
             )
             return session.scalars(stmt).all()
 
+    def delete_orphaned_associations(
+        self, project_uuid: UUID, valid_route_names: list[str]
+    ) -> int:
+        """Delete the project's group↔route associations whose route_name is not
+        in valid_route_names (the routes of the newly served config). Returns the
+        number of deleted rows.
+        """
+        with self.db.begin_session() as session:
+            query = delete(GroupRoute).where(
+                GroupRoute.project_uuid == project_uuid,
+                GroupRoute.route_name.notin_(valid_route_names),
+            )
+            return session.execute(query).rowcount
+
     def get_route_names_by_group_uuid(self, group_uuid: UUID) -> list[str]:
         """Return fully-qualified route names (project_name/route_name) for a group."""
         with self.db.begin_session() as session:

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -147,7 +147,17 @@ class ProjectRoute:
                 await register_project_routes(
                     project_uuid, project.name, served.config_file
                 )
-            logger.info('Served config %s for project %s', config_uuid, project_uuid)
+            # Auto-cleanup on swap: drop group↔route associations whose route_name
+            # is no longer present in the newly served config.
+            removed = group_service.cleanup_orphaned_associations(
+                project_uuid, project.name
+            )
+            logger.info(
+                'Served config %s for project %s (removed %d orphaned associations)',
+                config_uuid,
+                project_uuid,
+                removed,
+            )
             return project
 
         @router.post(

--- a/gateway/radicalbit_ai_gateway/services/group_service.py
+++ b/gateway/radicalbit_ai_gateway/services/group_service.py
@@ -51,6 +51,20 @@ class GroupService:
             return
         raise RouteNotFoundError(f'Route {project_name}/{route_name} not exists')
 
+    def cleanup_orphaned_associations(
+        self, project_uuid: UUID, project_name: str
+    ) -> int:
+        """Drop the project's group↔route associations whose route_name is not
+        present in the currently served config. Must be called after the newly
+        served config has been registered in project_configs. Returns the number
+        of deleted associations.
+        """
+        entry = self._project_configs.get(project_name)
+        valid_route_names = list(entry.config.routes) if entry else []
+        return self.group_dao.delete_orphaned_associations(
+            project_uuid, valid_route_names
+        )
+
     def _get_group(
         self, group_uuid: UUID, include_routes: bool = False, include_keys: bool = False
     ) -> GroupFullOut:

--- a/gateway/tests/dao/group_route_dao_test.py
+++ b/gateway/tests/dao/group_route_dao_test.py
@@ -103,3 +103,43 @@ class GroupRouteDAOTest(DatabaseIntegration):
         project_uuids = {r.project_uuid for r in inserted}
         assert self.project_uuid in project_uuids
         assert project_b_uuid in project_uuids
+
+    def test_delete_orphaned_associations_removes_routes_absent_from_config(self):
+        routes = [
+            db_mock.get_sample_group_route(
+                group_uuid=self.group_one,
+                route_name='route-A',
+                project_uuid=self.project_uuid,
+            ),
+            db_mock.get_sample_group_route(
+                group_uuid=self.group_two,
+                route_name='gone-route',
+                project_uuid=self.project_uuid,
+            ),
+        ]
+        self.group_route_dao.add_bulk(routes)
+        removed = self.group_dao.delete_orphaned_associations(
+            self.project_uuid, ['route-A']
+        )
+        assert removed == 1
+        remaining = self.group_dao.get_all_group_by_route_name(
+            self.project_uuid, 'gone-route'
+        )
+        assert remaining == []
+
+    def test_delete_orphaned_associations_empty_keep_list_removes_all(self):
+        routes = [
+            db_mock.get_sample_group_route(
+                group_uuid=self.group_one,
+                route_name='route-A',
+                project_uuid=self.project_uuid,
+            ),
+            db_mock.get_sample_group_route(
+                group_uuid=self.group_two,
+                route_name='route-B',
+                project_uuid=self.project_uuid,
+            ),
+        ]
+        self.group_route_dao.add_bulk(routes)
+        removed = self.group_dao.delete_orphaned_associations(self.project_uuid, [])
+        assert removed == 2

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -152,11 +152,29 @@ class TestProjectRoute(unittest.TestCase):
             uuid=pid, served_config_uuid=cid, configs=[served, other]
         )
         self.project_service.serve_config = MagicMock(return_value=out)
+        self.group_service.cleanup_orphaned_associations = MagicMock(return_value=0)
         res = self.client.patch(f'{self.prefix}/projects/{pid}/configs/{cid}/serve')
         assert res.status_code == 200
         self.project_service.serve_config.assert_called_once_with(pid, cid)
         self.deregister.assert_awaited_once_with(pid)
         self.register.assert_awaited_once_with(pid, out.name, _VALID)
+
+    def test_serve_config_cleans_up_orphaned_associations(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        served = db_mock.get_sample_config_slot_out(
+            uuid=cid, slot=Slot.A, config_file=_VALID, config_status=ConfigStatus.SERVED
+        )
+        other = db_mock.get_sample_config_slot_out(uuid=uuid.uuid4(), slot=Slot.B)
+        out = db_mock.get_sample_project_out(
+            uuid=pid, served_config_uuid=cid, configs=[served, other]
+        )
+        self.project_service.serve_config = MagicMock(return_value=out)
+        self.group_service.cleanup_orphaned_associations = MagicMock(return_value=2)
+        res = self.client.patch(f'{self.prefix}/projects/{pid}/configs/{cid}/serve')
+        assert res.status_code == 200
+        self.group_service.cleanup_orphaned_associations.assert_called_once_with(
+            pid, out.name
+        )
 
     def test_unserve_config_deregisters(self):
         pid, cid = uuid.uuid4(), uuid.uuid4()

--- a/gateway/tests/services/group_service_test.py
+++ b/gateway/tests/services/group_service_test.py
@@ -793,3 +793,27 @@ class GroupServiceTest(unittest.TestCase):
         route = next(r for r in res if r.name == 'proj-route')
         assert route.project_uuid == _MY_PROJECT_UUID
         assert route.project_name == 'my-project'
+
+    def test_cleanup_orphaned_associations_keeps_served_routes(self):
+        """Cleanup passes the served config's route names as the keep-list."""
+        self.group_dao.delete_orphaned_associations = MagicMock(return_value=2)
+        removed = self.group_service.cleanup_orphaned_associations(
+            _MY_PROJECT_UUID, 'my-project'
+        )
+        assert removed == 2
+        self.group_dao.delete_orphaned_associations.assert_called_once()
+        args = self.group_dao.delete_orphaned_associations.call_args.args
+        assert args[0] == _MY_PROJECT_UUID
+        assert set(args[1]) == {'route-A', 'route-B'}
+
+    def test_cleanup_orphaned_associations_unknown_project_deletes_all(self):
+        """With no served config the keep-list is empty, so every association is
+        removed.
+        """
+        self.group_dao.delete_orphaned_associations = MagicMock(return_value=3)
+        removed = self.group_service.cleanup_orphaned_associations(
+            uuid.uuid4(), 'unknown-project'
+        )
+        assert removed == 3
+        args = self.group_dao.delete_orphaned_associations.call_args.args
+        assert args[1] == []


### PR DESCRIPTION
# PR Summary: feat/handle-group-route-association-when-editing-configs

Auto-cleanup of orphaned group↔route associations on config swap (Slot A/B model, AG-784). When a config is served, any group↔route association whose `route_name` is no longer declared by the newly served config is dropped. No API contract change.

---

## DTO Changes

None. `ProjectOut` and all other DTOs are unchanged.

---

## Affected Endpoints

### `PATCH /projects/{project_uuid}/configs/{config_uuid}/serve` (MODIFIED — behavior only)

The request/response contract is unchanged (still returns `ProjectOut`). The swap now performs an extra cleanup step after registering the newly served config.

**Changes:**
```diff
  serve config (DB swap)
  deregister old routes
  register newly served config routes
+ delete group↔route associations whose route_name is absent from the served config
```

**Example request:**
```
PATCH /projects/550e8400-e29b-41d4-a716-446655440000/configs/aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa/serve
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `config_uuid` | string | yes | Config UUID to serve (path) |

**Behavior notes:**
- A group↔route association is keyed by `(group_uuid, route_name, project_uuid)` — not bound to a slot. It becomes "orphaned" only when the newly served config no longer declares that `route_name` (e.g. routes renamed between Slot A and Slot B).
- Orphaned associations are **deleted** at serve time; the removed count is logged.
- This is destructive: re-serving a slot that re-introduces the route name does **not** restore the association — it must be re-created.

### `PATCH /projects/{project_uuid}/configs/{config_uuid}/unserve` (UNCHANGED)

Cleanup is intentionally **not** run on unserve. The config returns to `DRAFT`, routes are deregistered, but `group_routes` rows are left untouched (dormant). They reactivate when a config containing those routes is served again, or are cleaned up when a config lacking them is served.

---

## Other Changes

- `db/dao/group_dao.py` — **NEW** `delete_orphaned_associations(project_uuid, valid_route_names) -> int`: deletes the project's associations whose `route_name` is not in the keep-list; returns the deleted row count. Empty keep-list deletes all of the project's associations.
- `services/group_service.py` — **NEW** `cleanup_orphaned_associations(project_uuid, project_name) -> int`: builds the keep-list from the served config's routes (`project_configs`) and delegates to the DAO.
- `routes/project_route.py` — `serve_config` invokes the cleanup after registering the served config and logs the removed count.

### Tests

- `tests/dao/group_route_dao_test.py` — integration: removes only routes absent from the keep-list; empty keep-list removes all.
- `tests/services/group_service_test.py` — keep-list equals the served config's routes; unknown/unserved project → empty keep-list.
- `tests/routes/test_project_route.py` — `serve_config` invokes cleanup on swap.

---

## Test Scenarios

Step-by-step scenarios to validate the behavior end-to-end.

### Serve / swap

| # | Setup | Action | Expected |
|---|-------|--------|----------|
| A1 | Slot A served with `r1`, `r2`; associate `group-X → r1`; Slot B has the **same** routes `r1`, `r2` | Serve Slot B | Association kept; `removed 0`; `GET .../routes/r1/associable-groups` still works |
| A2 | Slot A served with `r1`; associate `group-X → r1`; Slot B has only `r2` | Serve Slot B | `group-X → r1` deleted (`removed 1`); `GET/PATCH .../routes/r1/...` → 404 |
| A3 | Slot A served with `r1`, `r2`; associate `group-X → r1` and `group-Y → r2`; Slot B has `r1`, `r3` | Serve Slot B | `group-X → r1` kept; `group-Y → r2` deleted (`removed 1`) |
| A4 | Slot A served with `r1`; associate `group-X`, `group-Y`, `group-Z` all to `r1`; Slot B without `r1` | Serve Slot B | All 3 associations deleted (`removed 3`) |
| A5 | After A2 (B served, `group-X → r1` deleted) | Re-serve Slot A (which re-declares `r1`) | Association does **not** come back — must be re-created (destructive cleanup) |

### Unserve (associations preserved)

| # | Setup | Action | Expected |
|---|-------|--------|----------|
| B1 | Slot A served with `r1`; associate `group-X → r1` | Unserve Slot A | Row kept in `group_routes`; project → `DEV`, `servedConfigUuid = null`; `GET/PATCH .../routes/r1/...` → 404 |
| B2 | Continue from B1 | Re-serve Slot A (with `r1`) | `group-X → r1` reactivates; `removed 0` |
| B3 | Continue from B1 (dormant association on `r1`); Slot B without `r1` | Serve Slot B | Serve-path cleanup deletes `group-X → r1` (`removed 1`) |

### Isolation

| # | Setup | Action | Expected |
|---|-------|--------|----------|
| C1 | Projects P1 and P2 both have route `r1` with a group association; P1 has a Slot without `r1` | Serve the swap on P1 | Only P1's association deleted; P2's stays intact (key includes `project_uuid`) |

### Runtime / authz

| # | Setup | Action | Expected |
|---|-------|--------|----------|
| D1 | Slot A served with `r1`; group with an API key; `group → r1`; runtime call to `r1` → 200 | Serve Slot B without `r1` (association deleted), then re-serve A | After re-serving A, the same key on `r1` is no longer authorized (401/403) until the association is recreated |
