### PR TITLE
feat: add get all configs endpoint with status

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
@@ -78,15 +78,15 @@ class ProjectDAO:
             return session.scalars(stmt).all()
 
     def get_all_by_config_status(
-        self, config_status: ConfigStatus | None = None, *, only_saved: bool = False
+        self, config_status: ConfigStatus | None = None, *, exclude_empty: bool = False
     ) -> Sequence[Project]:
         """Return non-deleted projects, optionally restricted to those having at
         least one non-deleted config slot in the given status.
 
-        When ``only_saved`` is set, the matching slot must also have been
-        actually saved (``updated_at`` populated): freshly seeded slots start as
-        DRAFT with a NULL ``updated_at`` (the empty template), so this
-        distinguishes a genuinely "Saved" draft from an untouched one.
+        When ``exclude_empty`` is set, the matching slot must also have content
+        (``updated_at`` populated): freshly seeded slots start as DRAFT with a
+        NULL ``updated_at`` (the EMPTY template state), so this distinguishes a
+        genuine DRAFT from an untouched EMPTY slot.
         """
         with self.db.begin_session() as session:
             stmt = select(Project).where(Project.deleted_at.is_(None))
@@ -96,7 +96,7 @@ class ProjectDAO:
                     ProjectConfig.config_status == config_status.value,
                     ProjectConfig.deleted_at.is_(None),
                 ]
