### PR TITLE
feat: export project configuration slot

### DIFF
--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Query, Request, Response
 
 from radicalbit_ai_gateway.models.auth_dto import (
     GroupFullOut,
@@ -182,6 +182,23 @@ class ProjectRoute:
             )
             logger.info('Generated config %s for project %s', config_uuid, project_uuid)
             return GenerateConfigOut(config_file=yaml_str)
+
+        @router.get(
+            '/projects/{project_uuid}/configs/{config_uuid}/export',
+            status_code=200,
+        )
+        def export_config(project_uuid: UUID, config_uuid: UUID):
+            content, filename = project_service.export_config(
+                project_uuid, config_uuid
+            )
+            logger.info('Exported config %s for project %s', config_uuid, project_uuid)
+            return Response(
+                content=content,
+                media_type='application/zip',
+                headers={
+                    'Content-Disposition': f'attachment; filename="{filename}"'
+                },
+            )
 
         @router.patch(
             '/projects/{project_uuid}/configs/{config_uuid}/unserve',

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -196,6 +196,19 @@ class ProjectRoute:
                 headers={'Content-Disposition': f'attachment; filename="{filename}"'},
             )
 
+        @router.get(
+            '/projects/{project_uuid}/configs/export',
+            status_code=200,
+        )
+        def export_all_configs(project_uuid: UUID):
+            content, filename = project_service.export_all_configs(project_uuid)
+            logger.info('Exported all configs for project %s', project_uuid)
+            return Response(
+                content=content,
+                media_type='application/zip',
+                headers={'Content-Disposition': f'attachment; filename="{filename}"'},
+            )
+
         @router.patch(
             '/projects/{project_uuid}/configs/{config_uuid}/unserve',
             status_code=200,

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -188,16 +188,12 @@ class ProjectRoute:
             status_code=200,
         )
         def export_config(project_uuid: UUID, config_uuid: UUID):
-            content, filename = project_service.export_config(
-                project_uuid, config_uuid
-            )
+            content, filename = project_service.export_config(project_uuid, config_uuid)
             logger.info('Exported config %s for project %s', config_uuid, project_uuid)
             return Response(
                 content=content,
                 media_type='application/zip',
-                headers={
-                    'Content-Disposition': f'attachment; filename="{filename}"'
-                },
+                headers={'Content-Disposition': f'attachment; filename="{filename}"'},
             )
 
         @router.patch(

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -199,6 +199,18 @@ class ProjectService:
             f'{project_name}_config_{Slot(config.slot).value}_{status_label}'
         )
 
+    @staticmethod
+    def _build_configs_zip(
+        project_name: str, configs: list[ProjectConfig]
+    ) -> tuple[bytes, str]:
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
+            for config in configs:
+                entry = ProjectService._config_entry_name(project_name, config)
+                archive.writestr(f'{entry}.yaml', config.config_file)
+        zip_name = _sanitize_filename(f'{project_name}_config')
+        return buffer.getvalue(), f'{zip_name}.zip'
+
     def export_config(self, project_uuid: UUID, config_uuid: UUID) -> tuple[bytes, str]:
         project = self._get_project_or_raise(project_uuid)
         config = self._get_config_or_raise(project_uuid, config_uuid)
@@ -206,13 +218,7 @@ class ProjectService:
             raise ProjectConfigValidationError(
                 f'Config {config_uuid} has no configuration to export'
             )
-
-        buffer = io.BytesIO()
-        with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
-            entry = self._config_entry_name(project.name, config)
-            archive.writestr(f'{entry}.yaml', config.config_file)
-        zip_name = _sanitize_filename(f'{project.name}_config')
-        return buffer.getvalue(), f'{zip_name}.zip'
+        return self._build_configs_zip(project.name, [config])
 
     def export_all_configs(self, project_uuid: UUID) -> tuple[bytes, str]:
         project = self._get_project_or_raise(project_uuid)
@@ -225,14 +231,7 @@ class ProjectService:
             raise ProjectConfigValidationError(
                 f'Project {project_uuid} has no configuration to export'
             )
