### PR TITLE
feat: add extension

### DIFF
--- a/gateway/radicalbit_ai_gateway/models/gateway_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config.py
@@ -20,6 +20,7 @@ from radicalbit_ai_gateway.models.routing import (
     RoutingRuleType,
     SemanticRoutingConfig,
 )
+from radicalbit_ai_gateway.utils.config_hooks import get_extension_validators
 
 
 def get_model_from_model_id(
@@ -316,4 +317,24 @@ class GatewayConfig(BaseModel):
                     f"Route '{route_name}': budget routing requires budget_limiting to be configured."
                 )
 
+        return self
+
+    @model_validator(mode='after')
+    def validate_route_extensions(self) -> Self:
+        """Run registered plugin validators against each route's ``extension``.
+
+        Plugins register validators via
+        ``radicalbit_ai_gateway.utils.config_hooks.register_extension_validator``.
+        A validator raises ValueError on invalid config, which surfaces as a
+        normal config validation error. Validation runs once here at config-load
+        time rather than on every ``GatewayRouteConfig`` construction.
+        """
+        validators = get_extension_validators()
+        if not validators:
+            return self
+        for route in self.routes.values():
+            if not route.extension:
+                continue
+            for validate in validators:
+                validate(route.extension)
         return self

--- a/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
@@ -203,7 +203,6 @@ class GatewayRouteConfigOut(GatewayRouteConfig):
     guardrails: list[GuardrailOut] | None
     caching: AnyCachingOut | None
     routing: AnyRoutingConfigOut | None