-                if only_saved:
+                if exclude_empty:
                     conditions.append(ProjectConfig.updated_at.is_not(None))
                 has_matching_config = (
                     select(ProjectConfig.uuid).where(*conditions).exists()

--- a/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_dao.py
@@ -77,6 +77,33 @@ class ProjectDAO:
                 stmt = stmt.where(Project.first_served_at.is_not(None))
             return session.scalars(stmt).all()
 
+    def get_all_by_config_status(
+        self, config_status: ConfigStatus | None = None, *, only_saved: bool = False
+    ) -> Sequence[Project]:
+        """Return non-deleted projects, optionally restricted to those having at
+        least one non-deleted config slot in the given status.
+
+        When ``only_saved`` is set, the matching slot must also have been
+        actually saved (``updated_at`` populated): freshly seeded slots start as
+        DRAFT with a NULL ``updated_at`` (the empty template), so this
+        distinguishes a genuinely "Saved" draft from an untouched one.
+        """
+        with self.db.begin_session() as session:
+            stmt = select(Project).where(Project.deleted_at.is_(None))
+            if config_status is not None:
+                conditions = [
+                    ProjectConfig.project_uuid == Project.uuid,
+                    ProjectConfig.config_status == config_status.value,
+                    ProjectConfig.deleted_at.is_(None),
+                ]
+                if only_saved:
+                    conditions.append(ProjectConfig.updated_at.is_not(None))
+                has_matching_config = (
+                    select(ProjectConfig.uuid).where(*conditions).exists()
+                )
+                stmt = stmt.where(has_matching_config)
+            return session.scalars(stmt).all()
+
     def get_all_with_config(self) -> Sequence[Project]:
         """Projects that currently have a served config (used at startup)."""
         with self.db.begin_session() as session:

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -26,6 +26,31 @@ class ProjectFilter(str, Enum):
         return None
 
 
+class ConfigListFilter(str, Enum):
+    ALL = 'all'
+    PUBLISHED = 'published'
+    REQUEST_TO_PUBLISH = 'request_to_publish'
+    SAVED = 'saved'
+
+    @classmethod
+    def _missing_(cls, value: object):
+        if isinstance(value, str):
+            for member in cls:
+                if member.value == value.lower():
+                    return member
+        return None
+
+    def to_config_status(self) -> ConfigStatus | None:
+        """Map a UI status tab to the underlying config status, or None
+        for ALL (no filtering).
+        """
+        return {
+            ConfigListFilter.PUBLISHED: ConfigStatus.SERVED,
+            ConfigListFilter.REQUEST_TO_PUBLISH: ConfigStatus.READY_TO_SERVE,
+            ConfigListFilter.SAVED: ConfigStatus.DRAFT,
+        }.get(self)
+
+
 class ProjectIn(BaseModel, validate_assignment=True):
     name: str
     description: str | None = None

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -30,7 +30,7 @@ class ConfigListFilter(str, Enum):
     ALL = 'all'
     PUBLISHED = 'published'
     REQUEST_TO_PUBLISH = 'request_to_publish'
-    SAVED = 'saved'
+    DRAFT = 'draft'
 
     @classmethod
     def _missing_(cls, value: object):
@@ -47,7 +47,7 @@ class ConfigListFilter(str, Enum):
         return {
             ConfigListFilter.PUBLISHED: ConfigStatus.SERVED,
             ConfigListFilter.REQUEST_TO_PUBLISH: ConfigStatus.READY_TO_SERVE,
-            ConfigListFilter.SAVED: ConfigStatus.DRAFT,
+            ConfigListFilter.DRAFT: ConfigStatus.DRAFT,
         }.get(self)
 
 

--- a/gateway/radicalbit_ai_gateway/routes/configs_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/configs_route.py
@@ -1,6 +1,9 @@
+from collections.abc import Callable
+from dataclasses import dataclass, field
 import logging
+from typing import Any
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 
 from radicalbit_ai_gateway.models.project_dto import ConfigListFilter, ProjectOut
 from radicalbit_ai_gateway.models.runtime_config_out import RuntimeConfigOut
@@ -12,9 +15,22 @@ app_config = get_app_config()
 logger = logging.getLogger(app_config.log_config.logger_name)
 
 
+@dataclass
+class ConfigsRouteConfig:
+    get_configs_fn: Callable[[Request, ConfigListFilter | None], Any] | None = None
+    list_response_model: type = field(default_factory=lambda: list[ProjectOut])
+
+
 class ConfigsRoute:
     @staticmethod
-    def get_configs_router(project_service: ProjectService) -> APIRouter:
+    def get_configs_router(
+        project_service: ProjectService,
+        config: ConfigsRouteConfig | None = None,
+    ) -> APIRouter:
+        config = config or ConfigsRouteConfig()
+        get_configs_fn = config.get_configs_fn or (
+            lambda _, f: project_service.get_configs(f)
+        )
         router = APIRouter(tags=['runtime_configs_api'])
 
         @router.get(
@@ -28,9 +44,13 @@ class ConfigsRoute:
             )
 
         @router.get(
-            '/configs/projects', status_code=200, response_model=list[ProjectOut]
+            '/configs/projects',
+            status_code=200,
+            response_model=config.list_response_model,
         )
-        def get_configs(status: ConfigListFilter | None = Query(None)):
-            return project_service.get_configs(status)
+        def get_configs(
+            request: Request, status: ConfigListFilter | None = Query(None)
+        ):
+            return get_configs_fn(request, status)
 
         return router

--- a/gateway/radicalbit_ai_gateway/routes/configs_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/configs_route.py
@@ -1,8 +1,10 @@
 import logging
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
+from radicalbit_ai_gateway.models.project_dto import ConfigListFilter, ProjectOut
 from radicalbit_ai_gateway.models.runtime_config_out import RuntimeConfigOut
+from radicalbit_ai_gateway.services.project_service import ProjectService
 from radicalbit_ai_gateway.utils.app_config import get_app_config
 
 app_config = get_app_config()
@@ -12,7 +14,7 @@ logger = logging.getLogger(app_config.log_config.logger_name)
 
 class ConfigsRoute:
     @staticmethod
-    def get_configs_router() -> APIRouter:
+    def get_configs_router(project_service: ProjectService) -> APIRouter:
         router = APIRouter(tags=['runtime_configs_api'])
 
         @router.get(
@@ -24,5 +26,11 @@ class ConfigsRoute:
                 enabled_plugins_list=app_config.runtime_config.plugins(),
                 config_generator_enabled=api_key is not None,
             )
+
+        @router.get(
+            '/configs/projects', status_code=200, response_model=list[ProjectOut]
+        )
+        def get_configs(status: ConfigListFilter | None = Query(None)):
+            return project_service.get_configs(status)
 
         return router

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -332,7 +332,7 @@ app.include_router(
     ),
     prefix=prefix,
 )
