### PR TITLE
fixing tool request cache

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -1073,7 +1073,9 @@ class GatewayRoute:
                 last_human_idx = idx
 
         last_human = messages[last_human_idx] if last_human_idx != -1 else None
-        messages_for_cache: list[BaseMessage] = messages[last_human_idx:] if last_human_idx != -1 else []
+        messages_for_cache: list[BaseMessage] = (
+            messages[last_human_idx:] if last_human_idx != -1 else []
+        )
         user_content = (
             ContentUtils.extract_text_content(last_human.content) if last_human else ''
         )

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -1066,11 +1066,14 @@ class GatewayRoute:
         cached_response = None
         embeddings = None
         cache_key = ''
-        # Use only the last user message (HumanMessage) for cache/embedding
-        last_human: HumanMessage | None = next(
-            (m for m in reversed(messages) if isinstance(m, HumanMessage)), None
-        )
-        messages_for_cache: list[BaseMessage] = [last_human] if last_human else []
+        # Use messages from the last user message (HumanMessage) to the end for cache/embedding
+        last_human_idx = -1
+        for idx, m in enumerate(messages):
+            if isinstance(m, HumanMessage):
+                last_human_idx = idx
+
+        last_human = messages[last_human_idx] if last_human_idx != -1 else None
+        messages_for_cache: list[BaseMessage] = messages[last_human_idx:] if last_human_idx != -1 else []
         user_content = (
             ContentUtils.extract_text_content(last_human.content) if last_human else ''
         )


### PR DESCRIPTION
## Summary
# Fix Infinite Loops in Agent Tool-Calling due to Last-User Caching

## 🎯 Problem Statement
Previously, the caching system in the AI Gateway generated cache signatures based **exclusively** on the last `HumanMessage` in the history list (`messages_for_cache = [last_human]`). 

While this optimization successfully enables cache hits in multi-turn chatbot conversations (where older context shouldn't invalidate caching of the newest user turn), it **breaks agent tool-calling loops**. 

During a single user turn, when an agent makes sequential tool calls and receives tool responses:
1. **First request**: User prompt `[User: "Generate X"]` produces a cache miss. The LLM requests a tool call (e.g., `read_document`). The response is cached under the key for `[User: "Generate X"]`.
2. **Subsequent requests**: The conversation history evolves to `[User: "Generate X", Assistant: tool_call, Tool: response]`. Because the last `HumanMessage` is still `[User: "Generate X"]`, the gateway generates the exact same cache signature. 
3. **Infinite Loop**: The gateway serves the cached step 1 response (the tool call request) repeatedly. The agent gets stuck executing the same tool infinitely.

---

## 🛠️ Proposed Solution
We adjusted the cache key generation logic in `radicalbit_ai_gateway/ai_gateway.py` to target the slice of messages starting from the **last human message to the end of the history array**:

```python
last_human_idx = -1
for idx, m in enumerate(messages):
    if isinstance(m, HumanMessage):
        last_human_idx = idx

last_human = messages[last_human_idx] if last_human_idx != -1 else None
messages_for_cache: list[BaseMessage] = messages[last_human_idx:] if last_human_idx != -1 else []
```


## Type of Change
- [X] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