-    extension: dict | None
 
     model_config = ConfigDict(
         populate_by_name=True, alias_generator=to_camel, protected_namespaces=()

--- a/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
@@ -203,6 +203,7 @@ class GatewayRouteConfigOut(GatewayRouteConfig):
     guardrails: list[GuardrailOut] | None
     caching: AnyCachingOut | None
     routing: AnyRoutingConfigOut | None
+    extension: dict | None
 
     model_config = ConfigDict(
         populate_by_name=True, alias_generator=to_camel, protected_namespaces=()

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -1,4 +1,9 @@
-from pydantic import BaseModel, ConfigDict, Field
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from radicalbit_ai_gateway.limiting.budget_limiting import BudgetLimiter
 from radicalbit_ai_gateway.limiting.rate_limiter import RequestRateLimiter
@@ -10,6 +15,7 @@ from radicalbit_ai_gateway.models.limiting import (
     RateLimiting,
     TokenLimiting,
 )
+from radicalbit_ai_gateway.utils.config_hooks import get_extension_validators
 
 
 class GatewayRouteConfig(BaseModel):
@@ -57,6 +63,29 @@ class GatewayRouteConfig(BaseModel):
         default=None,
         description='Name of a top-level routing config.',
     )
+    extension: dict | None = Field(
+        default=None,
+        description=(
+            'Free-form configuration consumed by enterprise plugins/extensions. '
+            'Opaque to the core gateway, which never reads or interprets it; '
+            'enabled plugins validate their own keys.'
+        ),
+    )
+
+    @model_validator(mode='after')
+    def run_extension_validators(self) -> Self:
+        """Run registered plugin validators against ``extension``.
+
+        Plugins register validators via
+        ``radicalbit_ai_gateway.utils.config_hooks.register_extension_validator``.
+        A validator raises ValueError on invalid config, which surfaces as a
+        normal config validation error.
+        """
+        if not self.extension:
+            return self
+        for validate in get_extension_validators():
+            validate(self.extension)
+        return self
 
     def get_token_limiter(self) -> TokenLimiter:
         return TokenLimiter(

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -59,9 +59,7 @@ class GatewayRouteConfig(BaseModel):
     )
     extension: dict | None = Field(
         default=None,
-        description=(
-            'Extension configuration for the route.'
-        ),
+        description=('Extension configuration for the route.'),
     )
 
     def get_token_limiter(self) -> TokenLimiter:

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -1,9 +1,4 @@
-try:
-    from typing import Self
-except ImportError:
-    from typing_extensions import Self
-
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from radicalbit_ai_gateway.limiting.budget_limiting import BudgetLimiter
 from radicalbit_ai_gateway.limiting.rate_limiter import RequestRateLimiter
@@ -15,7 +10,6 @@ from radicalbit_ai_gateway.models.limiting import (
     RateLimiting,
     TokenLimiting,
 )
-from radicalbit_ai_gateway.utils.config_hooks import get_extension_validators
 
 
 class GatewayRouteConfig(BaseModel):
@@ -66,26 +60,9 @@ class GatewayRouteConfig(BaseModel):
     extension: dict | None = Field(
         default=None,
         description=(
-            'Free-form configuration consumed by enterprise plugins/extensions. '
-            'Opaque to the core gateway, which never reads or interprets it; '
-            'enabled plugins validate their own keys.'
+            'Extension configuration for the route.'
         ),
     )
-
-    @model_validator(mode='after')
-    def run_extension_validators(self) -> Self:
-        """Run registered plugin validators against ``extension``.
-
-        Plugins register validators via
-        ``radicalbit_ai_gateway.utils.config_hooks.register_extension_validator``.
-        A validator raises ValueError on invalid config, which surfaces as a
-        normal config validation error.
-        """
-        if not self.extension:
-            return self
-        for validate in get_extension_validators():
-            validate(self.extension)
-        return self
 
     def get_token_limiter(self) -> TokenLimiter:
         return TokenLimiter(

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -92,7 +92,6 @@ from radicalbit_ai_gateway.utils.exceptions import (
     unhandled_exception_handler,
 )
 from radicalbit_ai_gateway.utils.filtering_exporter import FilteringExporter
-from radicalbit_ai_gateway.utils.telemetry_hooks import get_exporter_wrappers
 from radicalbit_ai_gateway.utils.gateway_route_factory import (
     build_project_route_registrar,
 )
@@ -114,6 +113,7 @@ from radicalbit_ai_gateway.utils.responses_translation import (
 from radicalbit_ai_gateway.utils.streaming_response import (
     StreamingResponseWithStatusCode,
 )
+from radicalbit_ai_gateway.utils.telemetry_hooks import get_exporter_wrappers
 from radicalbit_ai_gateway.utils.trace_attributes import (
     OperationCategory,
     ensure_endpoint_category,

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -92,6 +92,7 @@ from radicalbit_ai_gateway.utils.exceptions import (
     unhandled_exception_handler,
 )
 from radicalbit_ai_gateway.utils.filtering_exporter import FilteringExporter
+from radicalbit_ai_gateway.utils.telemetry_hooks import get_exporter_wrappers
 from radicalbit_ai_gateway.utils.gateway_route_factory import (
     build_project_route_registrar,
 )
@@ -246,17 +247,14 @@ async def lifespan(app: FastAPI):
 
     processors = []
 
+    def _build_processor(exporter: OTLPSpanExporter) -> BatchSpanProcessor:
+        for wrap in get_exporter_wrappers():
+            exporter = wrap(exporter)
+        return BatchSpanProcessor(FilteringExporter(exporter))
+
     if app_config.telemetry_config.collector_base_url:
         endpoint = _otlp_endpoint(app_config.telemetry_config.collector_base_url)
-        processors.append(
-            BatchSpanProcessor(
-                FilteringExporter(
-                    OTLPSpanExporter(
-                        endpoint=endpoint,
-                    )
-                )
-            )
-        )
+        processors.append(_build_processor(OTLPSpanExporter(endpoint=endpoint)))
         logger.info('Configured otel-collector for url: %s', endpoint)
 
     for exp_cfg in app_config.telemetry_config.otlp_exporters:
@@ -265,14 +263,7 @@ async def lifespan(app: FastAPI):
             headers['Authorization'] = f'Bearer {exp_cfg.api_key}'
         endpoint = _otlp_endpoint(exp_cfg.url)
         processors.append(
-            BatchSpanProcessor(
-                FilteringExporter(
-                    OTLPSpanExporter(
-                        endpoint=endpoint,
-                        headers=headers,
-                    )
-                )
-            )
+            _build_processor(OTLPSpanExporter(endpoint=endpoint, headers=headers))
         )
         logger.info('Configured extra processor for url: %s', endpoint)
 

--- a/gateway/radicalbit_ai_gateway/utils/config_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/config_hooks.py
@@ -1,15 +1,3 @@
-"""Generic registry for validating the route ``extension`` config.
-
-A route's ``extension`` map is opaque to the core gateway. Plugins register a
-validator at init time; ``GatewayRouteConfig`` runs every registered validator
-against a route's ``extension`` during validation, so malformed plugin config is
-rejected with the rest of the gateway config. The core carries no knowledge of
-what the validators check.
-
-A validator receives the route's ``extension`` value and must raise
-``ValueError`` if it is invalid.
-"""
-
 from collections.abc import Callable
 
 _extension_validators: list[Callable[[object], None]] = []

--- a/gateway/radicalbit_ai_gateway/utils/config_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/config_hooks.py
@@ -1,0 +1,25 @@
+"""Generic registry for validating the route ``extension`` config.
+
+A route's ``extension`` map is opaque to the core gateway. Plugins register a
+validator at init time; ``GatewayRouteConfig`` runs every registered validator
+against a route's ``extension`` during validation, so malformed plugin config is
+rejected with the rest of the gateway config. The core carries no knowledge of
+what the validators check.
+
+A validator receives the route's ``extension`` value and must raise
+``ValueError`` if it is invalid.
+"""
+
+from collections.abc import Callable
+
+_extension_validators: list[Callable[[object], None]] = []
+
+
+def register_extension_validator(validate: Callable[[object], None]) -> None:
+    """Register a validator for a route's ``extension`` config."""
+    _extension_validators.append(validate)
+
+
+def get_extension_validators() -> list[Callable[[object], None]]:
+    """Return the registered extension validators, in registration order."""
+    return list(_extension_validators)

--- a/gateway/radicalbit_ai_gateway/utils/filtering_exporter/exporter.py
+++ b/gateway/radicalbit_ai_gateway/utils/filtering_exporter/exporter.py
@@ -50,7 +50,7 @@ class FilteringExporter(SpanExporter):
 
     def __init__(self, wrapped: SpanExporter):
         self._wrapped = wrapped
-        self._remap: dict[int, int] = FIFOCache(maxsize=_REMAP_CACHE_SIZE)
+        self._remap: FIFOCache[int, int] = FIFOCache(maxsize=_REMAP_CACHE_SIZE)
 
     # ------------------------------------------------------------------
     # Phase helpers — each handles one step of the export pipeline

--- a/gateway/radicalbit_ai_gateway/utils/telemetry_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/telemetry_hooks.py
@@ -1,10 +1,3 @@
-"""Generic registry for wrapping the OTLP span exporter at startup.
-
-Plugins register a wrapper at import time; ``lifespan`` applies the registered
-wrappers around each ``OTLPSpanExporter`` when it builds the span processors.
-The core carries no knowledge of what the wrappers do.
-"""
-
 from collections.abc import Callable
 
 from opentelemetry.sdk.trace.export import SpanExporter

--- a/gateway/radicalbit_ai_gateway/utils/telemetry_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/telemetry_hooks.py
@@ -1,0 +1,22 @@
+"""Generic registry for wrapping the OTLP span exporter at startup.
+
+Plugins register a wrapper at import time; ``lifespan`` applies the registered
+wrappers around each ``OTLPSpanExporter`` when it builds the span processors.
+The core carries no knowledge of what the wrappers do.
+"""
+
+from collections.abc import Callable
+
+from opentelemetry.sdk.trace.export import SpanExporter
+
+_exporter_wrappers: list[Callable[[SpanExporter], SpanExporter]] = []
+
+
+def register_exporter_wrapper(fn: Callable[[SpanExporter], SpanExporter]) -> None:
+    """Register a callable that wraps (and returns) a span exporter."""
+    _exporter_wrappers.append(fn)
+
+
+def get_exporter_wrappers() -> list[Callable[[SpanExporter], SpanExporter]]:
+    """Return the registered exporter wrappers, in registration order."""
+    return list(_exporter_wrappers)

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -15,7 +15,8 @@ def _clean_registry():
 def _config(extension):
     """Build a config the way it is loaded in production: validation of a
     route's ``extension`` happens at GatewayConfig load time, not on bare
-    GatewayRouteConfig construction."""
+    GatewayRouteConfig construction.
+    """
     return GatewayConfig(
         chat_models=[{'model_id': 'm', 'model': 'openai/gpt-4o'}],
         routes={'r': {'chat_models': ['m'], 'extension': extension}},

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -1,0 +1,44 @@
+import pytest
+
+from radicalbit_ai_gateway.models.gateway_route_config import GatewayRouteConfig
+from radicalbit_ai_gateway.utils import config_hooks
+from radicalbit_ai_gateway.utils.config_hooks import register_extension_validator
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    config_hooks._extension_validators.clear()
+    yield
+    config_hooks._extension_validators.clear()
+
+
+def _route(extension):
+    return GatewayRouteConfig(
+        route_name='r', chat_models=['m'], extension=extension
+    )
+
+
+def test_registered_validator_receives_extension():
+    seen = []
+    register_extension_validator(seen.append)
+
+    _route({'privacy_tracing_enabled': True})
+
+    assert seen == [{'privacy_tracing_enabled': True}]
+
+
+def test_validator_error_fails_config_validation():
+    def validate(extension):
+        raise ValueError('bad plugin config')
+
+    register_extension_validator(validate)
+
+    with pytest.raises(Exception) as exc_info:
+        _route({'whatever': 1})
+    assert 'bad plugin config' in str(exc_info.value)
+
+
+def test_no_extension_is_a_noop():
+    register_extension_validator(lambda extension: 1 / 0)
+
+    _route(None)

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from radicalbit_ai_gateway.models.gateway_route_config import GatewayRouteConfig
+from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 from radicalbit_ai_gateway.utils import config_hooks
 from radicalbit_ai_gateway.utils.config_hooks import register_extension_validator
 
@@ -12,15 +12,21 @@ def _clean_registry():
     config_hooks._extension_validators.clear()
 
 
-def _route(extension):
-    return GatewayRouteConfig(route_name='r', chat_models=['m'], extension=extension)
+def _config(extension):
+    """Build a config the way it is loaded in production: validation of a
+    route's ``extension`` happens at GatewayConfig load time, not on bare
+    GatewayRouteConfig construction."""
+    return GatewayConfig(
+        chat_models=[{'model_id': 'm', 'model': 'openai/gpt-4o'}],
+        routes={'r': {'chat_models': ['m'], 'extension': extension}},
+    )
 
 
 def test_registered_validator_receives_extension():
     seen = []
     register_extension_validator(seen.append)
 
-    _route({'fake_enabled': True})
+    _config({'fake_enabled': True})
 
     assert seen == [{'fake_enabled': True}]
 
@@ -32,11 +38,11 @@ def test_validator_error_fails_config_validation():
     register_extension_validator(validate)
 
     with pytest.raises(Exception) as exc_info:
-        _route({'whatever': 1})
+        _config({'whatever': 1})
     assert 'bad plugin config' in str(exc_info.value)
 
 
 def test_no_extension_is_a_noop():
     register_extension_validator(lambda extension: 1 / 0)
 
-    _route(None)
+    _config(None)

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -13,18 +13,16 @@ def _clean_registry():
 
 
 def _route(extension):
-    return GatewayRouteConfig(
-        route_name='r', chat_models=['m'], extension=extension
-    )
+    return GatewayRouteConfig(route_name='r', chat_models=['m'], extension=extension)
 
 
 def test_registered_validator_receives_extension():
     seen = []
     register_extension_validator(seen.append)
 
-    _route({'privacy_tracing_enabled': True})
+    _route({'fake_enabled': True})
 
-    assert seen == [{'privacy_tracing_enabled': True}]
+    assert seen == [{'fake_enabled': True}]
 
 
 def test_validator_error_fails_config_validation():


### PR DESCRIPTION
## Summary

Adds two extension points for hooking into the gateway without touching core logic: a per-route, free-form `extension` config block validated by registered validators at config-load time, and a span-exporter wrapper registry for the telemetry pipeline.

## Description

Two module-level registries (`config_hooks`, `telemetry_hooks`) expose `register_*`/`get_*` functions that callers wire up at import time. The `extension` field is opaque to the core; its registered validators run **once in `GatewayConfig`'s after-validator at load time**, not on every `GatewayRouteConfig` construction — avoiding re-validation on the per-request `GatewayRouteConfigOut` path. Telemetry exporters are funneled through a single `_build_processor` helper that applies registered wrappers before `FilteringExporter`.

## Key Changes

- **`models/gateway_route_config.py`**: adds the opaque `extension: dict | None` field (default `None`).
- **`models/gateway_config.py`**: adds `validate_route_extensions` (`@model_validator(mode='after')`) running registered validators over each route's `extension` once at load time; early-returns when none are registered.
- **`utils/config_hooks.py`** (new): registry for `extension` validators.
- **`utils/telemetry_hooks.py`** (new): registry for span-exporter wrappers.
- **`server.py`**: extracts a `_build_processor` helper applying registered wrappers, de-duplicating the repeated processor-construction blocks.
- **`utils/filtering_exporter/exporter.py`**: tightens `_remap` annotation from `dict[int, int]` to `FIFOCache[int, int]`.
- **`tests/utils/test_config_hooks.py`** (new): validates the extension flow through `GatewayConfig` (registered validator receives `extension`, a raising validator fails config validation, absent `extension` is a no-op).


## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [x] Tests pass (locally/CI)
- [x] Lint/build pass
- [x] No secrets committed
- [ ] Docs updated (if needed)