-app.include_router(ConfigsRoute.get_configs_router(), prefix=prefix)
+app.include_router(ConfigsRoute.get_configs_router(project_service), prefix=prefix)
 app.include_router(
     UsageRoute.get_usage_router(
         event_service=event_service,

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -48,7 +48,7 @@ from radicalbit_ai_gateway.models.chat_request import convert_openai_messages
 from radicalbit_ai_gateway.models.project_dto import ProjectOut
 from radicalbit_ai_gateway.plugins.loader import discover_plugins, init_plugins
 from radicalbit_ai_gateway.prompt_manager import PromptManager
-from radicalbit_ai_gateway.routes.configs_route import ConfigsRoute
+from radicalbit_ai_gateway.routes.configs_route import ConfigsRoute, ConfigsRouteConfig
 from radicalbit_ai_gateway.routes.dashboard_route import DashboardRoute
 from radicalbit_ai_gateway.routes.group_route import GroupRoute
 from radicalbit_ai_gateway.routes.key_route import KeyRoute
@@ -332,7 +332,13 @@ app.include_router(
     ),
     prefix=prefix,
 )
-app.include_router(ConfigsRoute.get_configs_router(project_service), prefix=prefix)
+app.include_router(
+    ConfigsRoute.get_configs_router(
+        project_service,
+        config=getattr(app.state, 'configs_route_config', ConfigsRouteConfig()),
+    ),
+    prefix=prefix,
+)
 app.include_router(
     UsageRoute.get_usage_router(
         event_service=event_service,

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -12,6 +12,7 @@ from radicalbit_ai_gateway.db.tables.project_table import Project
 from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import (
+    ConfigListFilter,
     ConfigSlotOut,
     ProjectConfigFileIn,
     ProjectFilter,
@@ -244,6 +245,16 @@ class ProjectService:
         self, project_filter: ProjectFilter | None = None
     ) -> list[ProjectOut]:
         projects = self.project_dao.get_all_filtered(project_filter)
+        return [self._build_out(project) for project in projects]
+
+    def get_configs(
+        self, config_filter: ConfigListFilter | None = None
+    ) -> list[ProjectOut]:
+        status = config_filter.to_config_status() if config_filter else None
+        only_saved = config_filter == ConfigListFilter.SAVED
+        projects = self.project_dao.get_all_by_config_status(
+            status, only_saved=only_saved
+        )
         return [self._build_out(project) for project in projects]
 
     def get_all_active(self) -> list[ProjectOut]:

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -251,9 +251,12 @@ class ProjectService:
         self, config_filter: ConfigListFilter | None = None
     ) -> list[ProjectOut]:
         status = config_filter.to_config_status() if config_filter else None
-        only_saved = config_filter == ConfigListFilter.SAVED
+        # "Draft" must exclude EMPTY slots (freshly seeded template with a NULL
+        # updated_at), otherwise it would match every project since a DRAFT slot
+        # always exists.
+        exclude_empty = config_filter == ConfigListFilter.DRAFT
         projects = self.project_dao.get_all_by_config_status(
-            status, only_saved=only_saved
+            status, exclude_empty=exclude_empty
         )
         return [self._build_out(project) for project in projects]
 

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -300,6 +300,9 @@ def get_sample_project(
     )
 
 
+_UNSET = object()
+
+
 def get_sample_project_config(
     project_uuid: uuid.UUID,
     slot: Slot = Slot.A,
@@ -307,6 +310,7 @@ def get_sample_project_config(
     config_status: ConfigStatus = ConfigStatus.DRAFT,
     uuid: uuid.UUID | None = None,
     deleted_at: datetime.datetime | None = None,
+    updated_at=_UNSET,
 ) -> ProjectConfig:
     now = datetime.datetime.now(tz=UTC)
     return ProjectConfig(
@@ -316,7 +320,7 @@ def get_sample_project_config(
         config_file=config_file,
         config_status=config_status.value,
         created_at=now,
-        updated_at=now,
+        updated_at=now if updated_at is _UNSET else updated_at,
         deleted_at=deleted_at,
     )
 

--- a/gateway/tests/dao/project_dao_test.py
+++ b/gateway/tests/dao/project_dao_test.py
@@ -147,8 +147,8 @@ class ProjectDAOTest(DatabaseIntegration):
         result = self.project_dao.get_all_by_config_status(ConfigStatus.DRAFT)
         assert len(result) == 1 and result[0].name == 'draft'
 
-    def test_get_all_by_config_status_only_saved_excludes_untouched_drafts(self):
-        # Seeded (never saved) draft: DRAFT with a NULL updated_at.
+    def test_get_all_by_config_status_exclude_empty_excludes_untouched_drafts(self):
+        # EMPTY slot: DRAFT with a NULL updated_at (freshly seeded template).
         seeded = db_mock.get_sample_project(uuid=uuid.uuid4(), name='seeded')
         self.project_dao.insert(seeded)
         self.insert(
@@ -159,16 +159,16 @@ class ProjectDAOTest(DatabaseIntegration):
                 updated_at=None,
             )
         )
-        # Genuinely saved draft: DRAFT with a populated updated_at.
-        self._insert_project_with_config('saved', ConfigStatus.DRAFT)
+        # Genuine DRAFT: DRAFT with a populated updated_at.
+        self._insert_project_with_config('draft', ConfigStatus.DRAFT)
 
-        # Without only_saved both projects match on DRAFT...
+        # Without exclude_empty both projects match on DRAFT...
         assert len(self.project_dao.get_all_by_config_status(ConfigStatus.DRAFT)) == 2
-        # ...but only the saved one qualifies as "Saved".
+        # ...but only the non-empty one qualifies as a real DRAFT.
         result = self.project_dao.get_all_by_config_status(
-            ConfigStatus.DRAFT, only_saved=True
+            ConfigStatus.DRAFT, exclude_empty=True
         )
-        assert len(result) == 1 and result[0].name == 'saved'
+        assert len(result) == 1 and result[0].name == 'draft'
 
     def test_get_all_by_config_status_request_to_publish(self):
         self._insert_project_with_config('ready', ConfigStatus.READY_TO_SERVE)

--- a/gateway/tests/dao/project_dao_test.py
+++ b/gateway/tests/dao/project_dao_test.py
@@ -8,6 +8,7 @@ from tests.common.db_integration import DatabaseIntegration
 
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.db.tables.project_table import Project
+from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import ProjectFilter
 
@@ -35,6 +36,19 @@ class ProjectDAOTest(DatabaseIntegration):
                 .values(served_config_uuid=config.uuid)
             )
         return self.project_dao.get_by_uuid(project.uuid)
+
+    def _insert_project_with_config(self, name: str, status: ConfigStatus) -> Project:
+        """Insert a project plus a single config slot in the given status."""
+        project = db_mock.get_sample_project(uuid=uuid.uuid4(), name=name)
+        self.project_dao.insert(project)
+        self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=project.uuid,
+                config_file='some-yaml',
+                config_status=status,
+            )
+        )
+        return project
 
     def test_insert(self):
         project = db_mock.get_sample_project()
