### PR TITLE
feat: preprocessing hook

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -42,6 +42,7 @@ from radicalbit_ai_gateway.models.fallback import FallbackModelType
 from radicalbit_ai_gateway.models.gateway_route_config import GatewayRouteConfig
 from radicalbit_ai_gateway.models.guardrails import GuardrailClass, GuardrailWhereType
 from radicalbit_ai_gateway.models.model import ENABLE_PROMPT_CACHE_PARAM, Model
+from radicalbit_ai_gateway.preprocessing import run_preprocessing
 from radicalbit_ai_gateway.routing import (
     DeterministicRouter,
     SemanticRouter,
@@ -660,6 +661,10 @@ class GatewayRoute:
                     selected_model_id=model_selected.model_id,
                 )
             )
+
+        # Preprocessing plugins: transform messages before input guardrails.
+        # No-op when no plugins are registered; fail-closed if a plugin raises.
+        messages = await run_preprocessing(messages)
 
         guardrails_input_triggered = False
         guardrails_block_triggered = (

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -673,7 +673,7 @@ class GatewayRoute:
 
         # Inject the route's configured system prompt AFTER preprocessing, so
         # preprocessing plugins can never see or modify it.
-        await self._apply_config_prompt(messages, model_selected)
+        self._apply_config_prompt(messages, model_selected)
 
         guardrails_input_triggered = False
         guardrails_block_triggered = (
@@ -824,8 +824,7 @@ class GatewayRoute:
 
         return model_selected
 
-    @task(name='apply_config_prompt')
-    async def _apply_config_prompt(
+    def _apply_config_prompt(
         self, messages: list[BaseMessage], model_selected: Model
     ) -> None:
         """Prepend the route's configured system prompt to *messages* in place.

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -645,9 +645,7 @@ class GatewayRoute:
         # only ever see the client's messages. No-op when no plugin is enabled;
         # fail-closed if a plugin raises.
         set_operation_category(OperationCategory.PREPROCESSING)
-        messages = await run_preprocessing(
-            messages, self.gateway_route_config.extension
-        )
+        messages = await run_preprocessing(messages, self.gateway_route_config.plugins)
 
         # Prepare request for processing: route on the preprocessed messages.
         set_operation_category(OperationCategory.ROUTING)

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -664,6 +664,7 @@ class GatewayRoute:
 
         # Preprocessing plugins: transform messages before input guardrails.
         # No-op when no plugins are registered; fail-closed if a plugin raises.
+        set_operation_category(OperationCategory.PREPROCESSING)
         messages = await run_preprocessing(messages)
 
         guardrails_input_triggered = False

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -665,7 +665,9 @@ class GatewayRoute:
         # Preprocessing plugins: transform messages before input guardrails.
         # No-op when no plugins are registered; fail-closed if a plugin raises.
         set_operation_category(OperationCategory.PREPROCESSING)
-        messages = await run_preprocessing(messages)
+        messages = await run_preprocessing(
+            messages, self.gateway_route_config.extension
+        )
 
         guardrails_input_triggered = False
         guardrails_block_triggered = (

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -673,7 +673,7 @@ class GatewayRoute:
 
         # Inject the route's configured system prompt AFTER preprocessing, so
         # preprocessing plugins can never see or modify it.
-        self._apply_config_prompt(messages, model_selected)
+        await self._apply_config_prompt(messages, model_selected)
 
         guardrails_input_triggered = False
         guardrails_block_triggered = (
@@ -825,7 +825,7 @@ class GatewayRoute:
         return model_selected
 
     @task(name='apply_config_prompt')
-    def _apply_config_prompt(
+    async def _apply_config_prompt(
         self, messages: list[BaseMessage], model_selected: Model
     ) -> None:
         """Prepend the route's configured system prompt to *messages* in place.

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -640,9 +640,18 @@ class GatewayRoute:
         if not self.chat_invoker:
             raise GatewayBadRequest(f'Route {route_name} has no chat models defined')
 
-        # Prepare request for processing
+        # Preprocessing plugins: transform the raw client messages first, before
+        # routing and before the configured system prompt is injected, so plugins
+        # only ever see the client's messages. No-op when no plugin is enabled;
+        # fail-closed if a plugin raises.
+        set_operation_category(OperationCategory.PREPROCESSING)
+        messages = await run_preprocessing(
+            messages, self.gateway_route_config.extension
+        )
+
+        # Prepare request for processing: route on the preprocessed messages.
         set_operation_category(OperationCategory.ROUTING)
-        model_selected = await self._select_and_prepare_chat_model(messages)
+        model_selected = await self._select_chat_model(messages)
 
         if self.router and self.gateway_route_config.routing:
             emit_event(
@@ -662,12 +671,9 @@ class GatewayRoute:
                 )
             )
 
-        # Preprocessing plugins: transform messages before input guardrails.
-        # No-op when no plugins are registered; fail-closed if a plugin raises.
-        set_operation_category(OperationCategory.PREPROCESSING)
-        messages = await run_preprocessing(
-            messages, self.gateway_route_config.extension
-        )
+        # Inject the route's configured system prompt AFTER preprocessing, so
+        # preprocessing plugins can never see or modify it.
+        self._apply_config_prompt(messages, model_selected)
 
         guardrails_input_triggered = False
         guardrails_block_triggered = (
@@ -807,19 +813,30 @@ class GatewayRoute:
         )
 
     @task(name='select_model')
-    async def _select_and_prepare_chat_model(
-        self, messages: list[BaseMessage]
-    ) -> Model:
-        """Select chat model and prepare messages with config prompt."""
+    async def _select_chat_model(self, messages: list[BaseMessage]) -> Model:
+        """Select the chat model for this request based on the routing config."""
         if self.router:
             model_selected = await self.router.select_model(messages)
         else:
             model_selected = self._chat_models[0]
 
+        logger.debug('Selected chat model: %s', model_selected.model_id)
+
+        return model_selected
+
+    @task(name='apply_config_prompt')
+    def _apply_config_prompt(
+        self, messages: list[BaseMessage], model_selected: Model
+    ) -> None:
+        """Prepend the route's configured system prompt to *messages* in place.
+
+        Runs *after* preprocessing so the configured prompt is never exposed to
+        preprocessing plugins.
+        """
         config_prompt, role = model_selected.effective_prompt, model_selected.role
 
         logger.debug(
-            'Selected chat model: %s with config prompt: %s and role: %s',
+            'Config prompt for model %s: %s and role: %s',
             model_selected.model_id,
             config_prompt,
             role,
@@ -847,8 +864,6 @@ class GatewayRoute:
                     content=config_prompt, role=role, tool_calls=[], tool_call_id=None
                 )
             messages[:] = [system_msg, *messages]
-
-        return model_selected
 
     def _get_first_embedding_model(self) -> Model | None:
         """Return the first embedding model"""

--- a/gateway/radicalbit_ai_gateway/models/gateway_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config.py
@@ -21,9 +21,9 @@ from radicalbit_ai_gateway.models.routing import (
     SemanticRoutingConfig,
 )
 from radicalbit_ai_gateway.utils.config_hooks import (
-    build_route_extension_model,
-    get_extension_validators,
-    get_known_extension_keys,
+    build_route_plugins_model,
+    get_known_plugin_keys,
+    get_plugins_validators,
 )
 
 
@@ -324,41 +324,39 @@ class GatewayConfig(BaseModel):
         return self
 
     @model_validator(mode='after')
-    def validate_route_extensions(self) -> Self:
-        """Validate each route's ``extension`` against the registered plugins.
+    def validate_route_plugins(self) -> Self:
+        """Validate each route's ``plugins`` against the registered plugins.
 
-        ``extension`` is typed ``dict`` in the route model because its allowed
+        ``plugins`` is typed ``dict`` in the route model because its allowed
         keys are only known once plugins register. Here, at config-load time, we
         build a model whose fields are exactly the keys plugins claimed
-        (``extra='forbid'``) so an ``extension`` key no plugin claims — a typo'd
+        (``extra='forbid'``) so a ``plugins`` key no plugin claims — a typo'd
         or stale plugin name — is rejected instead of being silently ignored.
         Each plugin's per-slice validator (registered via
-        ``register_extension_slice_validator``) then validates its slice's
+        ``register_plugin_config_validator``) then validates its slice's
         contents. Validation runs once here rather than on every
         ``GatewayRouteConfig`` construction.
         """
-        validators = get_extension_validators()
+        validators = get_plugins_validators()
         if not validators:
             return self
-        known_keys = get_known_extension_keys()
+        known_keys = get_known_plugin_keys()
         # Gate unknown keys only when some plugin declared one. With only raw,
-        # whole-``extension`` validators (no declared key) there is nothing to
+        # whole-``plugins`` validators (no declared key) there is nothing to
         # gate against, so those keep validating the dict themselves.
-        extension_model = (
-            build_route_extension_model(known_keys) if known_keys else None
-        )
+        plugins_model = build_route_plugins_model(known_keys) if known_keys else None
         for route_name, route in self.routes.items():
-            if not route.extension:
+            if not route.plugins:
                 continue
-            if extension_model is not None:
+            if plugins_model is not None:
                 try:
-                    extension_model.model_validate(route.extension)
+                    plugins_model.model_validate(route.plugins)
                 except ValidationError as exc:
                     unknown = sorted(str(e['loc'][0]) for e in exc.errors())
                     raise ValueError(
-                        f"Route '{route_name}': unknown 'extension' key(s) "
+                        f"Route '{route_name}': unknown 'plugins' key(s) "
                         f'{unknown}; valid keys: {sorted(known_keys)}'
                     ) from exc
             for validate in validators:
-                validate(route.extension)
+                validate(route.plugins)
         return self

--- a/gateway/radicalbit_ai_gateway/models/gateway_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from typing_extensions import Self
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 
 from radicalbit_ai_gateway.models.caching import CacheConfig, SemanticCaching
 from radicalbit_ai_gateway.models.fallback import FallbackModelType
@@ -20,7 +20,11 @@ from radicalbit_ai_gateway.models.routing import (
     RoutingRuleType,
     SemanticRoutingConfig,
 )
-from radicalbit_ai_gateway.utils.config_hooks import get_extension_validators
+from radicalbit_ai_gateway.utils.config_hooks import (
+    build_route_extension_model,
+    get_extension_validators,
+    get_known_extension_keys,
+)
 
 
 def get_model_from_model_id(
@@ -321,20 +325,40 @@ class GatewayConfig(BaseModel):
 
     @model_validator(mode='after')
     def validate_route_extensions(self) -> Self:
-        """Run registered plugin validators against each route's ``extension``.
+        """Validate each route's ``extension`` against the registered plugins.
 
-        Plugins register validators via
-        ``radicalbit_ai_gateway.utils.config_hooks.register_extension_validator``.
-        A validator raises ValueError on invalid config, which surfaces as a
-        normal config validation error. Validation runs once here at config-load
-        time rather than on every ``GatewayRouteConfig`` construction.
+        ``extension`` is typed ``dict`` in the route model because its allowed
+        keys are only known once plugins register. Here, at config-load time, we
+        build a model whose fields are exactly the keys plugins claimed
+        (``extra='forbid'``) so an ``extension`` key no plugin claims — a typo'd
+        or stale plugin name — is rejected instead of being silently ignored.
+        Each plugin's per-slice validator (registered via
+        ``register_extension_slice_validator``) then validates its slice's
+        contents. Validation runs once here rather than on every
+        ``GatewayRouteConfig`` construction.
         """
         validators = get_extension_validators()
         if not validators:
             return self
-        for route in self.routes.values():
+        known_keys = get_known_extension_keys()
+        # Gate unknown keys only when some plugin declared one. With only raw,
+        # whole-``extension`` validators (no declared key) there is nothing to
+        # gate against, so those keep validating the dict themselves.
+        extension_model = (
+            build_route_extension_model(known_keys) if known_keys else None
+        )
+        for route_name, route in self.routes.items():
             if not route.extension:
                 continue
+            if extension_model is not None:
+                try:
+                    extension_model.model_validate(route.extension)
+                except ValidationError as exc:
+                    unknown = sorted(str(e['loc'][0]) for e in exc.errors())
+                    raise ValueError(
+                        f"Route '{route_name}': unknown 'extension' key(s) "
+                        f'{unknown}; valid keys: {sorted(known_keys)}'
+                    ) from exc
             for validate in validators:
                 validate(route.extension)
         return self

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -57,9 +57,9 @@ class GatewayRouteConfig(BaseModel):
         default=None,
         description='Name of a top-level routing config.',
     )
