### PR TITLE
feat: per-route applicative log suppression seams

### DIFF
--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -373,8 +373,8 @@ app.include_router(
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
-    logger.error('Validation error: %s', exc.errors())
-    logger.error('Body: %s', await request.body())
+    errors = [{'loc': e.get('loc'), 'type': e.get('type')} for e in exc.errors()]
+    logger.error('Validation error: %s', errors)
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content={'detail': exc.errors(), 'body': (await request.body()).decode()},

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -95,9 +95,14 @@ from radicalbit_ai_gateway.utils.filtering_exporter import FilteringExporter
 from radicalbit_ai_gateway.utils.gateway_route_factory import (
     build_project_route_registrar,
 )
+from radicalbit_ai_gateway.utils.logging_hooks import apply_log_filters
 from radicalbit_ai_gateway.utils.open_ai_types import (
     CompletionCreateParams,
     ResponseCreateParamsCustom,
+)
+from radicalbit_ai_gateway.utils.request_context import (
+    reset_route_context,
+    set_current_route_config,
 )
 from radicalbit_ai_gateway.utils.responses_streaming import (
     build_skeleton_response,
@@ -296,6 +301,9 @@ app.state.token_validator = ApiKeyValidator(key_service=key_service)
 
 # load plugins
 init_plugins(app)
+
+# Attach plugin-registered log filters, now that plugins have registered them.
+apply_log_filters(logger)
 
 # middleware
 app.add_middleware(
@@ -512,6 +520,7 @@ def otel_metrics_decorator(func):
 @otel_metrics_decorator
 @workflow(name='chat_completions')
 @ensure_endpoint_category
+@reset_route_context
 async def chat_completions(
     request: Request,
     completion_create_params: CompletionCreateParams,
@@ -528,6 +537,8 @@ async def chat_completions(
             f'The route name [{route_key}] was not found in the config'
         )
     route_name = route.gateway_route_config.route_name
+    # Publish the route config for per-route log filtering (cleared by the decorator).
+    set_current_route_config(route.gateway_route_config)
     # Mark the root workflow span with ENDPOINT category
     set_operation_category(OperationCategory.ENDPOINT)
 
@@ -825,14 +836,13 @@ async def embeddings(
 @otel_metrics_decorator
 @workflow(name='responses')
 @ensure_endpoint_category
+@reset_route_context
 async def responses(
     request: Request,
     response_create_params: ResponseCreateParamsCustom,
     gateway_routes: dict[str, GatewayRoute] = Depends(get_ai_gateway_dependency),
     request_uuid: str = Depends(set_request_uuid),
 ):
-    logger.debug('Responses API request: %s', response_create_params)
-
     # Mark the root workflow span with ENDPOINT category
     set_operation_category(OperationCategory.ENDPOINT)
 
@@ -851,6 +861,10 @@ async def responses(
             f'The route name [{route_key}] was not found in the config'
         )
     route_name = route.gateway_route_config.route_name
+    # Publish the route config for per-route log filtering (cleared by the decorator).
+    # Logged after resolution so the request dump is subject to that filtering.
+    set_current_route_config(route.gateway_route_config)
+    logger.debug('Responses API request: %s', response_create_params)
     request.state.otel_route_name = route_name
 
     # Set early trace attributes

--- a/gateway/radicalbit_ai_gateway/utils/logging_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/logging_hooks.py
@@ -1,0 +1,22 @@
+"""Registry for log filters contributed by plugins.
+
+Plugins register a ``logging.Filter`` at init; the server attaches them to the
+gateway logger at startup. The core carries no knowledge of what they do.
+"""
+
+import logging
+
+_log_filters: list[logging.Filter] = []
+
+
+def register_log_filter(log_filter: logging.Filter) -> None:
+    _log_filters.append(log_filter)
+
+
+def get_log_filters() -> list[logging.Filter]:
+    return list(_log_filters)
+
+
+def apply_log_filters(logger: logging.Logger) -> None:
+    for log_filter in get_log_filters():
+        logger.addFilter(log_filter)

--- a/gateway/radicalbit_ai_gateway/utils/request_context.py
+++ b/gateway/radicalbit_ai_gateway/utils/request_context.py
@@ -1,0 +1,34 @@
+"""Request-scoped route context.
+
+A ``logging.Filter`` only sees the ``LogRecord``, not the FastAPI request. The
+handler publishes the resolved route config here right after route resolution so
+per-route consumers (e.g. plugins) can read it; ``reset_route_context`` clears it
+when the request finishes. The core never interprets the config.
+"""
+
+from contextvars import ContextVar
+from functools import wraps
+from typing import Any
+
+# Route config of the current request, or None when none is resolved. Typed as
+# Any to avoid an import cycle with the model.
+current_route_config_ctx: ContextVar[Any] = ContextVar(
+    'current_route_config', default=None
+)
+
+
+def set_current_route_config(config: Any) -> None:
+    current_route_config_ctx.set(config)
+
+
+def reset_route_context(func):
+    """Clear the route context when the handler finishes, including on error."""
+
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            current_route_config_ctx.set(None)
+
+    return wrapper

--- a/gateway/tests/utils/test_logging_hooks.py
+++ b/gateway/tests/utils/test_logging_hooks.py
@@ -1,0 +1,49 @@
+import logging
+
+import pytest
+
+from radicalbit_ai_gateway.utils import logging_hooks
+from radicalbit_ai_gateway.utils.logging_hooks import (
+    apply_log_filters,
+    get_log_filters,
+    register_log_filter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    logging_hooks._log_filters.clear()
+    yield
+    logging_hooks._log_filters.clear()
+
+
+class _DropAll(logging.Filter):
+    def filter(self, record):
+        return False
+
+
+def test_register_and_get_returns_in_order():
+    f1, f2 = _DropAll(), _DropAll()
+    register_log_filter(f1)
+    register_log_filter(f2)
+
+    assert get_log_filters() == [f1, f2]
+
+
+def test_get_returns_a_copy():
+    register_log_filter(_DropAll())
+    get_log_filters().clear()
+
+    assert len(get_log_filters()) == 1
+
+
+def test_apply_attaches_registered_filters_to_logger():
+    f = _DropAll()
+    register_log_filter(f)
+    logger = logging.getLogger('test-apply-log-filters')
+
+    apply_log_filters(logger)
+
+    assert f in logger.filters
+    # The attached filter drops records on this logger.
+    assert logger.filter(logging.makeLogRecord({})) is False

--- a/gateway/tests/utils/test_request_context.py
+++ b/gateway/tests/utils/test_request_context.py
@@ -1,0 +1,42 @@
+import pytest
+
+from radicalbit_ai_gateway.utils.request_context import (
+    current_route_config_ctx,
+    reset_route_context,
+    set_current_route_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ctx():
+    current_route_config_ctx.set(None)
+    yield
+    current_route_config_ctx.set(None)
+
+
+def test_set_publishes_config():
+    set_current_route_config({'route': 'A'})
+    assert current_route_config_ctx.get() == {'route': 'A'}
+
+
+@pytest.mark.asyncio
+async def test_reset_decorator_clears_after_success():
+    @reset_route_context
+    async def handler():
+        set_current_route_config({'route': 'A'})
+        return 'ok'
+
+    assert await handler() == 'ok'
+    assert current_route_config_ctx.get() is None
+
+
+@pytest.mark.asyncio
+async def test_reset_decorator_clears_after_error():
+    @reset_route_context
+    async def handler():
+        set_current_route_config({'route': 'A'})
+        raise RuntimeError('boom')
+
+    with pytest.raises(RuntimeError):
+        await handler()
+    assert current_route_config_ctx.get() is None


### PR DESCRIPTION
# PR Summary: feat/AG-809-privacy-logging

OSS-side seams that let an enterprise plugin suppress a route's **applicative
(container) logs** per route. No API contract changes: no DTOs, request/response
schemas, or endpoint signatures are added or modified — only internal logging
plumbing and a request-scoped context.

---

## DTO Changes

None. No Pydantic models added or modified.

---

## Affected Endpoints

No new endpoints and no signature/parameter changes. Two existing endpoints gain
internal behavior only (a decorator + publishing the current route on a context
var); request and response shapes are unchanged.

### `POST /v1/chat/completions` (behavior only)

- Decorated with `@reset_route_context`.
- After route resolution, publishes the route config via
  `set_current_route_config(...)` so per-route log filters can act on it.

### `POST /v1/responses` (behavior only)

- Decorated with `@reset_route_context`.
- Publishes the route config after route resolution; the `Responses API request`
  debug log was moved to *after* resolution so it is subject to per-route log
  filtering.

**Observable effect (only when the enterprise `trace_log_privacy` plugin is
enabled and a route sets `extension.privacy_logging_enabled: true`):** that
route's applicative log records are dropped. With no such plugin, logging is
unchanged. The Uvicorn access-log line is unaffected (different logger).

---

## Other Changes

### New: `utils/request_context.py`

Request-scoped route context consumed by cross-cutting concerns (e.g. log
filters) that only see a `LogRecord`, not the FastAPI request.

- `current_route_config_ctx: ContextVar` — the current request's route config, or
  `None` when none is resolved.
- `set_current_route_config(config)` — publish it (called by the handlers).
- `reset_route_context(func)` — async decorator that clears the context in a
  `finally`, so it never leaks past a request (including on error).

The core never interprets the config; it only carries it.

### New: `utils/logging_hooks.py`

Registry for plugin-contributed log filters (mirrors `telemetry_hooks`).

- `register_log_filter(filter)` — a plugin registers a `logging.Filter` at init.
- `get_log_filters()` — registered filters, in order.
- `apply_log_filters(logger)` — attach them to a logger (called once at startup,
  after `init_plugins`).

The core carries no knowledge of what the filters do.

### `server.py`

- Imports the two modules above.
- Calls `apply_log_filters(logger)` after `init_plugins(app)`.
- Adds `@reset_route_context` + `set_current_route_config(...)` to the
  chat-completions and Responses handlers (see above).

### Tests

- `tests/utils/test_request_context.py` — context publish + reset on
  success/error.
- `tests/utils/test_logging_hooks.py` — registry order, copy semantics, and
  attaching a filter to a logger.

---

## Notes

- Enterprise side (the `trace_log_privacy` plugin's log filter and the
  `privacy_logging_enabled` extension key) lives in the enterprise repo and is
  not part of this PR.
- Known limitation: records emitted **before** route resolution (e.g. the
  request-validation handler) cannot be attributed to a route and are not
  suppressed.