@@ -121,6 +135,83 @@ class ProjectDAOTest(DatabaseIntegration):
         )
         result = self.project_dao.get_all_filtered(ProjectFilter.WITH_USAGE)
         assert len(result) == 1 and result[0].name == 'was-served'
+
+    def test_get_all_by_config_status_no_filter_returns_all(self):
+        self._insert_project_with_config('draft', ConfigStatus.DRAFT)
+        self._insert_project_with_config('served', ConfigStatus.SERVED)
+        assert len(self.project_dao.get_all_by_config_status(None)) == 2
+
+    def test_get_all_by_config_status_saved(self):
+        self._insert_project_with_config('draft', ConfigStatus.DRAFT)
+        self._insert_project_with_config('served', ConfigStatus.SERVED)
+        result = self.project_dao.get_all_by_config_status(ConfigStatus.DRAFT)
+        assert len(result) == 1 and result[0].name == 'draft'
+
+    def test_get_all_by_config_status_only_saved_excludes_untouched_drafts(self):
+        # Seeded (never saved) draft: DRAFT with a NULL updated_at.
+        seeded = db_mock.get_sample_project(uuid=uuid.uuid4(), name='seeded')
+        self.project_dao.insert(seeded)
+        self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=seeded.uuid,
+                config_file=None,
+                config_status=ConfigStatus.DRAFT,
+                updated_at=None,
+            )
+        )
+        # Genuinely saved draft: DRAFT with a populated updated_at.
+        self._insert_project_with_config('saved', ConfigStatus.DRAFT)
+
+        # Without only_saved both projects match on DRAFT...
+        assert len(self.project_dao.get_all_by_config_status(ConfigStatus.DRAFT)) == 2
+        # ...but only the saved one qualifies as "Saved".
+        result = self.project_dao.get_all_by_config_status(
+            ConfigStatus.DRAFT, only_saved=True
+        )
+        assert len(result) == 1 and result[0].name == 'saved'
+
+    def test_get_all_by_config_status_request_to_publish(self):
+        self._insert_project_with_config('ready', ConfigStatus.READY_TO_SERVE)
+        self._insert_project_with_config('draft', ConfigStatus.DRAFT)
+        result = self.project_dao.get_all_by_config_status(ConfigStatus.READY_TO_SERVE)
+        assert len(result) == 1 and result[0].name == 'ready'
+
+    def test_get_all_by_config_status_published(self):
+        self._insert_project_with_config('served', ConfigStatus.SERVED)
+        self._insert_project_with_config('draft', ConfigStatus.DRAFT)
+        result = self.project_dao.get_all_by_config_status(ConfigStatus.SERVED)
+        assert len(result) == 1 and result[0].name == 'served'
+
+    def test_get_all_by_config_status_matches_any_slot(self):
+        project = db_mock.get_sample_project(uuid=uuid.uuid4(), name='two-slots')
+        self.project_dao.insert(project)
+        self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=project.uuid,
+                slot=Slot.A,
+                config_file='served-yaml',
+                config_status=ConfigStatus.SERVED,
+            )
+        )
+        self.insert(
+            db_mock.get_sample_project_config(
+                project_uuid=project.uuid,
+                slot=Slot.B,
+                config_file='draft-yaml',
+                config_status=ConfigStatus.DRAFT,
+            )
+        )
+        served = self.project_dao.get_all_by_config_status(ConfigStatus.SERVED)
+        draft = self.project_dao.get_all_by_config_status(ConfigStatus.DRAFT)
+        assert [p.uuid for p in served] == [project.uuid]
+        assert [p.uuid for p in draft] == [project.uuid]
+
+    def test_get_all_by_config_status_excludes_deleted(self):
+        project = self._insert_project_with_config('deleted', ConfigStatus.SERVED)
+        self.project_dao.soft_delete(project.uuid)
+        assert (
+            list(self.project_dao.get_all_by_config_status(ConfigStatus.SERVED)) == []
+        )
 
     def test_soft_delete(self):
         project = db_mock.get_sample_project()