-    extension: dict | None = Field(
+    plugins: dict | None = Field(
         default=None,
-        description=('Extension configuration for the route.'),
+        description=('Plugins configuration for the route.'),
     )
 
     def get_token_limiter(self) -> TokenLimiter:

--- a/gateway/radicalbit_ai_gateway/plugins/loader.py
+++ b/gateway/radicalbit_ai_gateway/plugins/loader.py
@@ -3,7 +3,8 @@ import logging
 
 from radicalbit_ai_gateway.utils.app_config import get_app_config
 
-logger = logging.getLogger('radicalbit_ai_gateway')
+app_config = get_app_config()
+logger = logging.getLogger(app_config.log_config.logger_name)
 
 _EP_GROUP = 'radicalbit_ai_gateway.plugins'
 _plugin_modules: dict[str, object] = {}

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -152,8 +152,9 @@ def _config_key(plugin: PreprocessingPlugin) -> str:
     return type(plugin).__module__.partition('.')[0]
 
 
-# Registry of (config key, plugin, task-wrapped runner). Chain order ==
-# registration order (i.e. plugin load order).
+# Registry of (config key, plugin, task-wrapped runner) in registration order.
+# The executed chain is NOT registry order: per request it is reordered to the
+# route's ``extension`` key order (see ``_enabled_chain``).
 _PluginRunner = Callable[[list[BaseMessage], dict | None], Awaitable[list[BaseMessage]]]
 _registered: list[tuple[str, PreprocessingPlugin, _PluginRunner]] = []
 
@@ -163,8 +164,9 @@ def register_preprocessing_plugin(
 ) -> None:
     """Register a preprocessing plugin to join the chain.
 
-    Call from a plugin module at import time. The plugin runs in the order it
-    was registered, relative to other preprocessing plugins. Its ``preprocess``
+    Call from a plugin module at import time. Plugins run in the order their
+    keys appear in the route's ``extension`` config (route config order), not in
+    registration order; see :func:`_enabled_chain`. Its ``preprocess``
     method is wrapped with a traceloop ``task`` span named ``preprocess.<key>``
     once, here, rather than per request.
 

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -22,9 +22,11 @@ from fastapi import status
 from langchain_core.messages import BaseMessage
 from traceloop.sdk.decorators import task, workflow
 
+from radicalbit_ai_gateway.utils.app_config import get_app_config
 from radicalbit_ai_gateway.utils.exceptions import AppError, GatewayError
 
-logger = logging.getLogger('radicalbit_ai_gateway')
+app_config = get_app_config()
+logger = logging.getLogger(app_config.log_config.logger_name)
 
 
 class PreprocessingError(GatewayError):

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -1,0 +1,119 @@
+"""Preprocessing plugins.
+
+A hook that lets plugins transform the incoming chat messages *before* they
+reach the input guardrails. Plugins register an implementation at import time
+(during ``discover_plugins()``).
+
+Contract:
+- A plugin implements :class:`PreprocessingPlugin` and registers an instance via
+  :func:`register_preprocessing_plugin`.
+- ``preprocess`` takes the messages and returns the same structure
+  (``list[BaseMessage]``) so the chain composes.
+- Plugins run in registration order. With no plugins registered the chain is a
+  no-op and messages pass through unchanged.
+- Fail-closed: if a plugin raises, the chain stops and the request is aborted.
+"""
+
+from abc import ABC, abstractmethod
+import logging
+
+from fastapi import status
+from langchain_core.messages import BaseMessage
+
+from radicalbit_ai_gateway.utils.exceptions import AppError, GatewayError
+
+logger = logging.getLogger('radicalbit_ai_gateway')
+
+
+class PreprocessingError(GatewayError):
+    """Raised when a preprocessing plugin fails. Aborts the request (fail-closed).
+
+    Subclasses ``GatewayError`` so it is handled by the registered
+    ``gateway_exception_handler`` and returned as a structured JSON error.
+    """
+
+    def __init__(self, message: str, *, log_message: str | None = None):
+        super().__init__(
+            message,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            log_message=log_message,
+            code='preprocessing_error',
+        )
+
+
+class PreprocessingPlugin(ABC):
+    """Implemented by plugins that want to transform incoming chat messages."""
+
+    @abstractmethod
+    async def preprocess(self, messages: list[BaseMessage]) -> list[BaseMessage]:
+        """Transform *messages* and return the same structure.
+
+        Each message's ``content`` can take two shapes, and an implementation
+        that edits text should handle both:
+
+        - ``str`` — plain text content. Operate on it directly.
+        - ``list`` — multimodal content, i.e. a list of parts (dicts). Only the
+          text parts carry text: iterate the list and act on parts where
+          ``part.get('type') == 'text'`` (the text is in ``part['text']``).
+          Leave non-text parts (e.g. ``image_url``) untouched.
+
+        Template for a text-transforming plugin (replace ``transform`` with
+        your own logic)::
+
+            for message in messages:
+                content = message.content
+                if isinstance(content, str):
+                    message.content = transform(content)
+                elif isinstance(content, list):
+                    for part in content:
+                        if (
+                            isinstance(part, dict)
+                            and part.get('type') == 'text'
+                            and isinstance(part.get('text'), str)
+                        ):
+                            part['text'] = transform(part['text'])
+            return messages
+        """
+        ...
+
+
+# Registry. Chain order == registration order (i.e. plugin load order).
+_registered: list[PreprocessingPlugin] = []
+
+
+def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
+    """Register a preprocessing plugin to join the chain.
+
+    Call from a plugin module at import time. The plugin runs in the order it
+    was registered, relative to other preprocessing plugins.
+    """
+    _registered.append(plugin)
+    logger.info('Registered preprocessing plugin: %s', type(plugin).__name__)
+
+
+def get_preprocessing_plugins() -> list[PreprocessingPlugin]:
+    """Return the registered preprocessing plugins, in chain order."""
+    return list(_registered)
+
+
+async def run_preprocessing(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Run the preprocessing chain over *messages*.
+
+    No-op when no plugins are registered. Fail-closed: if a plugin raises an
+    ``AppError`` it is propagated as-is (so the plugin can control the response);
+    any other exception is wrapped in :class:`PreprocessingError`.
+    """
+    current = messages
+    for plugin in get_preprocessing_plugins():
+        name = type(plugin).__name__
+        try:
+            current = await plugin.preprocess(current)
+        except AppError:
+            # The plugin raised a structured gateway error on purpose; let it through.
+            raise
+        except Exception as e:
+            raise PreprocessingError(
+                'A preprocessing step failed.',
+                log_message=f'preprocessing plugin {name} failed: {e}',
+            ) from e
+    return current

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -27,11 +27,13 @@ import re
 
 from fastapi import status
 from langchain_core.messages import BaseMessage
-from pydantic import BaseModel, ConfigDict
 from traceloop.sdk.decorators import task, workflow
 
 from radicalbit_ai_gateway.utils.app_config import get_app_config
-from radicalbit_ai_gateway.utils.config_hooks import register_extension_validator
+from radicalbit_ai_gateway.utils.config_hooks import (
+    ExtensionConfig,
+    register_extension_slice_validator,
+)
 from radicalbit_ai_gateway.utils.exceptions import AppError, GatewayError
 
 app_config = get_app_config()
@@ -54,17 +56,16 @@ class PreprocessingError(GatewayError):
         )
 
 
-class PreprocessingConfig(BaseModel):
-    """Base schema for a plugin's ``extension`` slice.
+class PreprocessingConfig(ExtensionConfig):
+    """Base schema for a preprocessing plugin's ``extension`` slice.
 
-    Forbids unknown keys (``extra='forbid'``), so a route may only set the
-    parameters a plugin declares. Subclass to add plugin-specific fields::
+    Inherits ``extra='forbid'`` from :class:`ExtensionConfig` (a route may only
+    set the parameters a plugin declares) and adds the opt-in ``enabled`` flag.
+    Subclass to add plugin-specific fields::
 
         class MyConfig(PreprocessingConfig):
             threshold: int = 5
     """
-
-    model_config = ConfigDict(extra='forbid')
 
     enabled: bool = False
 
@@ -167,12 +168,7 @@ def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
     ) -> list[BaseMessage]:
         return await plugin.preprocess(messages, config)
 
-    def _validate(extension: dict) -> None:
-        config = extension.get(key)
-        if config is not None:
-            plugin.validate(config)
-
-    register_extension_validator(_validate)
+    register_extension_slice_validator(key, plugin.validate)
     _registered.append((key, plugin, _run))
     logger.info('Registered preprocessing plugin: %s', key)
 

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -8,17 +8,17 @@ Contract:
 - A plugin implements :class:`PreprocessingPlugin` and registers an instance via
   :func:`register_preprocessing_plugin`.
 - ``preprocess`` takes the messages and the plugin's own slice of the route's
-  ``extension`` config, and returns the same structure (``list[BaseMessage]``)
+  ``plugins`` config, and returns the same structure (``list[BaseMessage]``)
   so the chain composes.
 - Plugins receive only the **client's** chat messages. The route's configured
   system prompt is injected *after* preprocessing runs, so it is never passed to
   a plugin and cannot be modified by one.
 - Per-route, opt-in: a plugin runs only when its config key is present in the
-  route's ``extension`` and it is enabled there (see
+  route's ``plugins`` and it is enabled there (see
   :meth:`PreprocessingPlugin.is_enabled`). Plugins run in the order their keys
-  appear in ``extension`` (route config order); with none enabled the chain is
+  appear in ``plugins`` (route config order); with none enabled the chain is
   a no-op.
-- A plugin validates its own ``extension`` slice at config-load time by
+- A plugin validates its own ``plugins`` slice at config-load time by
   overriding :meth:`PreprocessingPlugin.validate`.
 - Fail-closed: if a plugin raises, the chain stops and the request is aborted.
 """
@@ -33,8 +33,8 @@ from traceloop.sdk.decorators import task, workflow
 
 from radicalbit_ai_gateway.utils.app_config import get_app_config
 from radicalbit_ai_gateway.utils.config_hooks import (
-    ExtensionConfig,
-    register_extension_slice_validator,
+    PluginConfig,
+    register_plugin_config_validator,
 )
 from radicalbit_ai_gateway.utils.exceptions import AppError, GatewayError
 
@@ -58,10 +58,10 @@ class PreprocessingError(GatewayError):
         )
 
 
-class PreprocessingConfig(ExtensionConfig):
-    """Base schema for a preprocessing plugin's ``extension`` slice.
+class PreprocessingConfig(PluginConfig):
+    """Base schema for a preprocessing plugin's ``plugins`` slice.
 
-    Inherits ``extra='forbid'`` from :class:`ExtensionConfig` (a route may only
+    Inherits ``extra='forbid'`` from :class:`PluginConfig` (a route may only
     set the parameters a plugin declares) and adds the opt-in ``enabled`` flag.
     Subclass to add plugin-specific fields::
 
@@ -75,7 +75,7 @@ class PreprocessingConfig(ExtensionConfig):
 class PreprocessingPlugin(ABC):
     """Implemented by plugins that want to transform incoming chat messages."""
 
-    #: Optional schema for this plugin's ``extension`` slice. When set, the
+    #: Optional schema for this plugin's ``plugins`` slice. When set, the
     #: default :meth:`validate` checks the slice against it, rejecting unknown
     #: keys and invalid types. Subclass :class:`PreprocessingConfig`.
     config_schema: type[PreprocessingConfig] | None = None
@@ -89,10 +89,10 @@ class PreprocessingPlugin(ABC):
         return isinstance(config, dict) and bool(config.get('enabled', False))
 
     def validate(self, config: dict) -> None:
-        """Validate this plugin's own ``extension`` slice at config-load time.
+        """Validate this plugin's own ``plugins`` slice at config-load time.
 
         Called once per route that declares a slice for this plugin (its config
-        key is present), via the extension validator registered in
+        key is present), via the plugins validator registered in
         :func:`register_preprocessing_plugin`. Raise ``ValueError`` on invalid
         config to fail config validation.
 
@@ -111,7 +111,7 @@ class PreprocessingPlugin(ABC):
         *messages* are the client's chat messages only; the route's configured
         system prompt is injected after preprocessing and is never present here.
 
-        *config* is this plugin's slice of the route's ``extension`` config
+        *config* is this plugin's slice of the route's ``plugins`` config
         (the value under this plugin's key); ``None`` when the route declares
         no slice for it. Read route-specific settings from it as needed.
 
@@ -145,7 +145,7 @@ class PreprocessingPlugin(ABC):
 
 
 def _config_key(plugin: PreprocessingPlugin) -> str:
-    """Resolve a plugin's ``extension`` config key: its top-level package name,
+    """Resolve a plugin's ``plugins`` config key: its top-level package name,
     which equals the entry-point name used in ``ENABLED_PLUGINS`` (e.g. a plugin
     in package ``uppercase_preprocessor`` keys on ``uppercase_preprocessor``).
     """
@@ -153,7 +153,7 @@ def _config_key(plugin: PreprocessingPlugin) -> str:
 
 
 # Registry of config key -> (plugin, task-wrapped runner). The executed chain is
-# NOT registry order: per request it follows the route's ``extension`` key order
+# NOT registry order: per request it follows the route's ``plugins`` key order
 # (see ``_enabled_chain``). Last registration per key wins.
 _PluginRunner = Callable[[list[BaseMessage], dict | None], Awaitable[list[BaseMessage]]]
 _registered: dict[str, tuple[PreprocessingPlugin, _PluginRunner]] = {}
@@ -165,12 +165,12 @@ def register_preprocessing_plugin(
     """Register a preprocessing plugin to join the chain.
 
     Call from a plugin module at import time. Plugins run in the order their
-    keys appear in the route's ``extension`` config (route config order), not in
+    keys appear in the route's ``plugins`` config (route config order), not in
     registration order; see :func:`_enabled_chain`. Its ``preprocess``
     method is wrapped with a traceloop ``task`` span named ``preprocess.<key>``
     once, here, rather than per request.
 
-    The plugin's ``extension`` config key defaults to its package name (see
+    The plugin's ``plugins`` config key defaults to its package name (see
     :func:`_config_key`); pass *name* to override it (e.g. in tests where several
     plugin classes share one module).
     """
@@ -182,7 +182,7 @@ def register_preprocessing_plugin(
     ) -> list[BaseMessage]:
         return await plugin.preprocess(messages, config)
 
-    register_extension_slice_validator(key, plugin.validate)
+    register_plugin_config_validator(key, plugin.validate)
     _registered[key] = (plugin, _run)
     logger.info('Registered preprocessing plugin: %s', key)
 
@@ -211,16 +211,16 @@ async def _invoke(
 
 
 def _enabled_chain(
-    extension: dict | None,
+    plugins: dict | None,
 ) -> list[tuple[str, _PluginRunner, dict | None]]:
-    """Resolve the ordered ``(key, runner, config)`` chain for *extension*.
+    """Resolve the ordered ``(key, runner, config)`` chain for *plugins*.
 
-    A plugin is included only when its config key is present in *extension* and
+    A plugin is included only when its config key is present in *plugins* and
     :meth:`PreprocessingPlugin.is_enabled` returns True for its slice. The order
-    follows the keys' order in *extension* (the route's config order). Extension
+    follows the keys' order in *plugins* (the route's config order). Plugins
     keys that are not registered preprocessing plugins are ignored.
     """
