### PR TITLE
feat: add secret validation

### DIFF
--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -139,6 +139,8 @@ class ProjectService:
                 f'Config {config_uuid} must be approved before serving'
             )
 
+        validate_gateway_config(config.config_file, check_secrets=True)
+
         served = self.project_config_dao.serve(config_uuid)
         if served is None:
             raise ProjectInternalError(

--- a/gateway/radicalbit_ai_gateway/utils/secrets.py
+++ b/gateway/radicalbit_ai_gateway/utils/secrets.py
@@ -13,6 +13,20 @@ class SecretProvider(ABC):
         """Resolve a secret by key. Raises SecretNotFoundError if unavailable."""
         ...
 
+    def validate_secret(self, key: str) -> str | None:
+        """Check that *key* exists and has a non-empty value.
+
+        Returns ``None`` when valid, or a short error description otherwise.
+        The actual secret value is never exposed.
+        """
+        try:
+            value = self.get_secret(key)
+        except SecretNotFoundError:
+            return 'not found'
+        if value is None or str(value).strip() == '':
+            return 'has an empty value'
+        return None
+
 
 class FileSecretProvider(SecretProvider):
     def __init__(self, secrets_path: str | Path):

--- a/gateway/radicalbit_ai_gateway/utils/secrets.py
+++ b/gateway/radicalbit_ai_gateway/utils/secrets.py
@@ -23,7 +23,7 @@ class SecretProvider(ABC):
             value = self.get_secret(key)
         except SecretNotFoundError:
             return 'not found'
-        if value is None or str(value).strip() == '':
+        if not str(value).strip():
             return 'has an empty value'
         return None
 

--- a/gateway/radicalbit_ai_gateway/utils/secrets.py
+++ b/gateway/radicalbit_ai_gateway/utils/secrets.py
@@ -78,7 +78,10 @@ def resolve_secrets_from_string(
 
     def secret_constructor(loader, node):
         key = loader.construct_scalar(node)
-        return provider.get_secret(key)
+        value = provider.get_secret(key)
+        if not str(value).strip():
+            raise SecretNotFoundError(key, 'value is empty')
+        return value
 
     loader = yaml.SafeLoader(yaml_content)
     loader.add_constructor('!secret', secret_constructor)

--- a/gateway/radicalbit_ai_gateway/utils/yaml_utils.py
+++ b/gateway/radicalbit_ai_gateway/utils/yaml_utils.py
@@ -63,61 +63,72 @@ def check_no_literal_secrets(yaml_content: str) -> list[str]:
     return violations
 
 
-def extract_secret_references(yaml_content: str) -> list[tuple[str, int | None]]:
-    """Return ``(key, line_number)`` for every ``!secret KEY`` in *yaml_content*."""
+def _parse_yaml_with_secrets(
+    yaml_content: str,
+) -> tuple[dict, list[tuple[str, int | None]]]:
+    """Parse *yaml_content*, replacing ``!secret`` tags with placeholders.
+
+    Returns ``(parsed_dict, secret_refs)`` where *secret_refs* is a list of
+    ``(key, line_number)`` for every ``!secret`` reference found.
+    """
     refs: list[tuple[str, int | None]] = []
     loader = yaml.SafeLoader(yaml_content)
 
-    def _collector(loader, node):
+    def secret_constructor(loader, node):
         key = loader.construct_scalar(node)
         line = node.start_mark.line + 1 if node.start_mark else None
         refs.append((key, line))
         return '__secret_placeholder__'
 
-    loader.add_constructor('!secret', _collector)
+    loader.add_constructor('!secret', secret_constructor)
     try:
-        loader.get_single_data()
+        data = loader.get_single_data()
     finally:
         loader.dispose()
+    return data, refs
+
+
+def extract_secret_references(yaml_content: str) -> list[tuple[str, int | None]]:
+    """Return ``(key, line_number)`` for every ``!secret KEY`` in *yaml_content*."""
+    _, refs = _parse_yaml_with_secrets(yaml_content)
     return refs
 
 
-def check_secret_references(yaml_content: str) -> list[str]:
+def check_secret_references(
+    yaml_content: str,
+    *,
+    _refs: list[tuple[str, int | None]] | None = None,
+) -> list[str]:
     """Validate that every ``!secret`` reference points to an existing,
     non-empty key in ``secrets.yaml``.
 
     Returns a (possibly empty) list of human-readable violation strings.
     """
-    refs = extract_secret_references(yaml_content)
+    refs = _refs if _refs is not None else extract_secret_references(yaml_content)
     if not refs:
         return []
 
     provider = get_secret_provider()
     violations: list[str] = []
-    for key, line in refs:
-        error = provider.validate_secret(key)
-        if error:
-            loc = f'line {line}: ' if line else ''
-            violations.append(f'{loc}!secret {key} - {error}')
+    try:
+        for key, line in refs:
+            error = provider.validate_secret(key)
+            if error:
+                loc = f'line {line}: ' if line else ''
+                violations.append(f'{loc}!secret {key} - {error}')
+    except OSError as e:
+        return [f'Cannot read secrets file: {e}']
     return violations
 
 
 def parse_yaml_with_secret_placeholders(yaml_content: str) -> dict:
-    loader = yaml.SafeLoader(yaml_content)
-
-    def secret_constructor(loader, node):
-        return '__secret_placeholder__'
-
-    loader.add_constructor('!secret', secret_constructor)
-    try:
-        return loader.get_single_data()
-    finally:
-        loader.dispose()
+    data, _ = _parse_yaml_with_secrets(yaml_content)
+    return data
 
 
 def validate_gateway_config(yaml_str: str, *, check_secrets: bool) -> str:
     try:
-        parsed = parse_yaml_with_secret_placeholders(yaml_str)
+        parsed, secret_refs = _parse_yaml_with_secrets(yaml_str)
     except yaml.YAMLError as e:
         mark = getattr(e, 'problem_mark', None)
         location = f' (line {mark.line + 1}, column {mark.column + 1})' if mark else ''
@@ -129,7 +140,7 @@ def validate_gateway_config(yaml_str: str, *, check_secrets: bool) -> str:
             raise ProjectConfigValidationError(
                 f'Config contains literal secrets: {violations}. Use !secret references instead.'
             )
-        secret_violations = check_secret_references(yaml_str)
+        secret_violations = check_secret_references(yaml_str, _refs=secret_refs)
         if secret_violations:
             raise ProjectConfigValidationError(
                 f'Config references invalid secrets: {"; ".join(secret_violations)}. '

--- a/gateway/radicalbit_ai_gateway/utils/yaml_utils.py
+++ b/gateway/radicalbit_ai_gateway/utils/yaml_utils.py
@@ -3,11 +3,13 @@ from importlib.resources import files
 import re
 
 from pydantic import ValidationError
+from pydantic_core import ErrorDetails
 import yaml
 
 from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 from radicalbit_ai_gateway.models.gateway_route_config import GatewayRouteConfig
 from radicalbit_ai_gateway.utils.exceptions import ProjectConfigValidationError
+from radicalbit_ai_gateway.utils.secrets import get_secret_provider
 
 _KNOWN_CONFIG_FIELDS = sorted(
     set(GatewayConfig.model_fields) | set(GatewayRouteConfig.model_fields)
@@ -28,7 +30,7 @@ def _find_key_line(yaml_str: str, key: str) -> int | None:
     return None
 
 
-def _format_validation_error(err: dict, yaml_str: str) -> str:
+def _format_validation_error(err: ErrorDetails, yaml_str: str) -> str:
     loc = '.'.join(str(p) for p in err['loc'])
     msg = err['msg']
     if err['type'] == 'extra_forbidden' and err['loc']:
@@ -61,6 +63,45 @@ def check_no_literal_secrets(yaml_content: str) -> list[str]:
     return violations
 
 
+def extract_secret_references(yaml_content: str) -> list[tuple[str, int | None]]:
+    """Return ``(key, line_number)`` for every ``!secret KEY`` in *yaml_content*."""
+    refs: list[tuple[str, int | None]] = []
+    loader = yaml.SafeLoader(yaml_content)
+
+    def _collector(loader, node):
+        key = loader.construct_scalar(node)
+        line = node.start_mark.line + 1 if node.start_mark else None
+        refs.append((key, line))
+        return '__secret_placeholder__'
+
+    loader.add_constructor('!secret', _collector)
+    try:
+        loader.get_single_data()
+    finally:
+        loader.dispose()
+    return refs
+
+
+def check_secret_references(yaml_content: str) -> list[str]:
+    """Validate that every ``!secret`` reference points to an existing,
+    non-empty key in ``secrets.yaml``.
+
+    Returns a (possibly empty) list of human-readable violation strings.
+    """
+    refs = extract_secret_references(yaml_content)
+    if not refs:
+        return []
+
+    provider = get_secret_provider()
+    violations: list[str] = []
+    for key, line in refs:
+        error = provider.validate_secret(key)
+        if error:
+            loc = f'line {line}: ' if line else ''
+            violations.append(f'{loc}!secret {key} - {error}')
+    return violations
+
+
 def parse_yaml_with_secret_placeholders(yaml_content: str) -> dict:
     loader = yaml.SafeLoader(yaml_content)
 
@@ -88,6 +129,12 @@ def validate_gateway_config(yaml_str: str, *, check_secrets: bool) -> str:
             raise ProjectConfigValidationError(
                 f'Config contains literal secrets: {violations}. Use !secret references instead.'
             )
+        secret_violations = check_secret_references(yaml_str)
+        if secret_violations:
+            raise ProjectConfigValidationError(
+                f'Config references invalid secrets: {"; ".join(secret_violations)}. '
+                'Ensure all !secret keys exist and have non-empty values.'
+            )
     try:
         GatewayConfig.model_validate(parsed)
     except (ValidationError, KeyError, TypeError) as e:
@@ -96,7 +143,7 @@ def validate_gateway_config(yaml_str: str, *, check_secrets: bool) -> str:
                 _format_validation_error(err, yaml_str) for err in e.errors()
             )
             raise ProjectConfigValidationError(
-                f'Invalid gateway configuration — {len(e.errors())} error(s): {details}'
+                f'Invalid gateway configuration - {len(e.errors())} error(s): {details}'
             ) from e
         raise ProjectConfigValidationError(f'Invalid gateway configuration: {e}') from e
     return yaml_str

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -217,3 +217,31 @@ class TestProjectRoute(unittest.TestCase):
         res = self.client.delete(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
         self.deregister.assert_not_awaited()
+
+    # --- route_meta ---
+
+    def _get_endpoint(self, path_suffix: str, method: str = 'PATCH') -> object:
+        """Return the endpoint function for a given path suffix and method."""
+        for route in self.client.app.routes:
+            if hasattr(route, 'path') and route.path.endswith(path_suffix):
+                if method.upper() in getattr(route, 'methods', set()):
+                    return route.endpoint
+        msg = f'No route found for {method} ...{path_suffix}'
+        raise AssertionError(msg)
+
+    def test_config_mutation_routes_have_entity_uuid_param(self):
+        config_routes = [
+            ('configs/{config_uuid}', 'PATCH'),
+            ('configs/{config_uuid}/approve', 'PATCH'),
+            ('configs/{config_uuid}/cancel-approval', 'PATCH'),
+            ('configs/{config_uuid}/serve', 'PATCH'),
+            ('configs/{config_uuid}/unserve', 'PATCH'),
+            ('configs/{config_uuid}/generate-config', 'POST'),
+        ]
+        for path_suffix, method in config_routes:
+            endpoint = self._get_endpoint(path_suffix, method)
+            meta = getattr(endpoint, '_route_meta', None)
+            assert meta is not None, f'{path_suffix} missing _route_meta'
+            assert meta.get('entity_uuid_param') == 'project_uuid', (
+                f'{path_suffix} missing entity_uuid_param'
+            )

--- a/gateway/tests/test_route_meta.py
+++ b/gateway/tests/test_route_meta.py
@@ -21,6 +21,20 @@ def test_returns_same_function_object():
     assert wrapped is original
 
 
+def test_entity_uuid_param():
+    @route_meta(
+        entity_type='PROJECT',
+        entity_uuid_param='project_uuid',
+    )
+    def handler():
+        pass
+
+    assert handler._route_meta == {
+        'entity_type': 'PROJECT',
+        'entity_uuid_param': 'project_uuid',
+    }
+
+
 def test_empty_kwargs():
     @route_meta()
     def handler():

--- a/gateway/tests/test_secrets.py
+++ b/gateway/tests/test_secrets.py
@@ -158,3 +158,38 @@ def test_resolve_secrets_from_string_missing_secret_raises(secrets_path):
     )
     with pytest.raises(Exception, match='NONEXISTENT_KEY'):
         resolve_secrets_from_string(yaml_with_unknown, provider=provider)
+
+
+# --- validate_secret tests ---
+
+
+def test_validate_secret_returns_none_for_valid_key(secrets_path):
+    provider = FileSecretProvider(secrets_path)
+    assert provider.validate_secret('OPENAI_API_KEY') is None
+
+
+def test_validate_secret_returns_error_for_missing_key(secrets_path):
+    provider = FileSecretProvider(secrets_path)
+    error = provider.validate_secret('NONEXISTENT')
+    assert error is not None
+    assert 'not found' in error
+
+
+def test_validate_secret_returns_error_for_empty_value():
+    with tempfile.NamedTemporaryFile('w+', suffix='.yaml', delete=False) as f:
+        f.write('EMPTY_SECRET: ""\n')
+        f.flush()
+        provider = FileSecretProvider(f.name)
+        error = provider.validate_secret('EMPTY_SECRET')
+        assert error is not None
+        assert 'empty' in error
+
+
+def test_validate_secret_returns_error_for_whitespace_only_value():
+    with tempfile.NamedTemporaryFile('w+', suffix='.yaml', delete=False) as f:
+        f.write('BLANK_SECRET: "   "\n')
+        f.flush()
+        provider = FileSecretProvider(f.name)
+        error = provider.validate_secret('BLANK_SECRET')
+        assert error is not None
+        assert 'empty' in error

--- a/gateway/tests/utils/test_yaml_utils.py
+++ b/gateway/tests/utils/test_yaml_utils.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from radicalbit_ai_gateway.utils.app_config import get_app_config

--- a/gateway/tests/utils/test_yaml_utils.py
+++ b/gateway/tests/utils/test_yaml_utils.py
@@ -1,8 +1,12 @@
+
 import pytest
 
+from radicalbit_ai_gateway.utils.app_config import get_app_config
 from radicalbit_ai_gateway.utils.exceptions import ProjectConfigValidationError
 from radicalbit_ai_gateway.utils.yaml_utils import (
     check_no_literal_secrets,
+    check_secret_references,
+    extract_secret_references,
     parse_yaml_with_secret_placeholders,
     validate_gateway_config,
 )
@@ -132,3 +136,136 @@ def test_validate_gateway_config_extra_field_includes_line():
     with pytest.raises(ProjectConfigValidationError) as exc_info:
         validate_gateway_config(yaml_with_typo, check_secrets=False)
     assert "'rout' (line 6)" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# extract_secret_references
+# ---------------------------------------------------------------------------
+
+
+def test_extract_secret_references_finds_keys_with_lines():
+    yaml_content = (
+        'chat_models:\n'
+        '  - model_id: m1\n'
+        '    credentials:\n'
+        '      api_key: !secret MY_KEY\n'
+        'cache:\n'
+        '  redis_host: !secret REDIS_HOST\n'
+    )
+    refs = extract_secret_references(yaml_content)
+    keys = {k for k, _ in refs}
+    assert keys == {'MY_KEY', 'REDIS_HOST'}
+    assert all(line is not None for _, line in refs)
+
+
+def test_extract_secret_references_returns_empty_for_no_secrets():
+    yaml_content = 'chat_models:\n  - model_id: m1\nroutes: {}\n'
+    assert extract_secret_references(yaml_content) == []
+
+
+# ---------------------------------------------------------------------------
+# check_secret_references
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _secrets_file_with_empty(tmp_path):
+    """Point the app config at a secrets file that has a valid key,
+    an empty key, and is missing other keys.
+    """
+    secrets = tmp_path / 'secrets.yaml'
+    secrets.write_text('VALID_KEY: some-value\nEMPTY_KEY: ""\n')
+    original = get_app_config().gateway_secrets_path
+    get_app_config().gateway_secrets_path = secrets
+    yield
+    get_app_config().gateway_secrets_path = original
+
+
+@pytest.mark.usefixtures('_secrets_file_with_empty')
+def test_check_secret_references_valid():
+    yaml_content = 'value: !secret VALID_KEY\n'
+    assert check_secret_references(yaml_content) == []
+
+
+@pytest.mark.usefixtures('_secrets_file_with_empty')
+def test_check_secret_references_missing_key():
+    yaml_content = 'value: !secret NONEXISTENT\n'
+    violations = check_secret_references(yaml_content)
+    assert len(violations) == 1
+    assert 'NONEXISTENT' in violations[0]
+    assert 'not found' in violations[0]
+
+
+@pytest.mark.usefixtures('_secrets_file_with_empty')
+def test_check_secret_references_empty_value():
+    yaml_content = 'value: !secret EMPTY_KEY\n'
+    violations = check_secret_references(yaml_content)
+    assert len(violations) == 1
+    assert 'EMPTY_KEY' in violations[0]
+    assert 'empty' in violations[0]
+
+
+@pytest.mark.usefixtures('_secrets_file_with_empty')
+def test_check_secret_references_multiple_violations():
+    yaml_content = (
+        'a: !secret NONEXISTENT\nb: !secret EMPTY_KEY\nc: !secret VALID_KEY\n'
+    )
+    violations = check_secret_references(yaml_content)
+    assert len(violations) == 2
+
+
+# ---------------------------------------------------------------------------
+# validate_gateway_config — secret reference validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures('_secrets_file_with_empty')
+def test_validate_gateway_config_rejects_missing_secret():
+    yaml_str = (
+        'chat_models:\n'
+        '  - model_id: m1\n'
+        '    model: openai/gpt-4o-mini\n'
+        '    credentials:\n'
+        '      api_key: !secret NONEXISTENT\n'
+        'routes:\n'
+        '  default-route:\n'
+        '    chat_models: [m1]\n'
+    )
+    with pytest.raises(ProjectConfigValidationError) as exc_info:
+        validate_gateway_config(yaml_str, check_secrets=True)
+    assert 'NONEXISTENT' in str(exc_info.value)
+    assert 'not found' in str(exc_info.value)
+
+
+@pytest.mark.usefixtures('_secrets_file_with_empty')
+def test_validate_gateway_config_rejects_empty_secret():
+    yaml_str = (
+        'chat_models:\n'
+        '  - model_id: m1\n'
+        '    model: openai/gpt-4o-mini\n'
+        '    credentials:\n'
+        '      api_key: !secret EMPTY_KEY\n'
+        'routes:\n'
+        '  default-route:\n'
+        '    chat_models: [m1]\n'
+    )
+    with pytest.raises(ProjectConfigValidationError) as exc_info:
+        validate_gateway_config(yaml_str, check_secrets=True)
+    assert 'EMPTY_KEY' in str(exc_info.value)
+    assert 'empty' in str(exc_info.value)
+
+
+@pytest.mark.usefixtures('_secrets_file_with_empty')
+def test_validate_gateway_config_skips_secret_check_when_disabled():
+    yaml_str = (
+        'chat_models:\n'
+        '  - model_id: m1\n'
+        '    model: openai/gpt-4o-mini\n'
+        '    credentials:\n'
+        '      api_key: !secret NONEXISTENT\n'
+        'routes:\n'
+        '  default-route:\n'
+        '    chat_models: [m1]\n'
+    )
+    # Should NOT raise — secret validation is off
+    validate_gateway_config(yaml_str, check_secrets=False)


### PR DESCRIPTION
## Summary

Add validation that every `!secret` reference in gateway YAML configs resolves to an existing, non-empty key in `secrets.yaml`, catching misconfiguration at config-validation time rather than at request time.

## Description

Previously, a typo in a `!secret KEY` reference or a missing entry in `secrets.yaml` would only surface when the gateway attempted to use the secret at runtime. This PR adds an early validation step inside `validate_gateway_config` that extracts all `!secret` references from the YAML, resolves each one against the configured `SecretProvider`, and rejects configs where keys are missing or have empty/whitespace-only values. The YAML parsing for secret extraction and placeholder replacement is consolidated into a single pass (`_parse_yaml_with_secrets`) to avoid redundant work, and `OSError` is caught gracefully so a missing secrets file produces a clear validation error instead of an unhandled 500.

## Key Changes

- **`gateway/radicalbit_ai_gateway/utils/secrets.py`**: Added `validate_secret()` method on the `SecretProvider` ABC that checks key existence and non-emptiness without exposing the secret value.
- **`gateway/radicalbit_ai_gateway/utils/yaml_utils.py`**: Introduced `_parse_yaml_with_secrets()` as a single-pass YAML parser that returns both the placeholder dict and `(key, line)` references. `parse_yaml_with_secret_placeholders` and `extract_secret_references` are thin wrappers over it. Added `check_secret_references()` to validate all `!secret` refs with `OSError` handling for missing secrets files. Wired the check into `validate_gateway_config` when `check_secrets=True`.
- **`gateway/radicalbit_ai_gateway/utils/yaml_utils.py`**: Narrowed `_format_validation_error` type annotation from `dict` to `ErrorDetails` for correctness.
- **`gateway/tests/test_secrets.py`**: Added tests for `validate_secret` covering valid keys, missing keys, empty values, and whitespace-only values.
- **`gateway/tests/utils/test_yaml_utils.py`**: Added tests for `extract_secret_references`, `check_secret_references` (valid, missing, empty, multiple violations), and `validate_gateway_config` integration (rejects missing/empty secrets, skips check when disabled).
- **`gateway/tests/test_route_meta.py`**: Added test for `entity_uuid_param` in `route_meta` decorator.
- **`gateway/tests/routes/test_project_route.py`**: Added test asserting all config-mutation routes carry the `entity_uuid_param` route metadata.


## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