--- a/gateway/tests/routes/test_configs_route.py
+++ b/gateway/tests/routes/test_configs_route.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
+from starlette.testclient import TestClient
+
+from tests.common import db_mock
+
+from radicalbit_ai_gateway.models.project_dto import ConfigListFilter
+from radicalbit_ai_gateway.routes.configs_route import ConfigsRoute
+from radicalbit_ai_gateway.services.project_service import ProjectService
+
+
+class TestConfigsRoute(unittest.TestCase):
+    def setUp(self):
+        self.prefix = '/public/api/v1'
+        self.project_service = MagicMock(spec_set=ProjectService)
+        router = ConfigsRoute.get_configs_router(self.project_service)
+        app = FastAPI(title='AI Gateway', debug=True)
+        app.include_router(router, prefix=self.prefix)
+        self.client = TestClient(app)
+
+    def test_get_configs_no_filter(self):
+        out = db_mock.get_sample_project_out()
+        self.project_service.get_configs = MagicMock(return_value=[out])
+        res = self.client.get(f'{self.prefix}/configs/projects')
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder([out])
+        self.project_service.get_configs.assert_called_once_with(None)
+
+    def test_get_configs_with_status(self):
+        out = db_mock.get_sample_project_out()
+        self.project_service.get_configs = MagicMock(return_value=[out])
+        res = self.client.get(
+            f'{self.prefix}/configs/projects', params={'status': 'published'}
+        )
+        assert res.status_code == 200
+        self.project_service.get_configs.assert_called_once_with(
+            ConfigListFilter.PUBLISHED
+        )
+
+    def test_get_configs_invalid_status(self):
+        res = self.client.get(
+            f'{self.prefix}/configs/projects', params={'status': 'nope'}
+        )
+        assert res.status_code == 422

