### PR TITLE
feat(guardrails): add X-RB-AIGATEWAY-GUARDRAILS-WARN header for non-b…

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -210,11 +210,15 @@ class GatewayRoute:
                     or prepared.guardrails_block_triggered
                 ):
                     headers['X-RB-AIGATEWAY-GUARDRAILS-TRIGGERED'] = 'true'
+                if output.guardrails_triggered or prepared.guardrails_input_triggered:
+                    headers['X-RB-AIGATEWAY-GUARDRAILS-WARN'] = 'true'
                 return InvokeResponse(content=content, headers=headers)
             content = prepared.cached_response.model_copy(update={'model': route_name})
             headers: dict[str, str] = {'X-RB-AIGATEWAY-CACHE-HIT': 'true'}
             if prepared.guardrails_block_triggered:
                 headers['X-RB-AIGATEWAY-GUARDRAILS-TRIGGERED'] = 'true'
+            if prepared.guardrails_input_triggered:
+                headers['X-RB-AIGATEWAY-GUARDRAILS-WARN'] = 'true'
             return InvokeResponse(content=content, headers=headers)
 
         # Process the request
@@ -263,6 +267,8 @@ class GatewayRoute:
         headers: dict[str, str] = {}
         if output.guardrails_block_triggered or prepared.guardrails_block_triggered:
             headers['X-RB-AIGATEWAY-GUARDRAILS-TRIGGERED'] = 'true'
+        if output.guardrails_triggered or prepared.guardrails_input_triggered:
+            headers['X-RB-AIGATEWAY-GUARDRAILS-WARN'] = 'true'
         return InvokeResponse(
             content=output.response.model_copy(update={'model': route_name}),
             headers=headers,
@@ -369,8 +375,17 @@ class GatewayRoute:
                 **kwargs,
             )
         ], {
-            'X-RB-AIGATEWAY-GUARDRAILS-TRIGGERED': 'true'
-        } if prepared.guardrails_block_triggered else {}
+            **(
+                {'X-RB-AIGATEWAY-GUARDRAILS-TRIGGERED': 'true'}
+                if prepared.guardrails_block_triggered
+                else {}
+            ),
+            **(
+                {'X-RB-AIGATEWAY-GUARDRAILS-WARN': 'true'}
+                if prepared.guardrails_input_triggered
+                else {}
+            ),
+        }
 
     async def invoke_stream(
         self,

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -653,6 +653,8 @@ async def chat_completions(
             headers = {}
             if prepared.guardrails_block_triggered:
                 headers['X-RB-AIGATEWAY-GUARDRAILS-TRIGGERED'] = 'true'
+            if prepared.guardrails_input_triggered:
+                headers['X-RB-AIGATEWAY-GUARDRAILS-WARN'] = 'true'
             if prepared.cached_response:
                 headers['X-RB-AIGATEWAY-CACHE-HIT'] = 'true'
 


### PR DESCRIPTION
## Summary
Add X-RB-AIGATEWAY-GUARDRAILS-WARN header for non-blocking triggers

Introduce a new HTTP response header X-RB-AIGATEWAY-GUARDRAILS-WARN: true when a warning or redact guardrail triggers. This allows client applications to receive non-blocking guardrail violation events without affecting the original blocking header behaviors or breaking existing integrations.

## Type of Change
- [ ] Bug fix
- [X] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
