### PR TITLE
feat: add import config

### DIFF
--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "langchain-mistralai>=1.1.2",
     "azure-health-deidentification>=1.0.0b3",
     "azure-identity>=1.21.0",
+    "python-multipart>=0.0.20",
 ]
 
 [project.scripts]

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Query, Request, Response
+from fastapi import APIRouter, File, Query, Request, Response, UploadFile
 
 from radicalbit_ai_gateway.models.auth_dto import (
     GroupFullOut,
@@ -208,6 +208,20 @@ class ProjectRoute:
                 media_type='application/zip',
                 headers={'Content-Disposition': f'attachment; filename="{filename}"'},
             )
+
+        @router.post(
+            '/projects/{project_uuid}/configs/{config_uuid}/import',
+            status_code=200,
+            response_model=ProjectOut,
+        )
+        @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
+        async def import_config(
+            project_uuid: UUID, config_uuid: UUID, file: UploadFile = File(...)
+        ):
+            content = await file.read()
+            project = project_service.import_config(project_uuid, config_uuid, content)
+            logger.info('Imported config %s for project %s', config_uuid, project_uuid)
+            return project
 
         @router.patch(
             '/projects/{project_uuid}/configs/{config_uuid}/unserve',

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -33,6 +33,9 @@ app_config = get_app_config()
 
 logger = logging.getLogger(app_config.log_config.logger_name)
 
+MAX_IMPORT_BYTES = 2 * 1024 * 1024  # 2 MB
+_ALLOWED_IMPORT_SUFFIXES = ('.yaml', '.yml')
+
 
 @dataclass
 class ProjectRouteConfig:
@@ -218,6 +221,15 @@ class ProjectRoute:
         async def import_config(
             project_uuid: UUID, config_uuid: UUID, file: UploadFile = File(...)
         ):
+            filename = file.filename or ''
+            if not filename.lower().endswith(_ALLOWED_IMPORT_SUFFIXES):
+                raise ProjectConfigValidationError(
+                    'Only .yaml or .yml files can be imported'
+                )
+            if file.size is not None and file.size > MAX_IMPORT_BYTES:
+                raise ProjectConfigValidationError(
+                    f'Uploaded file exceeds the {MAX_IMPORT_BYTES // (1024 * 1024)} MB limit'
+                )
             content = await file.read()
             project = project_service.import_config(project_uuid, config_uuid, content)
             logger.info('Imported config %s for project %s', config_uuid, project_uuid)

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -233,6 +233,31 @@ class ProjectService:
             )
         return self._build_configs_zip(project.name, configs)
 
+    def import_config(
+        self, project_uuid: UUID, config_uuid: UUID, content: bytes
+    ) -> ProjectOut:
+        self._get_project_or_raise(project_uuid)
+        config = self._get_config_or_raise(project_uuid, config_uuid)
+        if config.config_status == ConfigStatus.SERVED.value:
+            raise ProjectConfigValidationError(
+                f'Config {config_uuid} is served and cannot be overwritten by import'
+            )
+        try:
+            config_file = content.decode('utf-8')
+        except UnicodeDecodeError as e:
+            raise ProjectConfigValidationError(
+                'Uploaded file is not valid UTF-8 text'
+            ) from e
+
+        validate_gateway_config(config_file, check_secrets=True)
+
+        rows_updated = self.project_config_dao.update_config_file(
+            config_uuid, config_file
+        )
+        if rows_updated == 0:
+            raise ProjectNotFoundError(f'Config {config_uuid} not found')
+        return self._build_out_or_raise(project_uuid)
+
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):
             raise ProjectNotFoundError(f'Project with UUID {project_uuid} not found')

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -229,6 +229,27 @@ class TestProjectRoute(unittest.TestCase):
         res = self.client.post(f'{self.prefix}/projects/{pid}/configs/{cid}/import')
         assert res.status_code == 422
 