-    by_key = extension if isinstance(extension, dict) else {}
+    by_key = plugins if isinstance(plugins, dict) else {}
     chain: list[tuple[str, _PluginRunner, dict | None]] = []
     for key, config in by_key.items():
         entry = _registered.get(key)
@@ -244,16 +244,16 @@ async def _run_chain(
 
 
 async def run_preprocessing(
-    messages: list[BaseMessage], extension: dict | None = None
+    messages: list[BaseMessage], plugins: dict | None = None
 ) -> list[BaseMessage]:
-    """Run the preprocessing chain over *messages* for a route's *extension*.
+    """Run the preprocessing chain over *messages* for a route's *plugins*.
 
     Each plugin's slice is passed to ``preprocess``; plugins run in the route's
     config order (see :func:`_enabled_chain`). When no plugin is enabled this is
     a no-op that returns *messages* unchanged **without** opening a workflow
     span; otherwise the chain runs inside the ``run_preprocessing`` workflow.
     """
-    chain = _enabled_chain(extension)
+    chain = _enabled_chain(plugins)
     if not chain:
         return messages
     return await _run_chain(messages, chain)

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -23,7 +23,6 @@ Contract:
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 import logging
-import re
 
 from fastapi import status
 from langchain_core.messages import BaseMessage
@@ -140,10 +139,11 @@ class PreprocessingPlugin(ABC):
 
 
 def _config_key(plugin: PreprocessingPlugin) -> str:
-    """Resolve a plugin's ``extension`` config key: the snake_case form of the
-    class name (e.g. ``MyPlugin`` -> ``my_plugin``).
+    """Resolve a plugin's ``extension`` config key: its top-level package name,
+    which equals the entry-point name used in ``ENABLED_PLUGINS`` (e.g. a plugin
+    in package ``uppercase_preprocessor`` keys on ``uppercase_preprocessor``).
     """
-    return re.sub(r'(?<!^)(?=[A-Z])', '_', type(plugin).__name__).lower()
+    return type(plugin).__module__.partition('.')[0]
 
 
 # Registry of (config key, plugin, task-wrapped runner). Chain order ==
@@ -152,15 +152,21 @@ _PluginRunner = Callable[[list[BaseMessage], dict | None], Awaitable[list[BaseMe
 _registered: list[tuple[str, PreprocessingPlugin, _PluginRunner]] = []
 
 
-def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
+def register_preprocessing_plugin(
+    plugin: PreprocessingPlugin, name: str | None = None
+) -> None:
     """Register a preprocessing plugin to join the chain.
 
     Call from a plugin module at import time. The plugin runs in the order it
     was registered, relative to other preprocessing plugins. Its ``preprocess``
     method is wrapped with a traceloop ``task`` span named ``preprocess.<key>``
     once, here, rather than per request.
+
+    The plugin's ``extension`` config key defaults to its package name (see
+    :func:`_config_key`); pass *name* to override it (e.g. in tests where several
+    plugin classes share one module).
     """
-    key = _config_key(plugin)
+    key = name or _config_key(plugin)
 
     @task(name=f'preprocess.{key}')
     async def _run(

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -16,7 +16,6 @@ Contract:
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 import logging
 
 from fastapi import status
@@ -80,21 +79,10 @@ class PreprocessingPlugin(ABC):
         ...
 
 
-@dataclass
-class _Entry:
-    """A registered plugin plus its task-wrapped runner.
-
-    ``runner`` is decorated with :func:`task` once at registration (using a
-    per-plugin span name) so the wrapper is built at startup, not per request.
-    """
-
-    name: str
-    plugin: PreprocessingPlugin
-    runner: Callable[[list[BaseMessage]], Awaitable[list[BaseMessage]]]
-
-
-# Registry. Chain order == registration order (i.e. plugin load order).
-_registered: list[_Entry] = []
+# Registry of (plugin name, task-wrapped runner). Chain order == registration
+# order (i.e. plugin load order).
+_PluginRunner = Callable[[list[BaseMessage]], Awaitable[list[BaseMessage]]]
+_registered: list[tuple[str, _PluginRunner]] = []
 
 
 def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
@@ -106,23 +94,17 @@ def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
     once, here, rather than per request.
     """
     name = type(plugin).__name__
-    span_name = f'preprocess.{name}'
 
-    @task(name=span_name)
+    @task(name=f'preprocess.{name}')
     async def _run(messages: list[BaseMessage]) -> list[BaseMessage]:
         return await plugin.preprocess(messages)
 
-    _registered.append(_Entry(name=name, plugin=plugin, runner=_run))
+    _registered.append((name, _run))
     logger.info('Registered preprocessing plugin: %s', name)
 
 
-def get_preprocessing_plugins() -> list[PreprocessingPlugin]:
-    """Return the registered preprocessing plugins, in chain order."""
-    return [entry.plugin for entry in _registered]
-
-
-async def _invoke_entry(
-    entry: _Entry, messages: list[BaseMessage]
+async def _invoke(
+    name: str, run: _PluginRunner, messages: list[BaseMessage]
 ) -> list[BaseMessage]:
     """Run one plugin's task-wrapped runner with fail-closed error wrapping.
 
@@ -130,14 +112,14 @@ async def _invoke_entry(
     any other exception is wrapped in :class:`PreprocessingError`.
     """
     try:
-        return await entry.runner(messages)
+        return await run(messages)
     except AppError:
         # The plugin raised a structured gateway error on purpose; let it through.
         raise
     except Exception as e:
         raise PreprocessingError(
             'A preprocessing step failed.',
-            log_message=f'preprocessing plugin {entry.name} failed: {e}',
+            log_message=f'preprocessing plugin {name} failed: {e}',
         ) from e
 
 
@@ -146,9 +128,8 @@ async def run_preprocessing(messages: list[BaseMessage]) -> list[BaseMessage]:
     """Run the preprocessing chain over *messages*.
 
     No-op when no plugins are registered. Fail-closed per plugin via
-    :func:`_invoke_entry`.
+    :func:`_invoke`.
     """
-    current = messages
-    for entry in _registered:
-        current = await _invoke_entry(entry, current)
-    return current
+    for name, run in _registered:
+        messages = await _invoke(name, run, messages)
+    return messages

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -15,6 +15,8 @@ Contract:
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 import logging
 
 from fastapi import status
@@ -78,44 +80,75 @@ class PreprocessingPlugin(ABC):
         ...
 
 
+@dataclass
+class _Entry:
+    """A registered plugin plus its task-wrapped runner.
+
+    ``runner`` is decorated with :func:`task` once at registration (using a
+    per-plugin span name) so the wrapper is built at startup, not per request.
+    """
+
+    name: str
+    plugin: PreprocessingPlugin
+    runner: Callable[[list[BaseMessage]], Awaitable[list[BaseMessage]]]
+
+
 # Registry. Chain order == registration order (i.e. plugin load order).
-_registered: list[PreprocessingPlugin] = []
+_registered: list[_Entry] = []
 
 
 def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
     """Register a preprocessing plugin to join the chain.
 
     Call from a plugin module at import time. The plugin runs in the order it
-    was registered, relative to other preprocessing plugins.
+    was registered, relative to other preprocessing plugins. Its ``preprocess``
+    method is wrapped with a traceloop ``task`` span named ``preprocess.<Plugin>``
+    once, here, rather than per request.
     """
-    _registered.append(plugin)
-    logger.info('Registered preprocessing plugin: %s', type(plugin).__name__)
+    name = type(plugin).__name__
+    span_name = f'preprocess.{name}'
+
+    @task(name=span_name)
+    async def _run(messages: list[BaseMessage]) -> list[BaseMessage]:
+        return await plugin.preprocess(messages)
+
+    _registered.append(_Entry(name=name, plugin=plugin, runner=_run))
+    logger.info('Registered preprocessing plugin: %s', name)
 
 
 def get_preprocessing_plugins() -> list[PreprocessingPlugin]:
     """Return the registered preprocessing plugins, in chain order."""
-    return list(_registered)
+    return [entry.plugin for entry in _registered]
+
+
+async def _invoke_entry(
+    entry: _Entry, messages: list[BaseMessage]
+) -> list[BaseMessage]:
+    """Run one plugin's task-wrapped runner with fail-closed error wrapping.
+
+    An ``AppError`` is propagated unchanged so a plugin can control the response;
+    any other exception is wrapped in :class:`PreprocessingError`.
+    """
+    try:
+        return await entry.runner(messages)
+    except AppError:
+        # The plugin raised a structured gateway error on purpose; let it through.
+        raise
+    except Exception as e:
+        raise PreprocessingError(
+            'A preprocessing step failed.',
+            log_message=f'preprocessing plugin {entry.name} failed: {e}',
+        ) from e
 
 
 @workflow(name='run_preprocessing')
 async def run_preprocessing(messages: list[BaseMessage]) -> list[BaseMessage]:
     """Run the preprocessing chain over *messages*.
 
-    No-op when no plugins are registered. Fail-closed: if a plugin raises an
-    ``AppError`` it is propagated as-is (so the plugin can control the response);
-    any other exception is wrapped in :class:`PreprocessingError`.
+    No-op when no plugins are registered. Fail-closed per plugin via
+    :func:`_invoke_entry`.
     """
     current = messages
-    for plugin in get_preprocessing_plugins():
-        name = type(plugin).__name__
-        try:
-            current = await task(name=f'preprocess.{name}')(plugin.preprocess)(current)
-        except AppError:
-            # The plugin raised a structured gateway error on purpose; let it through.
-            raise
-        except Exception as e:
-            raise PreprocessingError(
-                'A preprocessing step failed.',
-                log_message=f'preprocessing plugin {name} failed: {e}',
-            ) from e
+    for entry in _registered:
+        current = await _invoke_entry(entry, current)
     return current

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -152,11 +152,11 @@ def _config_key(plugin: PreprocessingPlugin) -> str:
     return type(plugin).__module__.partition('.')[0]
 
 
-# Registry of (config key, plugin, task-wrapped runner) in registration order.
-# The executed chain is NOT registry order: per request it is reordered to the
-# route's ``extension`` key order (see ``_enabled_chain``).
+# Registry of config key -> (plugin, task-wrapped runner). The executed chain is
+# NOT registry order: per request it follows the route's ``extension`` key order
+# (see ``_enabled_chain``). Last registration per key wins.
 _PluginRunner = Callable[[list[BaseMessage], dict | None], Awaitable[list[BaseMessage]]]
-_registered: list[tuple[str, PreprocessingPlugin, _PluginRunner]] = []
+_registered: dict[str, tuple[PreprocessingPlugin, _PluginRunner]] = {}
 
 
 def register_preprocessing_plugin(
@@ -183,7 +183,7 @@ def register_preprocessing_plugin(
         return await plugin.preprocess(messages, config)
 
     register_extension_slice_validator(key, plugin.validate)
-    _registered.append((key, plugin, _run))
+    _registered[key] = (plugin, _run)
     logger.info('Registered preprocessing plugin: %s', key)
 
 
@@ -221,10 +221,9 @@ def _enabled_chain(
     keys that are not registered preprocessing plugins are ignored.
     """
     by_key = extension if isinstance(extension, dict) else {}
-    registered = {key: (plugin, run) for key, plugin, run in _registered}
     chain: list[tuple[str, _PluginRunner, dict | None]] = []
     for key, config in by_key.items():
-        entry = registered.get(key)
+        entry = _registered.get(key)
         if entry is None:
             continue
         plugin, run = entry

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -19,6 +19,7 @@ import logging
 
 from fastapi import status
 from langchain_core.messages import BaseMessage
+from traceloop.sdk.decorators import task, workflow
 
 from radicalbit_ai_gateway.utils.exceptions import AppError, GatewayError
 
@@ -96,6 +97,7 @@ def get_preprocessing_plugins() -> list[PreprocessingPlugin]:
     return list(_registered)
 
 
+@workflow(name='run_preprocessing')
 async def run_preprocessing(messages: list[BaseMessage]) -> list[BaseMessage]:
     """Run the preprocessing chain over *messages*.
 
@@ -107,7 +109,7 @@ async def run_preprocessing(messages: list[BaseMessage]) -> list[BaseMessage]:
     for plugin in get_preprocessing_plugins():
         name = type(plugin).__name__
         try:
-            current = await plugin.preprocess(current)
+            current = await task(name=f'preprocess.{name}')(plugin.preprocess)(current)
         except AppError:
             # The plugin raised a structured gateway error on purpose; let it through.
             raise

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -1,8 +1,8 @@
 """Preprocessing plugins.
 
-A hook that lets plugins transform the incoming chat messages *before* they
-reach the input guardrails. Plugins register an implementation at import time
-(during ``discover_plugins()``).
+A hook that lets plugins transform the incoming chat messages *before* model
+selection and the input guardrails. Plugins register an implementation at import
+time (during ``discover_plugins()``).
 
 Contract:
 - A plugin implements :class:`PreprocessingPlugin` and registers an instance via
@@ -10,6 +10,9 @@ Contract:
 - ``preprocess`` takes the messages and the plugin's own slice of the route's
   ``extension`` config, and returns the same structure (``list[BaseMessage]``)
   so the chain composes.
+- Plugins receive only the **client's** chat messages. The route's configured
+  system prompt is injected *after* preprocessing runs, so it is never passed to
+  a plugin and cannot be modified by one.
 - Per-route, opt-in: a plugin runs only when its config key is present in the
   route's ``extension`` and it is enabled there (see
   :meth:`PreprocessingPlugin.is_enabled`). Plugins run in the order their keys
@@ -104,6 +107,9 @@ class PreprocessingPlugin(ABC):
         self, messages: list[BaseMessage], config: dict | None
     ) -> list[BaseMessage]:
         """Transform *messages* and return the same structure.
+
+        *messages* are the client's chat messages only; the route's configured
+        system prompt is injected after preprocessing and is never present here.
 
         *config* is this plugin's slice of the route's ``extension`` config
         (the value under this plugin's key); ``None`` when the route declares

--- a/gateway/radicalbit_ai_gateway/preprocessing.py
+++ b/gateway/radicalbit_ai_gateway/preprocessing.py
@@ -7,22 +7,31 @@ reach the input guardrails. Plugins register an implementation at import time
 Contract:
 - A plugin implements :class:`PreprocessingPlugin` and registers an instance via
   :func:`register_preprocessing_plugin`.
-- ``preprocess`` takes the messages and returns the same structure
-  (``list[BaseMessage]``) so the chain composes.
-- Plugins run in registration order. With no plugins registered the chain is a
-  no-op and messages pass through unchanged.
+- ``preprocess`` takes the messages and the plugin's own slice of the route's
+  ``extension`` config, and returns the same structure (``list[BaseMessage]``)
+  so the chain composes.
+- Per-route, opt-in: a plugin runs only when its config key is present in the
+  route's ``extension`` and it is enabled there (see
+  :meth:`PreprocessingPlugin.is_enabled`). Plugins run in the order their keys
+  appear in ``extension`` (route config order); with none enabled the chain is
+  a no-op.
+- A plugin validates its own ``extension`` slice at config-load time by
+  overriding :meth:`PreprocessingPlugin.validate`.
 - Fail-closed: if a plugin raises, the chain stops and the request is aborted.
 """
 
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 import logging
+import re
 
 from fastapi import status
 from langchain_core.messages import BaseMessage
+from pydantic import BaseModel, ConfigDict
 from traceloop.sdk.decorators import task, workflow
 
 from radicalbit_ai_gateway.utils.app_config import get_app_config
+from radicalbit_ai_gateway.utils.config_hooks import register_extension_validator
 from radicalbit_ai_gateway.utils.exceptions import AppError, GatewayError
 
 app_config = get_app_config()
@@ -45,12 +54,60 @@ class PreprocessingError(GatewayError):
         )
 
 
+class PreprocessingConfig(BaseModel):
+    """Base schema for a plugin's ``extension`` slice.
+
+    Forbids unknown keys (``extra='forbid'``), so a route may only set the
+    parameters a plugin declares. Subclass to add plugin-specific fields::
+
+        class MyConfig(PreprocessingConfig):
+            threshold: int = 5
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+    enabled: bool = False
+
+
 class PreprocessingPlugin(ABC):
     """Implemented by plugins that want to transform incoming chat messages."""
 
+    #: Optional schema for this plugin's ``extension`` slice. When set, the
+    #: default :meth:`validate` checks the slice against it, rejecting unknown
+    #: keys and invalid types. Subclass :class:`PreprocessingConfig`.
+    config_schema: type[PreprocessingConfig] | None = None
+
+    def is_enabled(self, config: dict | None) -> bool:
+        """Whether this plugin runs for a route, given its config slice.
+
+        Default: opt-in — runs only when the slice has a truthy ``enabled``
+        flag. Override for custom gating.
+        """
+        return isinstance(config, dict) and bool(config.get('enabled', False))
+
+    def validate(self, config: dict) -> None:
+        """Validate this plugin's own ``extension`` slice at config-load time.
+
+        Called once per route that declares a slice for this plugin (its config
+        key is present), via the extension validator registered in
+        :func:`register_preprocessing_plugin`. Raise ``ValueError`` on invalid
+        config to fail config validation.
+
+        Default: validate against :attr:`config_schema` if set (which rejects
+        unknown keys); otherwise a no-op. Override for custom validation.
+        """
+        if self.config_schema is not None:
+            self.config_schema.model_validate(config)
+
     @abstractmethod
-    async def preprocess(self, messages: list[BaseMessage]) -> list[BaseMessage]:
+    async def preprocess(
+        self, messages: list[BaseMessage], config: dict | None
+    ) -> list[BaseMessage]:
         """Transform *messages* and return the same structure.
+
+        *config* is this plugin's slice of the route's ``extension`` config
+        (the value under this plugin's key); ``None`` when the route declares
+        no slice for it. Read route-specific settings from it as needed.
 
         Each message's ``content`` can take two shapes, and an implementation
         that edits text should handle both:
@@ -81,10 +138,17 @@ class PreprocessingPlugin(ABC):
         ...
 
 
-# Registry of (plugin name, task-wrapped runner). Chain order == registration
-# order (i.e. plugin load order).
-_PluginRunner = Callable[[list[BaseMessage]], Awaitable[list[BaseMessage]]]
-_registered: list[tuple[str, _PluginRunner]] = []
+def _config_key(plugin: PreprocessingPlugin) -> str:
+    """Resolve a plugin's ``extension`` config key: the snake_case form of the
+    class name (e.g. ``MyPlugin`` -> ``my_plugin``).
+    """
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', type(plugin).__name__).lower()
+
+
+# Registry of (config key, plugin, task-wrapped runner). Chain order ==
+# registration order (i.e. plugin load order).
+_PluginRunner = Callable[[list[BaseMessage], dict | None], Awaitable[list[BaseMessage]]]
+_registered: list[tuple[str, PreprocessingPlugin, _PluginRunner]] = []
 
 
 def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
@@ -92,21 +156,32 @@ def register_preprocessing_plugin(plugin: PreprocessingPlugin) -> None:
 
     Call from a plugin module at import time. The plugin runs in the order it
     was registered, relative to other preprocessing plugins. Its ``preprocess``
-    method is wrapped with a traceloop ``task`` span named ``preprocess.<Plugin>``
+    method is wrapped with a traceloop ``task`` span named ``preprocess.<key>``
     once, here, rather than per request.
     """
-    name = type(plugin).__name__
+    key = _config_key(plugin)
 
-    @task(name=f'preprocess.{name}')
-    async def _run(messages: list[BaseMessage]) -> list[BaseMessage]:
-        return await plugin.preprocess(messages)
+    @task(name=f'preprocess.{key}')
+    async def _run(
+        messages: list[BaseMessage], config: dict | None
+    ) -> list[BaseMessage]:
+        return await plugin.preprocess(messages, config)
 
-    _registered.append((name, _run))
-    logger.info('Registered preprocessing plugin: %s', name)
+    def _validate(extension: dict) -> None:
+        config = extension.get(key)
+        if config is not None:
+            plugin.validate(config)
+
+    register_extension_validator(_validate)
+    _registered.append((key, plugin, _run))
+    logger.info('Registered preprocessing plugin: %s', key)
 
 
 async def _invoke(
-    name: str, run: _PluginRunner, messages: list[BaseMessage]
+    key: str,
+    run: _PluginRunner,
+    messages: list[BaseMessage],
+    config: dict | None,
 ) -> list[BaseMessage]:
     """Run one plugin's task-wrapped runner with fail-closed error wrapping.
 
@@ -114,24 +189,62 @@ async def _invoke(
     any other exception is wrapped in :class:`PreprocessingError`.
     """
     try:
-        return await run(messages)
+        return await run(messages, config)
     except AppError:
         # The plugin raised a structured gateway error on purpose; let it through.
         raise
     except Exception as e:
         raise PreprocessingError(
             'A preprocessing step failed.',
-            log_message=f'preprocessing plugin {name} failed: {e}',
+            log_message=f'preprocessing plugin {key} failed: {e}',
         ) from e
 
 
-@workflow(name='run_preprocessing')
-async def run_preprocessing(messages: list[BaseMessage]) -> list[BaseMessage]:
-    """Run the preprocessing chain over *messages*.
+def _enabled_chain(
+    extension: dict | None,
+) -> list[tuple[str, _PluginRunner, dict | None]]:
+    """Resolve the ordered ``(key, runner, config)`` chain for *extension*.
 
-    No-op when no plugins are registered. Fail-closed per plugin via
-    :func:`_invoke`.
+    A plugin is included only when its config key is present in *extension* and
+    :meth:`PreprocessingPlugin.is_enabled` returns True for its slice. The order
+    follows the keys' order in *extension* (the route's config order). Extension
+    keys that are not registered preprocessing plugins are ignored.
     """
-    for name, run in _registered:
-        messages = await _invoke(name, run, messages)
+    by_key = extension if isinstance(extension, dict) else {}
+    registered = {key: (plugin, run) for key, plugin, run in _registered}
+    chain: list[tuple[str, _PluginRunner, dict | None]] = []
+    for key, config in by_key.items():
+        entry = registered.get(key)
+        if entry is None:
+            continue
+        plugin, run = entry
+        if plugin.is_enabled(config):
+            chain.append((key, run, config))
+    return chain
+
+
+@workflow(name='run_preprocessing')
+async def _run_chain(
+    messages: list[BaseMessage],
+    chain: list[tuple[str, _PluginRunner, dict | None]],
+) -> list[BaseMessage]:
+    """Run a resolved preprocessing *chain*, fail-closed per plugin."""
+    for key, run, config in chain:
+        messages = await _invoke(key, run, messages, config)
     return messages
+
+
+async def run_preprocessing(
+    messages: list[BaseMessage], extension: dict | None = None
+) -> list[BaseMessage]:
+    """Run the preprocessing chain over *messages* for a route's *extension*.
+
+    Each plugin's slice is passed to ``preprocess``; plugins run in the route's
+    config order (see :func:`_enabled_chain`). When no plugin is enabled this is
+    a no-op that returns *messages* unchanged **without** opening a workflow
+    span; otherwise the chain runs inside the ``run_preprocessing`` workflow.
+    """
+    chain = _enabled_chain(extension)
+    if not chain:
+        return messages
+    return await _run_chain(messages, chain)

--- a/gateway/radicalbit_ai_gateway/utils/config_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/config_hooks.py
@@ -3,55 +3,55 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, create_model
 
-_extension_validators: list[Callable[[object], None]] = []
-_known_extension_keys: set[str] = set()
+_plugins_validators: list[Callable[[object], None]] = []
+_known_plugin_keys: set[str] = set()
 
 
-def register_extension_validator(validate: Callable[[object], None]) -> None:
-    """Register a validator for a route's ``extension`` config."""
-    _extension_validators.append(validate)
+def register_plugins_validator(validate: Callable[[object], None]) -> None:
+    """Register a validator for a route's ``plugins`` config."""
+    _plugins_validators.append(validate)
 
 
-def get_extension_validators() -> list[Callable[[object], None]]:
-    """Return the registered extension validators, in registration order."""
-    return list(_extension_validators)
+def get_plugins_validators() -> list[Callable[[object], None]]:
+    """Return the registered plugins validators, in registration order."""
+    return list(_plugins_validators)
 
 
-def get_known_extension_keys() -> set[str]:
-    """Return the ``extension`` keys claimed by a registered plugin slice.
+def get_known_plugin_keys() -> set[str]:
+    """Return the ``plugins`` keys claimed by a registered plugin slice.
 
     A plugin declares a key by registering a slice validator/schema for it (see
-    :func:`register_extension_slice_validator`). A route may only set keys in
-    this set; see :func:`build_route_extension_model`.
+    :func:`register_plugin_config_validator`). A route may only set keys in
+    this set; see :func:`build_route_plugins_model`.
     """
-    return set(_known_extension_keys)
+    return set(_known_plugin_keys)
 
 
-def build_route_extension_model(keys: Iterable[str]) -> type[BaseModel]:
+def build_route_plugins_model(keys: Iterable[str]) -> type[BaseModel]:
     """Build a model whose only allowed fields are *keys*.
 
-    *keys* are the ``extension`` keys plugins claimed via slice/schema
+    *keys* are the ``plugins`` keys plugins claimed via slice/schema
     registration. The returned model lists exactly those keys and sets
-    ``extra='forbid'``, so a route ``extension`` that names a key no plugin
+    ``extra='forbid'``, so a route ``plugins`` that names a key no plugin
     claims — a typo'd or stale plugin name — fails config validation instead of
     being silently ignored. Field contents stay permissive (``Any``); the
     per-slice validators validate each slice's contents.
     """
     fields: dict[str, Any] = dict.fromkeys(keys, (Any, None))
     return create_model(
-        'RouteExtension',
+        'RoutePlugins',
         __config__=ConfigDict(extra='forbid'),
         **fields,
     )
 
 
-class ExtensionConfig(BaseModel):
-    """Base schema for a plugin's ``extension`` slice.
+class PluginConfig(BaseModel):
+    """Base schema for a plugin's ``plugins`` slice.
 
     Forbids unknown keys (``extra='forbid'``), so a route may only set the
     parameters a plugin declares. Subclass to add plugin-specific fields::
 
-        class MyPluginConfig(ExtensionConfig):
+        class MyPluginConfig(PluginConfig):
             threshold: int = 5
 
     Secret-bearing fields (set via ``!secret KEY`` in YAML) must be typed as
@@ -64,23 +64,23 @@ class ExtensionConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
 
-def register_extension_slice_validator(
+def register_plugin_config_validator(
     key: str, validate_slice: Callable[[Any], object]
 ) -> None:
-    """Register a validator scoped to one ``extension`` key.
+    """Register a validator scoped to one ``plugins`` key.
 
-    Runs ``validate_slice`` on ``extension[key]`` only when that key is present
-    in a route's ``extension``. Raise ``ValueError`` from *validate_slice* to
-    fail config validation. Records *key* as a known ``extension`` key (see
-    :func:`build_route_extension_model`), so a route may only set keys some
+    Runs ``validate_slice`` on ``plugins[key]`` only when that key is present
+    in a route's ``plugins``. Raise ``ValueError`` from *validate_slice* to
+    fail config validation. Records *key* as a known ``plugins`` key (see
+    :func:`build_route_plugins_model`), so a route may only set keys some
     plugin claims.
     """
-    _known_extension_keys.add(key)
+    _known_plugin_keys.add(key)
 
-    def _validate(extension: object) -> None:
-        if isinstance(extension, dict):
-            config = extension.get(key)
+    def _validate(plugins: object) -> None:
+        if isinstance(plugins, dict):
+            config = plugins.get(key)
             if config is not None:
                 validate_slice(config)
 
-    register_extension_validator(_validate)
+    register_plugins_validator(_validate)

--- a/gateway/radicalbit_ai_gateway/utils/config_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/config_hooks.py
@@ -84,13 +84,3 @@ def register_extension_slice_validator(
                 validate_slice(config)
 
     register_extension_validator(_validate)
-
-
-def register_extension_schema(key: str, schema: type[ExtensionConfig]) -> None:
-    """Validate the ``extension[key]`` slice against *schema* at config-load time.
-
-    The one-call path for any plugin that needs extra config fields: define an
-    :class:`ExtensionConfig` subclass and register it under the plugin's key.
-    Unknown keys and invalid types are rejected.
-    """
-    register_extension_slice_validator(key, schema.model_validate)

--- a/gateway/radicalbit_ai_gateway/utils/config_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/config_hooks.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+from pydantic import BaseModel, ConfigDict
+
 _extension_validators: list[Callable[[object], None]] = []
 
 
@@ -11,3 +13,50 @@ def register_extension_validator(validate: Callable[[object], None]) -> None:
 def get_extension_validators() -> list[Callable[[object], None]]:
     """Return the registered extension validators, in registration order."""
     return list(_extension_validators)
+
+
+class ExtensionConfig(BaseModel):
+    """Base schema for a plugin's ``extension`` slice.
+
+    Forbids unknown keys (``extra='forbid'``), so a route may only set the
+    parameters a plugin declares. Subclass to add plugin-specific fields::
+
+        class MyPluginConfig(ExtensionConfig):
+            threshold: int = 5
+
+    Secret-bearing fields (set via ``!secret KEY`` in YAML) must be typed as
+    ``str`` (or ``SecretStr`` / ``str | None``): ``!secret`` resolves to a
+    string before this schema runs, and during validation it is a placeholder
+    string rather than the real value — so do not type such fields ``int``/
+    ``bool`` or attach a format regex.
+    """
+
+    model_config = ConfigDict(extra='forbid')
+
+
+def register_extension_slice_validator(
+    key: str, validate_slice: Callable[[dict], object]
+) -> None:
+    """Register a validator scoped to one ``extension`` key.
+
+    Runs ``validate_slice`` on ``extension[key]`` only when that key is present
+    in a route's ``extension``. Raise ``ValueError`` from *validate_slice* to
+    fail config validation.
+    """
+
+    def _validate(extension: dict) -> None:
+        config = extension.get(key)
+        if config is not None:
+            validate_slice(config)
+
+    register_extension_validator(_validate)
+
+
+def register_extension_schema(key: str, schema: type[ExtensionConfig]) -> None:
+    """Validate the ``extension[key]`` slice against *schema* at config-load time.
+
+    The one-call path for any plugin that needs extra config fields: define an
+    :class:`ExtensionConfig` subclass and register it under the plugin's key.
+    Unknown keys and invalid types are rejected.
+    """
+    register_extension_slice_validator(key, schema.model_validate)

--- a/gateway/radicalbit_ai_gateway/utils/config_hooks.py
+++ b/gateway/radicalbit_ai_gateway/utils/config_hooks.py
@@ -1,8 +1,10 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, create_model
 
 _extension_validators: list[Callable[[object], None]] = []
+_known_extension_keys: set[str] = set()
 
 
 def register_extension_validator(validate: Callable[[object], None]) -> None:
@@ -13,6 +15,34 @@ def register_extension_validator(validate: Callable[[object], None]) -> None:
 def get_extension_validators() -> list[Callable[[object], None]]:
     """Return the registered extension validators, in registration order."""
     return list(_extension_validators)
+
+
+def get_known_extension_keys() -> set[str]:
+    """Return the ``extension`` keys claimed by a registered plugin slice.
+
+    A plugin declares a key by registering a slice validator/schema for it (see
+    :func:`register_extension_slice_validator`). A route may only set keys in
+    this set; see :func:`build_route_extension_model`.
+    """
+    return set(_known_extension_keys)
+
+
+def build_route_extension_model(keys: Iterable[str]) -> type[BaseModel]:
+    """Build a model whose only allowed fields are *keys*.
+
+    *keys* are the ``extension`` keys plugins claimed via slice/schema
+    registration. The returned model lists exactly those keys and sets
+    ``extra='forbid'``, so a route ``extension`` that names a key no plugin
+    claims — a typo'd or stale plugin name — fails config validation instead of
+    being silently ignored. Field contents stay permissive (``Any``); the
+    per-slice validators validate each slice's contents.
+    """
+    fields: dict[str, Any] = dict.fromkeys(keys, (Any, None))
+    return create_model(
+        'RouteExtension',
+        __config__=ConfigDict(extra='forbid'),
+        **fields,
+    )
 
 
 class ExtensionConfig(BaseModel):
@@ -35,19 +65,23 @@ class ExtensionConfig(BaseModel):
 
 
 def register_extension_slice_validator(
-    key: str, validate_slice: Callable[[dict], object]
+    key: str, validate_slice: Callable[[Any], object]
 ) -> None:
     """Register a validator scoped to one ``extension`` key.
 
     Runs ``validate_slice`` on ``extension[key]`` only when that key is present
     in a route's ``extension``. Raise ``ValueError`` from *validate_slice* to
-    fail config validation.
+    fail config validation. Records *key* as a known ``extension`` key (see
+    :func:`build_route_extension_model`), so a route may only set keys some
+    plugin claims.
     """
+    _known_extension_keys.add(key)
 
-    def _validate(extension: dict) -> None:
-        config = extension.get(key)
-        if config is not None:
-            validate_slice(config)
+    def _validate(extension: object) -> None:
+        if isinstance(extension, dict):
+            config = extension.get(key)
+            if config is not None:
+                validate_slice(config)
 
     register_extension_validator(_validate)
 

--- a/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
+++ b/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
@@ -9,6 +9,7 @@ class OperationCategory(str, Enum):
     ENDPOINT = 'endpoint'
     AUTH = 'auth'
     ROUTING = 'routing'
+    PREPROCESSING = 'preprocessing'
     GUARDRAIL_INPUT = 'guardrail_input'
     GUARDRAIL_OUTPUT = 'guardrail_output'
     CACHE = 'cache'

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -967,7 +967,7 @@ async def test_preprocessing_runs_before_prompt_injection():
     route_cfg = GatewayRouteConfig(
         route_name='r',
         chat_models=['m'],
-        extension={'spy': {'enabled': True}},
+        plugins={'spy': {'enabled': True}},
     )
     ai_gateway = GatewayRoute(
         gateway_route_config=route_cfg,
@@ -993,8 +993,8 @@ async def test_preprocessing_runs_before_prompt_injection():
         )
     finally:
         preprocessing_module._registered.clear()
-        config_hooks._extension_validators.clear()
-        config_hooks._known_extension_keys.clear()
+        config_hooks._plugins_validators.clear()
+        config_hooks._known_plugin_keys.clear()
 
     # The plugin only ever saw the client message — no injected system prompt.
     assert seen == [('HumanMessage', 'hello')]
@@ -1032,7 +1032,7 @@ async def test_preprocessing_includes_client_sent_system_prompt():
     route_cfg = GatewayRouteConfig(
         route_name='r',
         chat_models=['m'],
-        extension={'spy': {'enabled': True}},
+        plugins={'spy': {'enabled': True}},
     )
     ai_gateway = GatewayRoute(
         gateway_route_config=route_cfg,
@@ -1061,8 +1061,8 @@ async def test_preprocessing_includes_client_sent_system_prompt():
         )
     finally:
         preprocessing_module._registered.clear()
-        config_hooks._extension_validators.clear()
-        config_hooks._known_extension_keys.clear()
+        config_hooks._plugins_validators.clear()
+        config_hooks._known_plugin_keys.clear()
 
     # The plugin saw the client's own system message (and the human message);
     # the route-configured prompt was NOT yet present.

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -994,6 +994,7 @@ async def test_preprocessing_runs_before_prompt_injection():
     finally:
         preprocessing_module._registered.clear()
         config_hooks._extension_validators.clear()
+        config_hooks._known_extension_keys.clear()
 
     # The plugin only ever saw the client message — no injected system prompt.
     assert seen == [('HumanMessage', 'hello')]
@@ -1061,6 +1062,7 @@ async def test_preprocessing_includes_client_sent_system_prompt():
     finally:
         preprocessing_module._registered.clear()
         config_hooks._extension_validators.clear()
+        config_hooks._known_extension_keys.clear()
 
     # The plugin saw the client's own system message (and the human message);
     # the route-configured prompt was NOT yet present.

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -2,7 +2,7 @@ import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun import freeze_time
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 from openai.types import CreateEmbeddingResponse
 from openai.types.chat.chat_completion import ChatCompletion
 import pook
@@ -28,8 +28,17 @@ from radicalbit_ai_gateway.guardrails.guardrail_engine import GuardrailEngine
 from radicalbit_ai_gateway.guardrails.judges.judge_engine import JudgeEngine
 from radicalbit_ai_gateway.guardrails.presidio import PresidioEngine
 from radicalbit_ai_gateway.limiting.token_limiter import InputTokenLimitExceeded
+from radicalbit_ai_gateway.models.credentials import Credentials
+from radicalbit_ai_gateway.models.gateway_route_config import GatewayRouteConfig
+from radicalbit_ai_gateway.models.model import Model
+import radicalbit_ai_gateway.preprocessing as preprocessing_module
+from radicalbit_ai_gateway.preprocessing import (
+    PreprocessingPlugin,
+    register_preprocessing_plugin,
+)
 from radicalbit_ai_gateway.prompt_manager import PromptManager
 from radicalbit_ai_gateway.services.cost_service import CostService
+from radicalbit_ai_gateway.utils import config_hooks
 from radicalbit_ai_gateway.utils.exceptions import (
     BudgetLimitExceededError,
     GatewayBadRequest,
@@ -931,3 +940,140 @@ async def test_cache_hit_flag_set_on_request_state(
         assert len(pook.pending_mocks()) == 0
 
     pook.disable_network()
+
+
+@pytest.mark.asyncio
+async def test_preprocessing_runs_before_prompt_injection():
+    """Preprocessing sees only the client messages, and the route's configured
+    system prompt is injected afterwards (so plugins can never modify it).
+    """
+    seen = []
+
+    class Spy(PreprocessingPlugin):
+        async def preprocess(self, messages, config):
+            # Snapshot exactly what the plugin receives, then transform client text.
+            seen.extend((type(m).__name__, m.content) for m in messages)
+            for m in messages:
+                if isinstance(m.content, str):
+                    m.content = m.content.upper()
+            return messages
+
+    chat_model = Model(
+        model_id='m',
+        model='openai/gpt-4o',
+        credentials=Credentials(api_key='sk-123'),
+        prompt='You are a helpful assistant.',
+    )
+    route_cfg = GatewayRouteConfig(
+        route_name='r',
+        chat_models=['m'],
+        extension={'spy': {'enabled': True}},
+    )
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[chat_model],
+        embedding_models=None,
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        cost_service=MagicMock(spec_set=CostService),
+        gateway_cache=None,
+    )
+
+    try:
+        register_preprocessing_plugin(Spy(), name='spy')
+        result = await ai_gateway._prepare_and_validate_request(
+            request_uuid=str(REQUEST_UUID),
+            api_key_uuid=str(API_KEY_UUID),
+            group_uuid=str(GROUP_UUID),
+            api_key_name='rb-key',
+            group_name='test-group',
+            route_name='r',
+            messages=[HumanMessage(content='hello')],
+            tools=[],
+            tool_choice=None,
+        )
+    finally:
+        preprocessing_module._registered.clear()
+        config_hooks._extension_validators.clear()
+
+    # The plugin only ever saw the client message — no injected system prompt.
+    assert seen == [('HumanMessage', 'hello')]
+
+    # The final messages start with the untouched system prompt, followed by the
+    # client message the plugin transformed.
+    messages = result.redacted_messages
+    assert isinstance(messages[0], SystemMessage)
+    assert messages[0].content == 'You are a helpful assistant.'
+    assert messages[1].content == 'HELLO'
+
+
+@pytest.mark.asyncio
+async def test_preprocessing_includes_client_sent_system_prompt():
+    """A system message the *client* sends is part of the incoming messages, so
+    preprocessing sees and may transform it; only the *route-configured* prompt
+    (injected afterwards) is shielded from plugins.
+    """
+    seen = []
+
+    class Spy(PreprocessingPlugin):
+        async def preprocess(self, messages, config):
+            seen.extend((type(m).__name__, m.content) for m in messages)
+            for m in messages:
+                if isinstance(m.content, str):
+                    m.content = m.content.upper()
+            return messages
+
+    chat_model = Model(
+        model_id='m',
+        model='openai/gpt-4o',
+        credentials=Credentials(api_key='sk-123'),
+        prompt='Route prompt.',
+    )
+    route_cfg = GatewayRouteConfig(
+        route_name='r',
+        chat_models=['m'],
+        extension={'spy': {'enabled': True}},
+    )
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[chat_model],
+        embedding_models=None,
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        cost_service=MagicMock(spec_set=CostService),
+        gateway_cache=None,
+    )
+
+    try:
+        register_preprocessing_plugin(Spy(), name='spy')
+        result = await ai_gateway._prepare_and_validate_request(
+            request_uuid=str(REQUEST_UUID),
+            api_key_uuid=str(API_KEY_UUID),
+            group_uuid=str(GROUP_UUID),
+            api_key_name='rb-key',
+            group_name='test-group',
+            route_name='r',
+            messages=[
+                SystemMessage(content='client system'),
+                HumanMessage(content='hello'),
+            ],
+            tools=[],
+            tool_choice=None,
+        )
+    finally:
+        preprocessing_module._registered.clear()
+        config_hooks._extension_validators.clear()
+
+    # The plugin saw the client's own system message (and the human message);
+    # the route-configured prompt was NOT yet present.
+    assert seen == [
+        ('SystemMessage', 'client system'),
+        ('HumanMessage', 'hello'),
+    ]
+
+    # Final order: route prompt prepended (untouched), then the client's
+    # system + human messages, both transformed by the plugin.
+    messages = result.redacted_messages
+    assert [(type(m).__name__, m.content) for m in messages] == [
+        ('SystemMessage', 'Route prompt.'),
+        ('SystemMessage', 'CLIENT SYSTEM'),
+        ('HumanMessage', 'HELLO'),
+    ]

--- a/gateway/tests/preprocessing_test.py
+++ b/gateway/tests/preprocessing_test.py
@@ -1,51 +1,114 @@
 from langchain_core.messages import HumanMessage
 import pytest
 
+from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 import radicalbit_ai_gateway.preprocessing as preprocessing_module
 from radicalbit_ai_gateway.preprocessing import (
+    PreprocessingConfig,
     PreprocessingError,
     PreprocessingPlugin,
+    _config_key,
     register_preprocessing_plugin,
     run_preprocessing,
 )
+from radicalbit_ai_gateway.utils import config_hooks
 from radicalbit_ai_gateway.utils.exceptions import GatewayBadRequest
 
 
 @pytest.fixture(autouse=True)
 def _clear_registry():
-    """Each test starts with an empty preprocessing registry."""
+    """Each test starts with empty preprocessing and extension-validator registries.
+
+    Registering a plugin also registers an extension validator, so both globals
+    must be reset between tests.
+    """
     preprocessing_module._registered.clear()
+    config_hooks._extension_validators.clear()
     yield
     preprocessing_module._registered.clear()
+    config_hooks._extension_validators.clear()
 
 
-class _Upper(PreprocessingPlugin):
-    async def preprocess(self, messages):
+def _config(extension):
+    """Build a GatewayConfig as in production (extension validated at load)."""
+    return GatewayConfig(
+        chat_models=[{'model_id': 'm', 'model': 'openai/gpt-4o'}],
+        routes={'r': {'chat_models': ['m'], 'extension': extension}},
+    )
+
+
+class Upper(PreprocessingPlugin):
+    async def preprocess(self, messages, config):
         for m in messages:
             if isinstance(m.content, str):
                 m.content = m.content.upper()
         return messages
 
 
-class _Suffix(PreprocessingPlugin):
-    def __init__(self, suffix: str):
-        self._suffix = suffix
-
-    async def preprocess(self, messages):
+class Suffix(PreprocessingPlugin):
+    async def preprocess(self, messages, config):
+        suffix = (config or {}).get('suffix', '')
         for m in messages:
             if isinstance(m.content, str):
-                m.content = m.content + self._suffix
+                m.content = m.content + suffix
         return messages
 
 
-class _RuntimeError(PreprocessingPlugin):
-    async def preprocess(self, messages):
+class AlwaysOn(PreprocessingPlugin):
+    """Overrides gating to run regardless of the ``enabled`` flag."""
+
+    def is_enabled(self, config):
+        return True
+
+    async def preprocess(self, messages, config):
+        for m in messages:
+            if isinstance(m.content, str):
+                m.content = m.content + '!'
+        return messages
+
+
+class Validating(PreprocessingPlugin):
+    """Validates its own slice: requires a ``threshold`` key."""
+
+    def validate(self, config):
+        if 'threshold' not in config:
+            raise ValueError('threshold required')
+
+    async def preprocess(self, messages, config):
+        return messages
+
+
+class SchemaConfig(PreprocessingConfig):
+    threshold: int = 5
+
+
+class SchemaPlugin(PreprocessingPlugin):
+    """Uses a declared schema: only ``enabled`` and ``threshold`` allowed."""
+
+    config_schema = SchemaConfig
+
+    async def preprocess(self, messages, config):
+        return messages
+
+
+class Boom(PreprocessingPlugin):
+    async def preprocess(self, messages, config):
         raise RuntimeError('Error')
 
 
-class _BadRequestError(PreprocessingPlugin):
-    async def preprocess(self, messages):
+class BadRequest(PreprocessingPlugin):
+    async def preprocess(self, messages, config):
         raise GatewayBadRequest('Error')
+
+
+def _on(key: str, **extra) -> dict:
+    """Extension that enables *key* with optional plugin-specific settings."""
+    return {key: {'enabled': True, **extra}}
+
+
+def test_config_key_derives_snake_case():
+    assert _config_key(Upper()) == 'upper'
+    assert _config_key(BadRequest()) == 'bad_request'
 
 
 async def test_no_plugins_is_noop():
@@ -55,38 +118,129 @@ async def test_no_plugins_is_noop():
     assert out[0].content == 'hello'
 
 
-async def test_single_plugin_transforms():
-    register_preprocessing_plugin(_Upper())
-    out = await run_preprocessing([HumanMessage(content='hello')])
+async def test_enabled_plugin_transforms():
+    register_preprocessing_plugin(Upper())
+    out = await run_preprocessing([HumanMessage(content='hello')], _on('upper'))
     assert out[0].content == 'HELLO'
 
 
-async def test_chain_runs_in_registration_order():
-    register_preprocessing_plugin(_Suffix('-a'))
-    register_preprocessing_plugin(_Suffix('-b'))
-    out = await run_preprocessing([HumanMessage(content='x')])
-    assert out[0].content == 'x-a-b'
-    assert len(preprocessing_module._registered) == 2
+async def test_skipped_when_extension_is_none():
+    register_preprocessing_plugin(Upper())
+    out = await run_preprocessing([HumanMessage(content='hello')], None)
+    assert out[0].content == 'hello'
+
+
+async def test_skipped_when_key_missing():
+    register_preprocessing_plugin(Upper())
+    out = await run_preprocessing(
+        [HumanMessage(content='hello')], {'other_plugin': {'enabled': True}}
+    )
+    assert out[0].content == 'hello'
+
+
+async def test_skipped_when_enabled_false():
+    register_preprocessing_plugin(Upper())
+    out = await run_preprocessing(
+        [HumanMessage(content='hello')], {'upper': {'enabled': False}}
+    )
+    assert out[0].content == 'hello'
+
+
+async def test_plugin_reads_route_specific_config():
+    register_preprocessing_plugin(Suffix())
+    out = await run_preprocessing(
+        [HumanMessage(content='x')], _on('suffix', suffix='-done')
+    )
+    assert out[0].content == 'x-done'
+
+
+async def test_enabled_subset_runs():
+    register_preprocessing_plugin(Suffix())
+    register_preprocessing_plugin(Upper())
+    # Only suffix enabled: upper is skipped (its key absent from extension).
+    out = await run_preprocessing(
+        [HumanMessage(content='x')], _on('suffix', suffix='-a')
+    )
+    assert out[0].content == 'x-a'
+
+
+async def test_runs_in_extension_key_order():
+    # Registration order is suffix, upper — but extension lists upper first.
+    register_preprocessing_plugin(Suffix())
+    register_preprocessing_plugin(Upper())
+    extension = {**_on('upper'), **_on('suffix', suffix='-z')}
+    out = await run_preprocessing([HumanMessage(content='ab')], extension)
+    # upper ran first, then suffix: 'AB' -> 'AB-z'
+    assert out[0].content == 'AB-z'
+
+    # Reversed extension order -> reversed chain: 'ab-z' -> 'AB-Z'
+    extension = {**_on('suffix', suffix='-z'), **_on('upper')}
+    out = await run_preprocessing([HumanMessage(content='ab')], extension)
+    assert out[0].content == 'AB-Z'
+
+
+async def test_is_enabled_override_runs_without_flag():
+    # Key present but no explicit ``enabled`` flag: default would skip, the
+    # override opts in.
+    register_preprocessing_plugin(AlwaysOn())
+    out = await run_preprocessing([HumanMessage(content='hello')], {'always_on': {}})
+    assert out[0].content == 'hello!'
+
+
+async def test_override_does_not_run_when_key_absent():
+    register_preprocessing_plugin(AlwaysOn())
+    out = await run_preprocessing([HumanMessage(content='hello')], None)
+    assert out[0].content == 'hello'
 
 
 async def test_failing_plugin_is_fail_closed():
-    register_preprocessing_plugin(_RuntimeError())
+    register_preprocessing_plugin(Boom())
     with pytest.raises(PreprocessingError):
-        await run_preprocessing([HumanMessage(content='hello')])
+        await run_preprocessing([HumanMessage(content='hello')], _on('boom'))
 
 
 async def test_chain_stops_after_failure():
-    register_preprocessing_plugin(_RuntimeError())
-    register_preprocessing_plugin(_Upper())
+    register_preprocessing_plugin(Boom())
+    register_preprocessing_plugin(Upper())
     messages = [HumanMessage(content='hello')]
+    extension = {**_on('boom'), **_on('upper')}
     with pytest.raises(PreprocessingError):
-        await run_preprocessing(messages)
+        await run_preprocessing(messages, extension)
     # second plugin never ran
     assert messages[0].content == 'hello'
 
 
 async def test_app_error_propagates_unchanged():
     """A plugin may raise a structured gateway error to control the response."""
-    register_preprocessing_plugin(_BadRequestError())
+    register_preprocessing_plugin(BadRequest())
     with pytest.raises(GatewayBadRequest):
-        await run_preprocessing([HumanMessage(content='hello')])
+        await run_preprocessing([HumanMessage(content='hello')], _on('bad_request'))
+
+
+def test_plugin_validates_its_slice():
+    register_preprocessing_plugin(Validating())
+    with pytest.raises(Exception, match='threshold required'):
+        _config(_on('validating'))
+
+
+def test_plugin_validate_passes_on_valid_slice():
+    register_preprocessing_plugin(Validating())
+    _config(_on('validating', threshold=1))
+
+
+def test_validate_not_called_when_slice_absent():
+    register_preprocessing_plugin(Validating())
+    # No 'validating' key and no extension at all: validate must not run.
+    _config({'other': {'enabled': True}})
+    _config(None)
+
+
+def test_schema_rejects_unknown_key():
+    register_preprocessing_plugin(SchemaPlugin())
+    with pytest.raises(Exception, match='Extra inputs are not permitted'):
+        _config({'schema_plugin': {'enabled': True, 'bogus': 1}})
+
+
+def test_schema_accepts_declared_keys():
+    register_preprocessing_plugin(SchemaPlugin())
+    _config({'schema_plugin': {'enabled': True, 'threshold': 9}})

--- a/gateway/tests/preprocessing_test.py
+++ b/gateway/tests/preprocessing_test.py
@@ -24,9 +24,11 @@ def _clear_registry():
     """
     preprocessing_module._registered.clear()
     config_hooks._extension_validators.clear()
+    config_hooks._known_extension_keys.clear()
     yield
     preprocessing_module._registered.clear()
     config_hooks._extension_validators.clear()
+    config_hooks._known_extension_keys.clear()
 
 
 def _config(extension):
@@ -233,7 +235,9 @@ def test_plugin_validate_passes_on_valid_slice():
 
 def test_validate_not_called_when_slice_absent():
     register_preprocessing_plugin(Validating(), name='validating')
-    # No 'validating' key and no extension at all: validate must not run.
+    register_preprocessing_plugin(Upper(), name='other')
+    # 'validating' slice absent (only the other, claimed key is present) and no
+    # extension at all: its validate must not run (it would raise).
     _config({'other': {'enabled': True}})
     _config(None)
 

--- a/gateway/tests/preprocessing_test.py
+++ b/gateway/tests/preprocessing_test.py
@@ -106,9 +106,12 @@ def _on(key: str, **extra) -> dict:
     return {key: {'enabled': True, **extra}}
 
 
-def test_config_key_derives_snake_case():
-    assert _config_key(Upper()) == 'upper'
-    assert _config_key(BadRequest()) == 'bad_request'
+def test_config_key_is_top_level_package():
+    # Derives the plugin's top-level package name (== its entry-point name in
+    # ENABLED_PLUGINS), not the class name.
+    expected = Upper.__module__.partition('.')[0]
+    assert _config_key(Upper()) == expected
+    assert _config_key(BadRequest()) == expected
 
 
 async def test_no_plugins_is_noop():
@@ -119,19 +122,19 @@ async def test_no_plugins_is_noop():
 
 
 async def test_enabled_plugin_transforms():
-    register_preprocessing_plugin(Upper())
+    register_preprocessing_plugin(Upper(), name='upper')
     out = await run_preprocessing([HumanMessage(content='hello')], _on('upper'))
     assert out[0].content == 'HELLO'
 
 
 async def test_skipped_when_extension_is_none():
-    register_preprocessing_plugin(Upper())
+    register_preprocessing_plugin(Upper(), name='upper')
     out = await run_preprocessing([HumanMessage(content='hello')], None)
     assert out[0].content == 'hello'
 
 
 async def test_skipped_when_key_missing():
-    register_preprocessing_plugin(Upper())
+    register_preprocessing_plugin(Upper(), name='upper')
     out = await run_preprocessing(
         [HumanMessage(content='hello')], {'other_plugin': {'enabled': True}}
     )
@@ -139,7 +142,7 @@ async def test_skipped_when_key_missing():
 
 
 async def test_skipped_when_enabled_false():
-    register_preprocessing_plugin(Upper())
+    register_preprocessing_plugin(Upper(), name='upper')
     out = await run_preprocessing(
         [HumanMessage(content='hello')], {'upper': {'enabled': False}}
     )
@@ -147,7 +150,7 @@ async def test_skipped_when_enabled_false():
 
 
 async def test_plugin_reads_route_specific_config():
-    register_preprocessing_plugin(Suffix())
+    register_preprocessing_plugin(Suffix(), name='suffix')
     out = await run_preprocessing(
         [HumanMessage(content='x')], _on('suffix', suffix='-done')
     )
@@ -155,8 +158,8 @@ async def test_plugin_reads_route_specific_config():
 
 
 async def test_enabled_subset_runs():
-    register_preprocessing_plugin(Suffix())
-    register_preprocessing_plugin(Upper())
+    register_preprocessing_plugin(Suffix(), name='suffix')
+    register_preprocessing_plugin(Upper(), name='upper')
     # Only suffix enabled: upper is skipped (its key absent from extension).
     out = await run_preprocessing(
         [HumanMessage(content='x')], _on('suffix', suffix='-a')
@@ -166,8 +169,8 @@ async def test_enabled_subset_runs():
 
 async def test_runs_in_extension_key_order():
     # Registration order is suffix, upper — but extension lists upper first.
-    register_preprocessing_plugin(Suffix())
-    register_preprocessing_plugin(Upper())
+    register_preprocessing_plugin(Suffix(), name='suffix')
+    register_preprocessing_plugin(Upper(), name='upper')
     extension = {**_on('upper'), **_on('suffix', suffix='-z')}
     out = await run_preprocessing([HumanMessage(content='ab')], extension)
     # upper ran first, then suffix: 'AB' -> 'AB-z'
@@ -182,26 +185,26 @@ async def test_runs_in_extension_key_order():
 async def test_is_enabled_override_runs_without_flag():
     # Key present but no explicit ``enabled`` flag: default would skip, the
     # override opts in.
-    register_preprocessing_plugin(AlwaysOn())
+    register_preprocessing_plugin(AlwaysOn(), name='always_on')
     out = await run_preprocessing([HumanMessage(content='hello')], {'always_on': {}})
     assert out[0].content == 'hello!'
 
 
 async def test_override_does_not_run_when_key_absent():
-    register_preprocessing_plugin(AlwaysOn())
+    register_preprocessing_plugin(AlwaysOn(), name='always_on')
     out = await run_preprocessing([HumanMessage(content='hello')], None)
     assert out[0].content == 'hello'
 
 
 async def test_failing_plugin_is_fail_closed():
-    register_preprocessing_plugin(Boom())
+    register_preprocessing_plugin(Boom(), name='boom')
     with pytest.raises(PreprocessingError):
         await run_preprocessing([HumanMessage(content='hello')], _on('boom'))
 
 
 async def test_chain_stops_after_failure():
-    register_preprocessing_plugin(Boom())
-    register_preprocessing_plugin(Upper())
+    register_preprocessing_plugin(Boom(), name='boom')
+    register_preprocessing_plugin(Upper(), name='upper')
     messages = [HumanMessage(content='hello')]
     extension = {**_on('boom'), **_on('upper')}
     with pytest.raises(PreprocessingError):
@@ -212,35 +215,35 @@ async def test_chain_stops_after_failure():
 
 async def test_app_error_propagates_unchanged():
     """A plugin may raise a structured gateway error to control the response."""
-    register_preprocessing_plugin(BadRequest())
+    register_preprocessing_plugin(BadRequest(), name='bad_request')
     with pytest.raises(GatewayBadRequest):
         await run_preprocessing([HumanMessage(content='hello')], _on('bad_request'))
 
 
 def test_plugin_validates_its_slice():
-    register_preprocessing_plugin(Validating())
+    register_preprocessing_plugin(Validating(), name='validating')
     with pytest.raises(Exception, match='threshold required'):
         _config(_on('validating'))
 
 
 def test_plugin_validate_passes_on_valid_slice():
-    register_preprocessing_plugin(Validating())
+    register_preprocessing_plugin(Validating(), name='validating')
     _config(_on('validating', threshold=1))
 
 
 def test_validate_not_called_when_slice_absent():
-    register_preprocessing_plugin(Validating())
+    register_preprocessing_plugin(Validating(), name='validating')
     # No 'validating' key and no extension at all: validate must not run.
     _config({'other': {'enabled': True}})
     _config(None)
 
 
 def test_schema_rejects_unknown_key():
-    register_preprocessing_plugin(SchemaPlugin())
+    register_preprocessing_plugin(SchemaPlugin(), name='schema_plugin')
     with pytest.raises(Exception, match='Extra inputs are not permitted'):
         _config({'schema_plugin': {'enabled': True, 'bogus': 1}})
 
 
 def test_schema_accepts_declared_keys():
-    register_preprocessing_plugin(SchemaPlugin())
+    register_preprocessing_plugin(SchemaPlugin(), name='schema_plugin')
     _config({'schema_plugin': {'enabled': True, 'threshold': 9}})

--- a/gateway/tests/preprocessing_test.py
+++ b/gateway/tests/preprocessing_test.py
@@ -1,0 +1,93 @@
+from langchain_core.messages import HumanMessage
+import pytest
+
+import radicalbit_ai_gateway.preprocessing as preprocessing_module
+from radicalbit_ai_gateway.preprocessing import (
+    PreprocessingError,
+    PreprocessingPlugin,
+    get_preprocessing_plugins,
+    register_preprocessing_plugin,
+    run_preprocessing,
+)
+from radicalbit_ai_gateway.utils.exceptions import GatewayBadRequest
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry():
+    """Each test starts with an empty preprocessing registry."""
+    preprocessing_module._registered.clear()
+    yield
+    preprocessing_module._registered.clear()
+
+
+class _Upper(PreprocessingPlugin):
+    async def preprocess(self, messages):
+        for m in messages:
+            if isinstance(m.content, str):
+                m.content = m.content.upper()
+        return messages
+
+
+class _Suffix(PreprocessingPlugin):
+    def __init__(self, suffix: str):
+        self._suffix = suffix
+
+    async def preprocess(self, messages):
+        for m in messages:
+            if isinstance(m.content, str):
+                m.content = m.content + self._suffix
+        return messages
+
+
+class _RuntimeError(PreprocessingPlugin):
+    async def preprocess(self, messages):
+        raise RuntimeError('Error')
+
+
+class _BadRequestError(PreprocessingPlugin):
+    async def preprocess(self, messages):
+        raise GatewayBadRequest('Error')
+
+
+async def test_no_plugins_is_noop():
+    messages = [HumanMessage(content='hello')]
+    out = await run_preprocessing(messages)
+    assert out is messages
+    assert out[0].content == 'hello'
+
+
+async def test_single_plugin_transforms():
+    register_preprocessing_plugin(_Upper())
+    out = await run_preprocessing([HumanMessage(content='hello')])
+    assert out[0].content == 'HELLO'
+
+
+async def test_chain_runs_in_registration_order():
+    register_preprocessing_plugin(_Suffix('-a'))
+    register_preprocessing_plugin(_Suffix('-b'))
+    out = await run_preprocessing([HumanMessage(content='x')])
+    assert out[0].content == 'x-a-b'
+    assert len(get_preprocessing_plugins()) == 2
+
+
+async def test_failing_plugin_is_fail_closed():
+    register_preprocessing_plugin(_RuntimeError())
+    with pytest.raises(PreprocessingError):
+        await run_preprocessing([HumanMessage(content='hello')])
+
+
+async def test_chain_stops_after_failure():
+    register_preprocessing_plugin(_RuntimeError())
+    register_preprocessing_plugin(_Upper())
+    messages = [HumanMessage(content='hello')]
+    with pytest.raises(PreprocessingError):
+        await run_preprocessing(messages)
+    # second plugin never ran
+    assert messages[0].content == 'hello'
+
+
+async def test_app_error_propagates_unchanged():
+    """A plugin may raise a structured gateway error to control the response."""
+    register_preprocessing_plugin(_BadRequestError())
+    with pytest.raises(GatewayBadRequest):
+        await run_preprocessing([HumanMessage(content='hello')])

--- a/gateway/tests/preprocessing_test.py
+++ b/gateway/tests/preprocessing_test.py
@@ -5,7 +5,6 @@ import radicalbit_ai_gateway.preprocessing as preprocessing_module
 from radicalbit_ai_gateway.preprocessing import (
     PreprocessingError,
     PreprocessingPlugin,
-    get_preprocessing_plugins,
     register_preprocessing_plugin,
     run_preprocessing,
 )
@@ -67,7 +66,7 @@ async def test_chain_runs_in_registration_order():
     register_preprocessing_plugin(_Suffix('-b'))
     out = await run_preprocessing([HumanMessage(content='x')])
     assert out[0].content == 'x-a-b'
-    assert len(get_preprocessing_plugins()) == 2
+    assert len(preprocessing_module._registered) == 2
 
 
 async def test_failing_plugin_is_fail_closed():

--- a/gateway/tests/preprocessing_test.py
+++ b/gateway/tests/preprocessing_test.py
@@ -17,25 +17,25 @@ from radicalbit_ai_gateway.utils.exceptions import GatewayBadRequest
 
 @pytest.fixture(autouse=True)
 def _clear_registry():
-    """Each test starts with empty preprocessing and extension-validator registries.
+    """Each test starts with empty preprocessing and plugins-validator registries.
 
-    Registering a plugin also registers an extension validator, so both globals
+    Registering a plugin also registers an plugins validator, so both globals
     must be reset between tests.
     """
     preprocessing_module._registered.clear()
-    config_hooks._extension_validators.clear()
-    config_hooks._known_extension_keys.clear()
+    config_hooks._plugins_validators.clear()
+    config_hooks._known_plugin_keys.clear()
     yield
     preprocessing_module._registered.clear()
-    config_hooks._extension_validators.clear()
-    config_hooks._known_extension_keys.clear()
+    config_hooks._plugins_validators.clear()
+    config_hooks._known_plugin_keys.clear()
 
 
-def _config(extension):
-    """Build a GatewayConfig as in production (extension validated at load)."""
+def _config(plugins):
+    """Build a GatewayConfig as in production (plugins validated at load)."""
     return GatewayConfig(
         chat_models=[{'model_id': 'm', 'model': 'openai/gpt-4o'}],
-        routes={'r': {'chat_models': ['m'], 'extension': extension}},
+        routes={'r': {'chat_models': ['m'], 'plugins': plugins}},
     )
 
 
@@ -104,7 +104,7 @@ class BadRequest(PreprocessingPlugin):
 
 
 def _on(key: str, **extra) -> dict:
-    """Extension that enables *key* with optional plugin-specific settings."""
+    """Plugins that enables *key* with optional plugin-specific settings."""
     return {key: {'enabled': True, **extra}}
 
 
@@ -162,7 +162,7 @@ async def test_plugin_reads_route_specific_config():
 async def test_enabled_subset_runs():
     register_preprocessing_plugin(Suffix(), name='suffix')
     register_preprocessing_plugin(Upper(), name='upper')
-    # Only suffix enabled: upper is skipped (its key absent from extension).
+    # Only suffix enabled: upper is skipped (its key absent from plugins).
     out = await run_preprocessing(
         [HumanMessage(content='x')], _on('suffix', suffix='-a')
     )
@@ -170,17 +170,17 @@ async def test_enabled_subset_runs():
 
 
 async def test_runs_in_extension_key_order():
-    # Registration order is suffix, upper — but extension lists upper first.
+    # Registration order is suffix, upper — but plugins lists upper first.
     register_preprocessing_plugin(Suffix(), name='suffix')
     register_preprocessing_plugin(Upper(), name='upper')
-    extension = {**_on('upper'), **_on('suffix', suffix='-z')}
-    out = await run_preprocessing([HumanMessage(content='ab')], extension)
+    plugins = {**_on('upper'), **_on('suffix', suffix='-z')}
+    out = await run_preprocessing([HumanMessage(content='ab')], plugins)
     # upper ran first, then suffix: 'AB' -> 'AB-z'
     assert out[0].content == 'AB-z'
 
-    # Reversed extension order -> reversed chain: 'ab-z' -> 'AB-Z'
-    extension = {**_on('suffix', suffix='-z'), **_on('upper')}
-    out = await run_preprocessing([HumanMessage(content='ab')], extension)
+    # Reversed plugins order -> reversed chain: 'ab-z' -> 'AB-Z'
+    plugins = {**_on('suffix', suffix='-z'), **_on('upper')}
+    out = await run_preprocessing([HumanMessage(content='ab')], plugins)
     assert out[0].content == 'AB-Z'
 
 
@@ -208,9 +208,9 @@ async def test_chain_stops_after_failure():
     register_preprocessing_plugin(Boom(), name='boom')
     register_preprocessing_plugin(Upper(), name='upper')
     messages = [HumanMessage(content='hello')]
-    extension = {**_on('boom'), **_on('upper')}
+    plugins = {**_on('boom'), **_on('upper')}
     with pytest.raises(PreprocessingError):
-        await run_preprocessing(messages, extension)
+        await run_preprocessing(messages, plugins)
     # second plugin never ran
     assert messages[0].content == 'hello'
 
@@ -237,7 +237,7 @@ def test_validate_not_called_when_slice_absent():
     register_preprocessing_plugin(Validating(), name='validating')
     register_preprocessing_plugin(Upper(), name='other')
     # 'validating' slice absent (only the other, claimed key is present) and no
-    # extension at all: its validate must not run (it would raise).
+    # plugins at all: its validate must not run (it would raise).
     _config({'other': {'enabled': True}})
     _config(None)
 

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -13,8 +13,10 @@ from radicalbit_ai_gateway.utils.config_hooks import (
 @pytest.fixture(autouse=True)
 def _clean_registry():
     config_hooks._extension_validators.clear()
+    config_hooks._known_extension_keys.clear()
     yield
     config_hooks._extension_validators.clear()
+    config_hooks._known_extension_keys.clear()
 
 
 def _config(extension):
@@ -80,10 +82,12 @@ def test_schema_rejects_bad_type():
         _config({'my_plugin': {'threshold': 'not-an-int'}})
 
 
-def test_schema_noop_when_key_absent():
+def test_unknown_key_is_rejected():
     register_extension_schema('my_plugin', _MyConfig)
 
-    _config({'other_plugin': {'whatever': 1}})
+    with pytest.raises(Exception) as exc_info:
+        _config({'other_plugin': {'whatever': 1}})
+    assert 'other_plugin' in str(exc_info.value)
 
 
 def test_schema_accepts_secret_placeholder_for_str_field():
@@ -98,7 +102,10 @@ def test_slice_validator_runs_only_when_key_present():
     seen = []
     register_extension_slice_validator('my_plugin', seen.append)
 
-    _config({'other_plugin': {'a': 1}})
+    # A different, unclaimed key is rejected rather than silently skipped.
+    with pytest.raises(Exception) as exc_info:
+        _config({'other_plugin': {'a': 1}})
+    assert 'other_plugin' in str(exc_info.value)
     assert seen == []
 
     _config({'my_plugin': {'a': 1}})

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -4,7 +4,6 @@ from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 from radicalbit_ai_gateway.utils import config_hooks
 from radicalbit_ai_gateway.utils.config_hooks import (
     ExtensionConfig,
-    register_extension_schema,
     register_extension_slice_validator,
     register_extension_validator,
 )
@@ -62,13 +61,13 @@ class _MyConfig(ExtensionConfig):
 
 
 def test_schema_validates_known_keys():
-    register_extension_schema('my_plugin', _MyConfig)
+    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
 
     _config({'my_plugin': {'threshold': 3}})
 
 
 def test_schema_rejects_unknown_key():
-    register_extension_schema('my_plugin', _MyConfig)
+    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
 
     with pytest.raises(Exception) as exc_info:
         _config({'my_plugin': {'typo': 1}})
@@ -76,14 +75,14 @@ def test_schema_rejects_unknown_key():
 
 
 def test_schema_rejects_bad_type():
-    register_extension_schema('my_plugin', _MyConfig)
+    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
 
     with pytest.raises(Exception):
         _config({'my_plugin': {'threshold': 'not-an-int'}})
 
 
 def test_unknown_key_is_rejected():
-    register_extension_schema('my_plugin', _MyConfig)
+    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
 
     with pytest.raises(Exception) as exc_info:
         _config({'other_plugin': {'whatever': 1}})
@@ -93,7 +92,7 @@ def test_unknown_key_is_rejected():
 def test_schema_accepts_secret_placeholder_for_str_field():
     # ``!secret`` resolves to a string before validation (a placeholder during
     # the validate pass); a str-typed field must accept it.
-    register_extension_schema('my_plugin', _MyConfig)
+    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
 
     _config({'my_plugin': {'secret': '__secret_placeholder__'}})
 

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -3,35 +3,35 @@ import pytest
 from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 from radicalbit_ai_gateway.utils import config_hooks
 from radicalbit_ai_gateway.utils.config_hooks import (
-    ExtensionConfig,
-    register_extension_slice_validator,
-    register_extension_validator,
+    PluginConfig,
+    register_plugin_config_validator,
+    register_plugins_validator,
 )
 
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    config_hooks._extension_validators.clear()
-    config_hooks._known_extension_keys.clear()
+    config_hooks._plugins_validators.clear()
+    config_hooks._known_plugin_keys.clear()
     yield
-    config_hooks._extension_validators.clear()
-    config_hooks._known_extension_keys.clear()
+    config_hooks._plugins_validators.clear()
+    config_hooks._known_plugin_keys.clear()
 
 
-def _config(extension):
+def _config(plugins):
     """Build a config the way it is loaded in production: validation of a
-    route's ``extension`` happens at GatewayConfig load time, not on bare
+    route's ``plugins`` happens at GatewayConfig load time, not on bare
     GatewayRouteConfig construction.
     """
     return GatewayConfig(
         chat_models=[{'model_id': 'm', 'model': 'openai/gpt-4o'}],
-        routes={'r': {'chat_models': ['m'], 'extension': extension}},
+        routes={'r': {'chat_models': ['m'], 'plugins': plugins}},
     )
 
 
 def test_registered_validator_receives_extension():
     seen = []
-    register_extension_validator(seen.append)
+    register_plugins_validator(seen.append)
 
     _config({'fake_enabled': True})
 
@@ -39,10 +39,10 @@ def test_registered_validator_receives_extension():
 
 
 def test_validator_error_fails_config_validation():
-    def validate(extension):
+    def validate(plugins):
         raise ValueError('bad plugin config')
 
-    register_extension_validator(validate)
+    register_plugins_validator(validate)
 
     with pytest.raises(Exception) as exc_info:
         _config({'whatever': 1})
@@ -50,24 +50,24 @@ def test_validator_error_fails_config_validation():
 
 
 def test_no_extension_is_a_noop():
-    register_extension_validator(lambda extension: 1 / 0)
+    register_plugins_validator(lambda plugins: 1 / 0)
 
     _config(None)
 
 
-class _MyConfig(ExtensionConfig):
+class _MyConfig(PluginConfig):
     threshold: int = 5
     secret: str | None = None
 
 
 def test_schema_validates_known_keys():
-    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
+    register_plugin_config_validator('my_plugin', _MyConfig.model_validate)
 
     _config({'my_plugin': {'threshold': 3}})
 
 
 def test_schema_rejects_unknown_key():
-    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
+    register_plugin_config_validator('my_plugin', _MyConfig.model_validate)
 
     with pytest.raises(Exception) as exc_info:
         _config({'my_plugin': {'typo': 1}})
@@ -75,14 +75,14 @@ def test_schema_rejects_unknown_key():
 
 
 def test_schema_rejects_bad_type():
-    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
+    register_plugin_config_validator('my_plugin', _MyConfig.model_validate)
 
     with pytest.raises(Exception):
         _config({'my_plugin': {'threshold': 'not-an-int'}})
 
 
 def test_unknown_key_is_rejected():
-    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
+    register_plugin_config_validator('my_plugin', _MyConfig.model_validate)
 
     with pytest.raises(Exception) as exc_info:
         _config({'other_plugin': {'whatever': 1}})
@@ -92,14 +92,14 @@ def test_unknown_key_is_rejected():
 def test_schema_accepts_secret_placeholder_for_str_field():
     # ``!secret`` resolves to a string before validation (a placeholder during
     # the validate pass); a str-typed field must accept it.
-    register_extension_slice_validator('my_plugin', _MyConfig.model_validate)
+    register_plugin_config_validator('my_plugin', _MyConfig.model_validate)
 
     _config({'my_plugin': {'secret': '__secret_placeholder__'}})
 
 
 def test_slice_validator_runs_only_when_key_present():
     seen = []
-    register_extension_slice_validator('my_plugin', seen.append)
+    register_plugin_config_validator('my_plugin', seen.append)
 
     # A different, unclaimed key is rejected rather than silently skipped.
     with pytest.raises(Exception) as exc_info:

--- a/gateway/tests/utils/test_config_hooks.py
+++ b/gateway/tests/utils/test_config_hooks.py
@@ -2,7 +2,12 @@ import pytest
 
 from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 from radicalbit_ai_gateway.utils import config_hooks
-from radicalbit_ai_gateway.utils.config_hooks import register_extension_validator
+from radicalbit_ai_gateway.utils.config_hooks import (
+    ExtensionConfig,
+    register_extension_schema,
+    register_extension_slice_validator,
+    register_extension_validator,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -47,3 +52,54 @@ def test_no_extension_is_a_noop():
     register_extension_validator(lambda extension: 1 / 0)
 
     _config(None)
+
+
+class _MyConfig(ExtensionConfig):
+    threshold: int = 5
+    secret: str | None = None
+
+
+def test_schema_validates_known_keys():
+    register_extension_schema('my_plugin', _MyConfig)
+
+    _config({'my_plugin': {'threshold': 3}})
+
+
+def test_schema_rejects_unknown_key():
+    register_extension_schema('my_plugin', _MyConfig)
+
+    with pytest.raises(Exception) as exc_info:
+        _config({'my_plugin': {'typo': 1}})
+    assert 'typo' in str(exc_info.value)
+
+
+def test_schema_rejects_bad_type():
+    register_extension_schema('my_plugin', _MyConfig)
+
+    with pytest.raises(Exception):
+        _config({'my_plugin': {'threshold': 'not-an-int'}})
+
+
+def test_schema_noop_when_key_absent():
+    register_extension_schema('my_plugin', _MyConfig)
+
+    _config({'other_plugin': {'whatever': 1}})
+
+
+def test_schema_accepts_secret_placeholder_for_str_field():
+    # ``!secret`` resolves to a string before validation (a placeholder during
+    # the validate pass); a str-typed field must accept it.
+    register_extension_schema('my_plugin', _MyConfig)
+
+    _config({'my_plugin': {'secret': '__secret_placeholder__'}})
+
+
+def test_slice_validator_runs_only_when_key_present():
+    seen = []
+    register_extension_slice_validator('my_plugin', seen.append)
+
+    _config({'other_plugin': {'a': 1}})
+    assert seen == []
+
+    _config({'my_plugin': {'a': 1}})
+    assert seen == [{'a': 1}]


### PR DESCRIPTION
# Summary

Introduces a **preprocessing hook** that lets plugins transform the incoming
chat messages *before* model selection and input guardrails. The route's
per-plugin config is now exposed as a top-level `plugins` field (renamed from
`extension`) with proper, schema-driven validation: plugins declare the keys
they own, and the gateway rejects unknown keys (e.g. a typo'd or stale plugin
name) at config-load time instead of silently ignoring them.

The route's configured system prompt is now injected **after** preprocessing,
so preprocessing plugins can never see or modify it.

---

## Added

- **`PreprocessingPlugin`** - Abstract base class for plugins that transform incoming chat messages (`radicalbit_ai_gateway/preprocessing.py`)

  ```python
  class PreprocessingPlugin(ABC):
      config_schema: type[PreprocessingConfig] | None = None

      def is_enabled(self, config: dict | None) -> bool: ...
      def validate(self, config: dict) -> None: ...

      @abstractmethod
      async def preprocess(
          self, messages: list[BaseMessage], config: dict | None
      ) -> list[BaseMessage]: ...
  ```

  Plugins implement `preprocess` and register via `register_preprocessing_plugin`.
  Each message's `content` may be `str` (plain text) or `list` (multimodal parts);
  text-transforming plugins must handle both shapes.

- **`PreprocessingConfig`** - Base schema for a preprocessing plugin's `plugins` slice, with an opt-in `enabled: bool = False` flag

- **`PreprocessingError`** - `GatewayError` (HTTP 500, code `preprocessing_error`) raised when a plugin fails; the chain is fail-closed (aborts the request)

- **`run_preprocessing(messages, plugins)`** - Entry point that runs the resolved plugin chain over the client's messages; a no-op returning the messages unchanged when no plugin is enabled

- **`PluginConfig`** - Base schema for any plugin's `plugins` slice (`extra='forbid'`), in `radicalbit_ai_gateway/utils/config_hooks.py`

- **Slice-scoped plugin validators** in `config_hooks.py`:
  - `register_plugin_config_validator(key, validate_slice)` - register a validator scoped to a single `plugins` key, and record `key` as a known key
  - `build_route_plugins_model(keys)` - build a Pydantic model (`extra='forbid'`) whose fields are exactly the keys plugins claimed
  - `get_known_plugin_keys()` - return the set of keys claimed by plugins

- **`OperationCategory.PREPROCESSING`** - New trace operation category for preprocessing spans (`radicalbit_ai_gateway/utils/trace_attributes.py`)

- **Tracing** - The chain runs under a `run_preprocessing` workflow; each plugin's `preprocess` runs in a `preprocess.<key>` task span

- **Tests** - `tests/preprocessing_test.py` (chain ordering, opt-in gating, fail-closed, multimodal content); additions to `ai_gateway_test.py` and `tests/utils/test_config_hooks.py`

---

## Changed

- **`GatewayRouteConfig`** - The `extension` field is renamed to **`plugins`** (`plugins: dict | None`)
- **`GatewayRoute._chat_completion`** - New flow:
  1. Run `run_preprocessing(messages, plugins)` under `OperationCategory.PREPROCESSING`
  2. Select the chat model (`OperationCategory.ROUTING`)
  3. Inject the route's configured system prompt *after* preprocessing
- **`GatewayConfig.validate_route_plugins`** (renamed from `validate_route_extensions`) - Now rejects unknown `plugins` keys at config-load time, and runs each plugin's slice validator against its own slice
- **`_select_and_prepare_chat_model`** split into:
  - `_select_chat_model(messages)` - model selection only
  - `_apply_config_prompt(messages, model_selected)` - injects the route's system prompt in place
- **`config_hooks.py` API renamed** - `register_extension_validator` → `register_plugins_validator`, `get_extension_validators` → `get_plugins_validators`
- **`plugins/loader.py`** - Uses `app_config.log_config.logger_name` instead of the hard-coded `'radicalbit_ai_gateway'` logger


## Linked Issue
Closes AG-810

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [x] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