-
-        buffer = io.BytesIO()
-        with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
-            for config in configs:
-                entry = self._config_entry_name(project.name, config)
-                archive.writestr(f'{entry}.yaml', config.config_file)
-        zip_name = _sanitize_filename(f'{project.name}_config')
-        return buffer.getvalue(), f'{zip_name}.zip'
+        return self._build_configs_zip(project.name, configs)
 
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -188,9 +188,7 @@ class ProjectService:
             self._get_config_or_raise(project_uuid, config_uuid)
         )
 
-    def export_config(
-        self, project_uuid: UUID, config_uuid: UUID
-    ) -> tuple[bytes, str]:
+    def export_config(self, project_uuid: UUID, config_uuid: UUID) -> tuple[bytes, str]:
         project = self._get_project_or_raise(project_uuid)
         config = self._get_config_or_raise(project_uuid, config_uuid)
         if not config.config_file:
@@ -199,9 +197,7 @@ class ProjectService:
             )
 
         status_label = (
-            'served'
-            if config.config_status == ConfigStatus.SERVED.value
-            else 'draft'
+            'served' if config.config_status == ConfigStatus.SERVED.value else 'draft'
         )
         slug = _sanitize_filename(
             f'{project.name}_slot_{Slot(config.slot).value}_{status_label}'

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -188,6 +188,15 @@ class ProjectService:
             self._get_config_or_raise(project_uuid, config_uuid)
         )
 
+    @staticmethod
+    def _config_entry_name(project_name: str, config: ProjectConfig) -> str:
+        status_label = (
+            'served' if config.config_status == ConfigStatus.SERVED.value else 'draft'
+        )
+        return _sanitize_filename(
+            f'{project_name}_config_{Slot(config.slot).value}_{status_label}'
+        )
+
     def export_config(self, project_uuid: UUID, config_uuid: UUID) -> tuple[bytes, str]:
         project = self._get_project_or_raise(project_uuid)
         config = self._get_config_or_raise(project_uuid, config_uuid)
@@ -196,17 +205,32 @@ class ProjectService:
                 f'Config {config_uuid} has no configuration to export'
             )
 
-        status_label = (
-            'served' if config.config_status == ConfigStatus.SERVED.value else 'draft'
-        )
-        slug = _sanitize_filename(
-            f'{project.name}_slot_{Slot(config.slot).value}_{status_label}'
-        )
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
+            entry = self._config_entry_name(project.name, config)
+            archive.writestr(f'{entry}.yaml', config.config_file)
+        zip_name = _sanitize_filename(f'{project.name}_config')
+        return buffer.getvalue(), f'{zip_name}.zip'
+
+    def export_all_configs(self, project_uuid: UUID) -> tuple[bytes, str]:
+        project = self._get_project_or_raise(project_uuid)
+        configs = [
+            config
+            for config in self.project_config_dao.list_by_project(project_uuid)
+            if config.config_file
+        ]
+        if not configs:
+            raise ProjectConfigValidationError(
+                f'Project {project_uuid} has no configuration to export'
+            )
 
         buffer = io.BytesIO()
         with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
-            archive.writestr(f'{slug}.yaml', config.config_file)
-        return buffer.getvalue(), f'{slug}.zip'
+            for config in configs:
+                entry = self._config_entry_name(project.name, config)
+                archive.writestr(f'{entry}.yaml', config.config_file)
+        zip_name = _sanitize_filename(f'{project.name}_config')
+        return buffer.getvalue(), f'{zip_name}.zip'
 
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -1,4 +1,7 @@
+import io
+import re
 from uuid import UUID
+import zipfile
 
 from sqlalchemy.exc import IntegrityError
 
@@ -25,6 +28,11 @@ from radicalbit_ai_gateway.utils.yaml_utils import (
     get_default_config_template,
     validate_gateway_config,
 )
+
+
+def _sanitize_filename(name: str) -> str:
+    sanitized = re.sub(r'[^A-Za-z0-9_-]+', '_', name).strip('_')
+    return sanitized or 'config'
 
 
 class ProjectService:
