### PR TITLE
feat: filter rootless span

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/otel_traces_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/otel_traces_dao.py
@@ -405,9 +405,14 @@ class OtelTracesDAO:
         trace_agg = (
             select(
                 T.c['TraceId'].label('trace_id'),
-                F.anyIf(T.c['Timestamp'], T.c['ParentSpanId'] == '').label(
-                    'root_timestamp'
-                ),
+                # nullIf converts the epoch default (returned by anyIf when a
+                # trace has no root span, i.e. no span with an empty
+                # ParentSpanId) to NULL, so rootless traces can be filtered out
+                # below instead of bucketing to 1970 and exploding the range.
+                F.nullIf(
+                    F.anyIf(T.c['Timestamp'], T.c['ParentSpanId'] == ''),
+                    text('toDateTime(0)'),
+                ).label('root_timestamp'),
                 F.anyIf(T.c['StatusCode'], T.c['ParentSpanId'] == '').label(
                     'root_status'
                 ),
@@ -423,8 +428,9 @@ class OtelTracesDAO:
             .group_by(T.c['TraceId'])
         ).subquery('trace_agg')
 
-        # Filter by route names on the aggregated root span route_name
-        outer_conditions = []
+        # Drop traces with no root span: their root_timestamp is NULL (see the
+        # nullIf above) and they would otherwise bucket to the Unix epoch.
+        outer_conditions = [trace_agg.c.root_timestamp.isnot(None)]
         if route_names:
             outer_conditions.append(trace_agg.c.route_name.in_(route_names))
 

--- a/gateway/tests/dao/otel_traces_dao_test.py
+++ b/gateway/tests/dao/otel_traces_dao_test.py
@@ -955,6 +955,52 @@ class OtelTracesDAOTest(DatabaseIntegrationClickhouse):
         assert len(res) == 1
         assert res[0].total_requests == 1
 
+    def test_get_traces_chart_data_excludes_rootless_traces(self):
+        """A trace with no root span must not bucket to the Unix epoch.
+
+        Regression: anyIf over a trace with no empty-ParentSpanId span returns
+        the epoch default (toDateTime(0)), which weekly-bucketed to 1969 and
+        blew the chart range up to thousands of buckets.
+        """
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        test_spans = [
+            # Normal trace with a root span
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t1',
+                span_id='span-root',
+                status_code='Unset',
+                parent_span_id='',
+            ),
+            # Orphan trace: only a child span, no root span
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t2',
+                span_id='span-orphan-child',
+                status_code='Unset',
+                parent_span_id='span-missing-root',
+            ),
+        ]
+        self.insert(test_spans)
+
+        res = self.otel_traces_dao.get_traces_chart_data(
+            project_uuid=TEST_PROJECT_UUID,
+            route_names=None,
+            _from=base_time,
+            _to=base_time + datetime.timedelta(hours=1),
+            granularity='weeks',
+            timezone_offset_seconds=0,
+        )
+
+        # Only the trace with a root span is counted; the orphan is dropped.
+        assert len(res) == 1
+        assert res[0].total_requests == 1
+        # No bucket should land at/near the Unix epoch.
+        assert all(p.timestamp > 0 for p in res)
+
     # --- get_latencies ---
 
     def test_get_latencies_empty(self):


### PR DESCRIPTION
## Summary:

Fixes **AG-811** — the tracing chart endpoint intermittently returned a huge (~11k-line) payload with weekly buckets starting before the Unix epoch (e.g. `-259200`). Traces with no root span made ClickHouse's `anyIf` return the epoch default (`1970-01-01`), which dragged the chart's start time back to 1969. This PR excludes rootless traces from the chart query.

---

## DTO Changes

**None.** The `TracesChartDataDTO` response schema is unchanged.

For reference, the (unchanged) response shape is:

| Field | Type | Description |
|-------|------|-------------|
| `granularity` | string | One of: `hours`, `days`, `weeks`, `months` |
| `timestamp` | integer[] | List of Unix timestamps (one per bucket) |
| `data` | object[] | Series per status: `{ "name": "success" \| "warning" \| "error", "data": integer[] }` |
| `total` | integer | Total trace count across all buckets/statuses |

**Example response (after fix — compact, correct range):**
```json
{
  "granularity": "weeks",
  "timestamp": [1782086400],
  "data": [
    {"name": "success", "data": [3]},
    {"name": "warning", "data": [0]},
    {"name": "error", "data": [0]}
  ],
  "total": 3
}
```

---

## Affected Endpoints

### `GET /public/api/v1/projects/{project_uuid}/traces/chart` (BEHAVIOR CHANGE)

No request/response **schema** change. Behavior change only:

```diff
- Traces with no root span were counted and bucketed to the Unix epoch (1970),
-   producing thousands of weekly buckets and negative timestamps.
+ Traces with no root span are excluded from the chart; buckets now span only
+   the real data range. Such traces no longer contribute to `total`.
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `_from` | integer (unix ts) | no | Start of range; granularity defaults to `weeks` when omitted |
| `_to` | integer (unix ts) | no | End of range |
| `routes` | string[] | no | Filter by route names |

**Example request:**
```
GET /public/api/v1/projects/550e8400-e29b-41d4-a716-446655440000/traces/chart
```

---

## Other Changes

- `db/dao/otel_traces_dao.py` — In `get_traces_chart_data`, the root-span timestamp aggregation is wrapped in `nullIf(anyIf(Timestamp, ParentSpanId == ''), toDateTime(0))` so rootless traces resolve to `NULL` instead of the epoch default (mirrors the existing pattern in `request_event_dao.py`). A new outer condition `root_timestamp IS NOT NULL` drops those traces before bucketing.
- `tests/dao/otel_traces_dao_test.py` — Added `test_get_traces_chart_data_excludes_rootless_traces`: inserts a normal trace plus an orphan (child-only) trace and asserts the orphan is excluded and no bucket lands at/near the epoch.


## Linked Issue
Closes #123

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [x] Tests pass (locally/CI)
- [x] Lint/build pass
- [x] No secrets committed
- [ ] Docs updated (if needed)