+    def test_import_config_wrong_extension_returns_400(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.import_config = MagicMock()
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/configs/{cid}/import',
+            files={'file': ('c.json', b'{}', 'application/json')},
+        )
+        assert res.status_code == 400
+        self.project_service.import_config.assert_not_called()
+
+    def test_import_config_too_large_returns_400(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.import_config = MagicMock()
+        oversized = b'x' * (2 * 1024 * 1024 + 1)
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/configs/{cid}/import',
+            files={'file': ('c.yaml', oversized, 'application/x-yaml')},
+        )
+        assert res.status_code == 400
+        self.project_service.import_config.assert_not_called()
+
     def test_approve_config(self):
         pid, cid = uuid.uuid4(), uuid.uuid4()
         self.project_service.approve_config = MagicMock(

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -186,6 +186,49 @@ class TestProjectRoute(unittest.TestCase):
         res = self.client.get(f'{self.prefix}/projects/{pid}/configs/export')
         assert res.status_code == 400
 
+    # --- import ---
+
+    def test_import_config_returns_project(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.import_config = MagicMock(
+            return_value=db_mock.get_sample_project_out(uuid=pid)
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/configs/{cid}/import',
+            files={'file': ('c.yaml', b'yaml-bytes', 'application/x-yaml')},
+        )
+        assert res.status_code == 200
+        self.project_service.import_config.assert_called_once_with(
+            pid, cid, b'yaml-bytes'
+        )
+
+    def test_import_config_not_found(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.import_config = MagicMock(
+            side_effect=ProjectNotFoundError('nope')
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/configs/{cid}/import',
+            files={'file': ('c.yaml', b'yaml-bytes', 'application/x-yaml')},
+        )
+        assert res.status_code == 404
+
+    def test_import_config_invalid_returns_400(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.import_config = MagicMock(
+            side_effect=ProjectConfigValidationError('invalid')
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/configs/{cid}/import',
+            files={'file': ('c.yaml', b'yaml-bytes', 'application/x-yaml')},
+        )
+        assert res.status_code == 400
+
+    def test_import_config_missing_file_returns_422(self):
+        pid, cid = uuid.uuid4(), uuid.uuid4()
+        res = self.client.post(f'{self.prefix}/projects/{pid}/configs/{cid}/import')
+        assert res.status_code == 422
+
     def test_approve_config(self):
         pid, cid = uuid.uuid4(), uuid.uuid4()
         self.project_service.approve_config = MagicMock(

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -286,6 +286,38 @@ class ProjectServiceTest(DatabaseIntegration):
         with pytest.raises(ProjectNotFoundError):
             self.svc.export_config(uuid.uuid4(), uuid.uuid4())
 
+    # --- import ---
+
+    def test_import_config_writes_draft(self):
+        out, a, _ = self._create()
+        res = self.svc.import_config(out.uuid, a, _VALID.encode())
+        ca = next(c for c in res.configs if c.uuid == a)
+        assert ca.config_file == _VALID
+        assert ca.config_status == ConfigStatus.DRAFT
+        assert ca.updated_at is not None
+
+    def test_import_config_into_served_raises(self):
+        out, a, _ = self._create()
+        self.svc.update_config(out.uuid, a, ProjectConfigFileIn(config_file=_VALID))
+        self.svc.approve_config(out.uuid, a)
+        self.svc.serve_config(out.uuid, a)
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.import_config(out.uuid, a, _VALID.encode())
+
+    def test_import_config_invalid_yaml_raises(self):
+        out, a, _ = self._create()
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.import_config(out.uuid, a, b'::not yaml::')
+
+    def test_import_config_non_utf8_raises(self):
+        out, a, _ = self._create()
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.import_config(out.uuid, a, b'\xff\xfe')
+
+    def test_import_config_not_found(self):
+        with pytest.raises(ProjectNotFoundError):
+            self.svc.import_config(uuid.uuid4(), uuid.uuid4(), _VALID.encode())
+
     # --- listing / filters ---
 
     def test_get_all_and_filters(self):

--- a/gateway/uv.lock
+++ b/gateway/uv.lock
@@ -1104,7 +1104,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -4314,6 +4314,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4449,6 +4458,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pydantic-yaml" },
     { name = "python-json-logger" },
+    { name = "python-multipart" },
     { name = "redis" },
     { name = "rich" },
     { name = "sqlalchemy" },
@@ -4515,6 +4525,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pydantic-yaml", specifier = ">=1.6.0" },
     { name = "python-json-logger", specifier = ">=4.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "redis", specifier = ">=7.1.0" },
     { name = "rich", specifier = ">=14.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },


### PR DESCRIPTION
# PR Summary: feat/import-config

Adds an **import** endpoint that uploads a YAML config file into a specific project config slot — the inverse of the existing export endpoints. The uploaded file is validated (extension, size, UTF-8, schema, and secrets) and written into the slot as a `DRAFT`.

---

## DTO Changes

**None.** The endpoint reuses the existing `ProjectOut` response model (returned by the other config-mutation endpoints such as update/approve/serve).

For reference, the (unchanged) response shape returned on success:

### `ProjectOut` (response, camelCase keys)

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Project UUID |
| `name` | string | Project name |
| `description` | string \| null | Project description |
| `projectStatus` | string | One of: `DEV`, `PROD` |
| `servedConfigUuid` | string \| null | UUID of the currently served config, if any |
| `configs` | object[] | The project's config slots (see `ConfigSlotOut` below) |
| `createdAt` | string | Creation timestamp |
| `updatedAt` | string | Last update timestamp |

### `ConfigSlotOut` (nested in `configs`)

| Field | Type | Description |
|-------|------|-------------|
| `uuid` | string | Config slot UUID |
| `slot` | string | One of: `A`, `B` |
| `configFile` | string \| null | The YAML config content |
| `configStatus` | string | One of: `DRAFT`, `READY_TO_SERVE`, `SERVED` |
| `createdAt` | string | Creation timestamp |
| `updatedAt` | string \| null | Last update timestamp |

**Example response (200):**
```json
{
  "uuid": "550e8400-e29b-41d4-a716-446655440000",
  "name": "my-project",
  "description": "example project",
  "projectStatus": "DEV",
  "servedConfigUuid": null,
  "configs": [
    {
      "uuid": "11111111-1111-1111-1111-111111111111",
      "slot": "A",
      "configFile": "routes:\n  - name: chat\n    ...",
      "configStatus": "DRAFT",
      "createdAt": "2024-01-15T10:30:00Z",
      "updatedAt": "2024-01-15T11:00:00Z"
    },
    {
      "uuid": "22222222-2222-2222-2222-222222222222",
      "slot": "B",
      "configFile": null,
      "configStatus": "DRAFT",
      "createdAt": "2024-01-15T10:30:00Z",
      "updatedAt": null
    }
  ],
  "createdAt": "2024-01-15T10:30:00Z",
  "updatedAt": "2024-01-15T11:00:00Z"
}
```

**Used by:** `POST /projects/{project_uuid}/configs/{config_uuid}/import`

---

## Affected Endpoints

### `POST /public/api/v1/projects/{project_uuid}/configs/{config_uuid}/import` (NEW)

Uploads a YAML config file into the given config slot. The upload is `multipart/form-data` with a single `file` field. On success the slot is written as `DRAFT` and the full updated `ProjectOut` is returned.

**Example request:**
```
POST /public/api/v1/projects/550e8400-e29b-41d4-a716-446655440000/configs/11111111-1111-1111-1111-111111111111/import
Content-Type: multipart/form-data

file=@my-project_config_A_draft.yaml
```

```bash
curl -X POST \
  "http://localhost:8000/public/api/v1/projects/{project_uuid}/configs/{config_uuid}/import" \
  -F "file=@config.yaml"
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `config_uuid` | string | yes | Config slot UUID (path) |
| `file` | file (multipart) | yes | The `.yaml` / `.yml` config file to import |

**Responses:**

| Status | When |
|--------|------|
| `200` | Import succeeded; returns the updated `ProjectOut` (slot set to `DRAFT`) |
| `400` | Wrong extension (not `.yaml`/`.yml`), file larger than **2 MB**, non-UTF-8 content, invalid YAML/schema, literal secrets, `!secret` referencing a missing key, or the target slot is `SERVED` (read-only) |
| `404` | Unknown project or config UUID |
| `422` | Missing `file` field |

**Validation rules (in order, before the body is read where possible):**
1. Filename must end with `.yaml` or `.yml` (case-insensitive) → else `400`.
2. `file.size` must be ≤ 2 MB (`MAX_IMPORT_BYTES`) → else `400`.
3. Target slot must not be `SERVED` → else `400`.
4. Content must decode as UTF-8 → else `400`.
5. Content must pass `validate_gateway_config(..., check_secrets=True)` (schema + secrets) → else `400`.

---

## Other Changes

- `services/project_service.py` — New `ProjectService.import_config(project_uuid, config_uuid, content: bytes)`. Guards against served slots, decodes bytes → str, validates via `validate_gateway_config`, then writes through `ProjectConfigDAO.update_config_file` (which resets the slot to `DRAFT` and bumps `updated_at`). Mirrors the `update_config` write path.
- `routes/project_route.py` — New `import_config` route + `MAX_IMPORT_BYTES` (2 MB) and `_ALLOWED_IMPORT_SUFFIXES` (`.yaml`, `.yml`) constants; extension and size guards run at the route layer before reading the upload.
- `pyproject.toml` / `uv.lock` — Added `python-multipart>=0.0.20` (required by FastAPI `UploadFile`; resolved to `0.0.32`).
- `tests/routes/test_project_route.py` — Route tests: success (200), not found (404), invalid (400), missing file (422), wrong extension (400), too large (400).
- `tests/services/project_service_test.py` — Service tests: writes draft, rejects import into served slot, invalid YAML, non-UTF-8, not found.


## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [x] Tests pass (locally/CI)
- [x] Lint/build pass
- [x] No secrets committed
- [ ] Docs updated (if needed)