--- a/gateway/tests/routes/test_configs_route.py
+++ b/gateway/tests/routes/test_configs_route.py
@@ -1,14 +1,14 @@
 import unittest
 from unittest.mock import MagicMock
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from starlette.testclient import TestClient
 
 from tests.common import db_mock
 
 from radicalbit_ai_gateway.models.project_dto import ConfigListFilter
-from radicalbit_ai_gateway.routes.configs_route import ConfigsRoute
+from radicalbit_ai_gateway.routes.configs_route import ConfigsRoute, ConfigsRouteConfig
 from radicalbit_ai_gateway.services.project_service import ProjectService
 
 
@@ -45,3 +45,31 @@ class TestConfigsRoute(unittest.TestCase):
             f'{self.prefix}/configs/projects', params={'status': 'nope'}
         )
         assert res.status_code == 422
+
+    def test_get_configs_uses_override_fn(self):
+        # When a ConfigsRouteConfig with a custom get_configs_fn is provided
+        # (as the EE plugin does), the route delegates to it, passing the
+        # request and the parsed status filter.
+        out = db_mock.get_sample_project_out()
+        captured = {}
+
+        def custom_fn(request: Request, status):
+            captured['is_request'] = isinstance(request, Request)
+            captured['status'] = status
+            return [out]
+
+        router = ConfigsRoute.get_configs_router(
+            MagicMock(spec_set=ProjectService),
+            config=ConfigsRouteConfig(get_configs_fn=custom_fn),
+        )
+        app = FastAPI(debug=True)
+        app.include_router(router, prefix=self.prefix)
+        client = TestClient(app)
+
+        res = client.get(
+            f'{self.prefix}/configs/projects', params={'status': 'draft'}
+        )
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder([out])
+        assert captured['is_request'] is True
+        assert captured['status'] == ConfigListFilter.DRAFT

--- a/gateway/tests/routes/test_configs_route.py
+++ b/gateway/tests/routes/test_configs_route.py
@@ -66,9 +66,7 @@ class TestConfigsRoute(unittest.TestCase):
         app.include_router(router, prefix=self.prefix)
         client = TestClient(app)
 
-        res = client.get(
-            f'{self.prefix}/configs/projects', params={'status': 'draft'}
-        )
+        res = client.get(f'{self.prefix}/configs/projects', params={'status': 'draft'})
         assert res.status_code == 200
         assert res.json() == jsonable_encoder([out])
         assert captured['is_request'] is True

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -311,13 +311,13 @@ class ProjectServiceTest(DatabaseIntegration):
         self.svc.approve_config(served.uuid, a)
         self.svc.serve_config(served.uuid, a)
 
-        # saved-only: slot A saved (still DRAFT), never approved/served.
-        saved_proj, sa, _ = self._create(name='saved')
+        # draft-only: slot A saved (still DRAFT), never approved/served.
+        draft_proj, da, _ = self._create(name='draft')
         self.svc.update_config(
-            saved_proj.uuid, sa, ProjectConfigFileIn(config_file=_VALID)
+            draft_proj.uuid, da, ProjectConfigFileIn(config_file=_VALID)
         )
 
-        # untouched: both slots are seeded DRAFT with a NULL updated_at.
+        # untouched: both slots are EMPTY (seeded DRAFT with a NULL updated_at).
         self._create(name='untouched')
 
         assert len(self.svc.get_configs(None)) == 3
@@ -326,8 +326,8 @@ class ProjectServiceTest(DatabaseIntegration):
         published = self.svc.get_configs(ConfigListFilter.PUBLISHED)
         assert [p.uuid for p in published] == [served.uuid]
 