@@ -179,6 +187,30 @@ class ProjectService:
         return ConfigSlotOut.from_config(
             self._get_config_or_raise(project_uuid, config_uuid)
         )
+
+    def export_config(
+        self, project_uuid: UUID, config_uuid: UUID
+    ) -> tuple[bytes, str]:
+        project = self._get_project_or_raise(project_uuid)
+        config = self._get_config_or_raise(project_uuid, config_uuid)
+        if not config.config_file:
+            raise ProjectConfigValidationError(
+                f'Config {config_uuid} has no configuration to export'
+            )
+
+        status_label = (
+            'served'
+            if config.config_status == ConfigStatus.SERVED.value
+            else 'draft'
+        )
+        slug = _sanitize_filename(
+            f'{project.name}_slot_{Slot(config.slot).value}_{status_label}'
+        )
+
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
+            archive.writestr(f'{slug}.yaml', config.config_file)
+        return buffer.getvalue(), f'{slug}.zip'
 
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -122,6 +122,39 @@ class TestProjectRoute(unittest.TestCase):
         )
         assert res.status_code == 400
 
+    # --- export ---
+
+    def test_export_config_returns_zip(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.export_config = MagicMock(
+            return_value=(b'zip-bytes', 'proj_slot_A_draft.zip')
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/configs/{cid}/export')
+        assert res.status_code == 200
+        assert res.headers['content-type'] == 'application/zip'
+        assert (
+            res.headers['content-disposition']
+            == 'attachment; filename="proj_slot_A_draft.zip"'
+        )
+        assert res.content == b'zip-bytes'
+        self.project_service.export_config.assert_called_once_with(pid, cid)
+
+    def test_export_config_not_found(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.export_config = MagicMock(
+            side_effect=ProjectNotFoundError('nope')
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/configs/{cid}/export')
+        assert res.status_code == 404
+
+    def test_export_config_empty_returns_400(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.export_config = MagicMock(
+            side_effect=ProjectConfigValidationError('empty')
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/configs/{cid}/export')
+        assert res.status_code == 400
+
     def test_approve_config(self):
         pid, cid = uuid.uuid4(), uuid.uuid4()
         self.project_service.approve_config = MagicMock(

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -127,14 +127,14 @@ class TestProjectRoute(unittest.TestCase):
     def test_export_config_returns_zip(self):
         pid, cid = uuid.uuid4(), uuid.uuid4()
         self.project_service.export_config = MagicMock(
-            return_value=(b'zip-bytes', 'proj_slot_A_draft.zip')
+            return_value=(b'zip-bytes', 'proj_config.zip')
         )
         res = self.client.get(f'{self.prefix}/projects/{pid}/configs/{cid}/export')
         assert res.status_code == 200
         assert res.headers['content-type'] == 'application/zip'
         assert (
             res.headers['content-disposition']
-            == 'attachment; filename="proj_slot_A_draft.zip"'
+            == 'attachment; filename="proj_config.zip"'
         )
         assert res.content == b'zip-bytes'
         self.project_service.export_config.assert_called_once_with(pid, cid)
@@ -153,6 +153,37 @@ class TestProjectRoute(unittest.TestCase):
             side_effect=ProjectConfigValidationError('empty')
         )
         res = self.client.get(f'{self.prefix}/projects/{pid}/configs/{cid}/export')
+        assert res.status_code == 400
+
+    def test_export_all_configs_returns_zip(self):
+        pid = uuid.uuid4()
+        self.project_service.export_all_configs = MagicMock(
+            return_value=(b'zip-bytes', 'proj_config.zip')
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/configs/export')
+        assert res.status_code == 200
+        assert res.headers['content-type'] == 'application/zip'
+        assert (
+            res.headers['content-disposition']
+            == 'attachment; filename="proj_config.zip"'
+        )
+        assert res.content == b'zip-bytes'
+        self.project_service.export_all_configs.assert_called_once_with(pid)
+
+    def test_export_all_configs_not_found(self):
+        pid = uuid.uuid4()
+        self.project_service.export_all_configs = MagicMock(
+            side_effect=ProjectNotFoundError('nope')
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/configs/export')
+        assert res.status_code == 404
+
+    def test_export_all_configs_empty_returns_400(self):
+        pid = uuid.uuid4()
+        self.project_service.export_all_configs = MagicMock(
+            side_effect=ProjectConfigValidationError('empty')
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/configs/export')
         assert res.status_code == 400
 
     def test_approve_config(self):

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -1,5 +1,7 @@
+import io
 from unittest.mock import MagicMock
 import uuid
+import zipfile
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -9,6 +11,7 @@ from tests.common.db_integration import DatabaseIntegration
 
 from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
+from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import (
     ProjectConfigFileIn,
@@ -201,6 +204,41 @@ class ProjectServiceTest(DatabaseIntegration):
         out, a, _ = self._create()
         with pytest.raises(ProjectNotFoundError):
             self.svc.get_config(uuid.uuid4(), a)
+
+    # --- export ---
+
+    def test_export_config_returns_zip(self):
+        out, a, _ = self._create()
+        content, filename = self.svc.export_config(out.uuid, a)
+        assert filename == 'proj_slot_A_draft.zip'
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            names = archive.namelist()
+            assert names == ['proj_slot_A_draft.yaml']
+            assert archive.read(names[0]).decode() == out.configs[0].config_file
+
+    def test_export_config_served_label(self):
+        out, a, _ = self._create()
+        self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        self.svc.approve_config(out.uuid, a)
+        self.svc.serve_config(out.uuid, a)
+        _, filename = self.svc.export_config(out.uuid, a)
+        assert filename == 'proj_slot_A_served.zip'
+
+    def test_export_config_empty_raises(self):
+        project = self.insert(
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='export-empty')
+        )
+        config = self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=project.uuid, slot=Slot.A, config_file=None
+            )
+        )
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.export_config(project.uuid, config.uuid)
+
+    def test_export_config_not_found(self):
+        with pytest.raises(ProjectNotFoundError):
+            self.svc.export_config(uuid.uuid4(), uuid.uuid4())
 
     # --- listing / filters ---
 

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -210,10 +210,10 @@ class ProjectServiceTest(DatabaseIntegration):
     def test_export_config_returns_zip(self):
         out, a, _ = self._create()
         content, filename = self.svc.export_config(out.uuid, a)
-        assert filename == 'proj_slot_A_draft.zip'
+        assert filename == 'proj_config.zip'
         with zipfile.ZipFile(io.BytesIO(content)) as archive:
             names = archive.namelist()
-            assert names == ['proj_slot_A_draft.yaml']
+            assert names == ['proj_config_A_draft.yaml']
             assert archive.read(names[0]).decode() == out.configs[0].config_file
 
     def test_export_config_served_label(self):
@@ -221,8 +221,54 @@ class ProjectServiceTest(DatabaseIntegration):
         self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
         self.svc.approve_config(out.uuid, a)
         self.svc.serve_config(out.uuid, a)
-        _, filename = self.svc.export_config(out.uuid, a)
-        assert filename == 'proj_slot_A_served.zip'
+        content, filename = self.svc.export_config(out.uuid, a)
+        assert filename == 'proj_config.zip'
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            assert archive.namelist() == ['proj_config_A_served.yaml']
+
+    def test_export_all_configs_returns_zip_with_both_slots(self):
+        out, a, b = self._create()
+        content, filename = self.svc.export_all_configs(out.uuid)
+        assert filename == 'proj_config.zip'
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            assert archive.namelist() == [
+                'proj_config_A_draft.yaml',
+                'proj_config_B_draft.yaml',
+            ]
+
+    def test_export_all_configs_skips_empty_slots(self):
+        project = self.insert(
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='partial')
+        )
+        self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=project.uuid, slot=Slot.A, config_file=_VALID
+            )
+        )
+        self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=project.uuid, slot=Slot.B, config_file=None
+            )
+        )
+        content, _ = self.svc.export_all_configs(project.uuid)
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            assert archive.namelist() == ['partial_config_A_draft.yaml']
+
+    def test_export_all_configs_empty_raises(self):
+        project = self.insert(
+            db_mock.get_sample_project(uuid=uuid.uuid4(), name='all-empty')
+        )
+        self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=project.uuid, slot=Slot.A, config_file=None
+            )
+        )
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.export_all_configs(project.uuid)
+
+    def test_export_all_configs_not_found(self):
+        with pytest.raises(ProjectNotFoundError):
+            self.svc.export_all_configs(uuid.uuid4())
 
     def test_export_config_empty_raises(self):
         project = self.insert(


### PR DESCRIPTION
# PR Summary: feat/export-project-configuration-zip

Adds the ability to export project configurations as downloadable ZIP files (AG-755). Two options are exposed to the FE: exporting a **single config slot** (the one currently being edited) or **all slots** at once. No DTO, DB, or migration changes.

---

## DTO Changes

None. The endpoints return a raw `application/zip` binary response (no JSON body), so no Pydantic models were added or modified.

---

## Affected Endpoints

### `GET /projects/{project_uuid}/configs/{config_uuid}/export` (NEW)

Exports the **current config slot** identified by `config_uuid`.

**Example request:**
```
GET /public/api/v1/projects/550e8400-e29b-41d4-a716-446655440000/configs/6ba7b810-9dad-11d1-80b4-00c04fd430c8/export
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string (UUID) | yes | Project identifier (path) |
| `config_uuid` | string (UUID) | yes | Config slot identifier (path) |

**Response:** `200 OK`, `Content-Type: application/zip`

```
Content-Disposition: attachment; filename="{project_name}_config.zip"
```

The ZIP contains a single YAML file: `{project_name}_config_{slot}_{state}.yaml`
- `slot` — one of: `A`, `B`
- `state` — one of: `draft`, `served`

Example: `my-project_config.zip` → `my-project_config_A_draft.yaml`

**Errors:**
- `404` — project or config does not exist (or the config does not belong to the project)
- `400` — the config has no content (`config_file` null/empty)

---

### `GET /projects/{project_uuid}/configs/export` (NEW)

Exports **all config slots** of the project in a single ZIP.

**Example request:**
```
GET /public/api/v1/projects/550e8400-e29b-41d4-a716-446655440000/configs/export
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string (UUID) | yes | Project identifier (path) |

**Response:** `200 OK`, `Content-Type: application/zip`

```
Content-Disposition: attachment; filename="{project_name}_config.zip"
```

The ZIP contains one YAML file per non-empty slot (ordered A, B), each named `{project_name}_config_{slot}_{state}.yaml`. Slots without content are skipped.

Example: `my-project_config.zip` → `my-project_config_A_draft.yaml`, `my-project_config_B_served.yaml`

**Errors:**
- `404` — project does not exist
- `400` — no slot has content to export

> Routing note: `configs/export` (static, 2 segments) and `configs/{config_uuid}/export` (3 segments) are distinct paths — no ambiguity.

---

## Other Changes

- `services/project_service.py`
  - `export_config(project_uuid, config_uuid) -> (bytes, filename)` — reworked to the new naming scheme (`{project_name}_config.zip` / `{project_name}_config_{slot}_{state}.yaml`).
  - `export_all_configs(project_uuid) -> (bytes, filename)` **NEW** — builds a ZIP with one YAML per non-empty slot; raises `400` if none have content.
  - `_config_entry_name(project_name, config)` **NEW** — shared helper producing the inner YAML entry name (`{project_name}_config_{slot}_{state}`); reused by both export methods.
  - `_sanitize_filename(name)` — sanitizes names to `[A-Za-z0-9_-]` (other chars → `_`). ZIP is built in memory via `io.BytesIO` + `zipfile.ZipFile` (`ZIP_DEFLATED`), no disk writes.
- `routes/project_route.py` — added the two `GET .../export` routes (single slot + all slots).
- `tests/services/project_service_test.py` — coverage: single slot zip, both slots, served/draft label, skip empty slot, 400 when empty, 404 when missing.
- `tests/routes/test_project_route.py` — coverage: response headers/content for both endpoints, 404 and 400 error mapping.