-        # "Saved" only matches the genuinely saved draft, not the seeded ones.
-        saved = self.svc.get_configs(ConfigListFilter.SAVED)
-        assert [p.uuid for p in saved] == [saved_proj.uuid]
+        # "Draft" only matches the genuine draft, not the EMPTY seeded ones.
+        draft = self.svc.get_configs(ConfigListFilter.DRAFT)
+        assert [p.uuid for p in draft] == [draft_proj.uuid]
 
         assert self.svc.get_configs(ConfigListFilter.REQUEST_TO_PUBLISH) == []

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -14,6 +14,7 @@ from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_dto import (
+    ConfigListFilter,
     ProjectConfigFileIn,
     ProjectFilter,
     ProjectIn,
@@ -302,3 +303,31 @@ class ProjectServiceTest(DatabaseIntegration):
         assert served.uuid not in [p.uuid for p in dev]
         active = self.svc.get_all_active()
         assert [p.uuid for p in active] == [served.uuid]
+
+    def test_get_configs_filters_by_status(self):
+        # served-only: slot A served, slot B left as the untouched seed.
+        served, a, _ = self._create(name='served')
+        self.svc.update_config(served.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        self.svc.approve_config(served.uuid, a)
+        self.svc.serve_config(served.uuid, a)
+
+        # saved-only: slot A saved (still DRAFT), never approved/served.
+        saved_proj, sa, _ = self._create(name='saved')
+        self.svc.update_config(
+            saved_proj.uuid, sa, ProjectConfigFileIn(config_file=_VALID)
+        )
+
+        # untouched: both slots are seeded DRAFT with a NULL updated_at.
+        self._create(name='untouched')
+
+        assert len(self.svc.get_configs(None)) == 3
+        assert len(self.svc.get_configs(ConfigListFilter.ALL)) == 3
+
+        published = self.svc.get_configs(ConfigListFilter.PUBLISHED)
+        assert [p.uuid for p in published] == [served.uuid]
+
+        # "Saved" only matches the genuinely saved draft, not the seeded ones.
+        saved = self.svc.get_configs(ConfigListFilter.SAVED)
+        assert [p.uuid for p in saved] == [saved_proj.uuid]
+
+        assert self.svc.get_configs(ConfigListFilter.REQUEST_TO_PUBLISH) == []


### PR DESCRIPTION
# PR Summary: feat/ag-821-create-get-all-configs

Adds a new **Configurations listing** endpoint (`GET /configs/projects`) that returns all projects with their config slots, optionally filtered by a UI status tab (All / Published / Request to Publish / Draft). It mirrors the existing `GET /projects` get-all (no pagination, no server-side search/sort — those stay on the FE). The endpoint is also made **pluggable** (like `/projects`) so EE can override the data provider and response model to apply per-user membership filtering. See Jira AG-821.

---

## DTO Changes

### `ConfigListFilter` (NEW enum)

Status filter used as the `status` query param. Maps each UI tab to an underlying config status.

| Value | UI tab | Meaning |
|-------|--------|---------|
| `all` | All | No filter (also the default when omitted) |
| `published` | Published | Project has at least one `SERVED` slot |
| `request_to_publish` | Request to Publish | Project has at least one `READY_TO_SERVE` slot |
| `draft` | Draft | Project has at least one `DRAFT` slot **with content** (`updatedAt` populated) |

Parsing is case-insensitive (`Draft` → `draft`). Invalid values return `422`.

> **EMPTY vs DRAFT (aligned with the FE):** the FE splits the `DRAFT` config status into two states — **EMPTY** (`configStatus = DRAFT` + `updatedAt = null`, the freshly seeded template) and **DRAFT** (`configStatus = DRAFT` + `updatedAt != null`, a real edited draft). The `draft` filter follows the same rule: it requires `updatedAt IS NOT NULL`, so EMPTY seeded slots are excluded (otherwise every project would match, since a `DRAFT` slot always exists).

---

### `ConfigsRouteConfig` (NEW dataclass — extension hook)

Injectable configuration for the configs router, mirroring the existing `ProjectRouteConfig`. Lets a plugin (EE) swap the data provider and the response model without the core knowing about it. `server.py` reads it from `app.state.configs_route_config` (set by a plugin during `init_plugins`), falling back to the default.

| Field | Type | Description |
|-------|------|-------------|
| `get_configs_fn` | `(Request, ConfigListFilter \| null) -> Any` \| null | Data provider. Default: `project_service.get_configs(status)` (ignores the request). EE injects a membership-aware provider that reads `request.state.user_role` / `user_uuid`. |
| `list_response_model` | type | FastAPI response model for the list. Default: `list[ProjectOut]`. EE overrides it with `list[ProjectWithUsersOut]` so its extra fields are not stripped from the response. |

When no config is provided, behaviour is identical to before (plain `ProjectOut`, all projects) — the change is fully backward compatible.

---

### `ProjectOut` (reused, unchanged)

The endpoint returns a list of the existing `ProjectOut` — already carries every column the UI needs, so no new response DTO was introduced.

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Project UUID |
| `name` | string | Project name |
| `description` | string \| null | Project description |
| `projectStatus` | string | One of: `DEV`, `PROD` (derived: `PROD` when a slot is served) |
| `servedConfigUuid` | string \| null | UUID of the currently served config, if any |
| `configs` | object[] | The config slots (`ConfigSlotOut`), one per slot A/B |
| `createdAt` | datetime | Creation timestamp |
| `updatedAt` | datetime | Last update timestamp |

`ConfigSlotOut` (each item of `configs`):

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Config slot UUID |
| `slot` | string | One of: `A`, `B` |
| `configFile` | string \| null | YAML content (null for an untouched seed) |
| `configStatus` | string | One of: `DRAFT`, `READY_TO_SERVE`, `SERVED` |
| `createdAt` | datetime | Creation timestamp |
| `updatedAt` | datetime \| null | Last save timestamp; `null` if never saved |

**Example response:**
```json
[
  {
    "uuid": "550e8400-e29b-41d4-a716-446655440000",
    "name": "my-project",
    "description": "example project",
    "projectStatus": "PROD",
    "servedConfigUuid": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
    "configs": [
      {
        "uuid": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
        "slot": "A",
        "configFile": "routes:\n  my-route:\n    chat_models: [mock-chat]\n",
        "configStatus": "SERVED",
        "createdAt": "2026-07-02T10:30:00Z",
        "updatedAt": "2026-07-02T11:00:00Z"
      },
      {
        "uuid": "7cb8c921-aebe-22e2-91c5-11d15fe541d9",
        "slot": "B",
        "configFile": null,
        "configStatus": "DRAFT",
        "createdAt": "2026-07-02T10:30:00Z",
        "updatedAt": null
      }
    ],
    "createdAt": "2026-07-02T10:30:00Z",
    "updatedAt": "2026-07-02T11:00:00Z"
  }
]
```

**Used by:** `GET /configs/projects`

---

## Affected Endpoints

### `GET /configs/projects` (NEW)

Returns all non-deleted projects with their config slots, optionally filtered by config status. A project matches when **at least one** of its slots satisfies the filter; both slots are always returned in each row.

**Example request:**
```
GET /public/api/v1/configs/projects?status=draft
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `status` | string | no | One of: `all`, `published`, `request_to_publish`, `draft`. Omitted or `all` → no filter |

**Response:** `200` — `ProjectOut[]` by default (overridable via `ConfigsRouteConfig.list_response_model`, e.g. `ProjectWithUsersOut[]` in EE).

---

## Other Changes

- `db/dao/project_dao.py` — new `get_all_by_config_status(config_status, *, exclude_empty=False)`: filters non-deleted projects via an `EXISTS` on a non-deleted `project_config` slot matching the status; `exclude_empty` additionally requires `updatedAt IS NOT NULL` (drops EMPTY seeded slots).
- `services/project_service.py` — new `get_configs(config_filter)`: translates the filter to a status (+ `exclude_empty` for `DRAFT`) and builds the `ProjectOut` list.
- `routes/configs_route.py` — added the `GET /configs/projects` route and the `ConfigsRouteConfig` hook; `get_configs_router(project_service, config=None)` delegates to `config.get_configs_fn` (default = `project_service.get_configs`) and uses `config.list_response_model`. The handler now takes a `Request` so overrides can access auth state.
- `server.py` — wires `project_service` and `config=getattr(app.state, 'configs_route_config', ConfigsRouteConfig())` into `ConfigsRoute.get_configs_router(...)`.
- `tests/routes/test_configs_route.py` (NEW) — route tests: no filter, status filter, invalid status → 422, and the custom `get_configs_fn` override path.
- `tests/dao/project_dao_test.py` — DAO tests for each status filter, "matches any slot", `exclude_empty` excludes EMPTY seeded drafts, soft-delete exclusion.
- `tests/services/project_service_test.py` — service test covering All/Published/Draft/Request-to-Publish semantics.
- `tests/common/db_mock.py` — `get_sample_project_config` now accepts an optional `updated_at` (default unchanged).
