### PR TITLE
feat(guardrails): add message_roles scope to guardrail configuration

### DIFF
--- a/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
+++ b/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
@@ -133,9 +133,9 @@ def _blob_from_messages(messages: list[BaseMessage]) -> str:
 # ---------------------------------------------------------------------------
 
 _ROLE_TO_TYPE: dict[GuardrailMessageRole, type[BaseMessage]] = {
-    GuardrailMessageRole.USER:      HumanMessage,
-    GuardrailMessageRole.SYSTEM:    SystemMessage,
-    GuardrailMessageRole.TOOL:      ToolMessage,
+    GuardrailMessageRole.USER: HumanMessage,
+    GuardrailMessageRole.SYSTEM: SystemMessage,
+    GuardrailMessageRole.TOOL: ToolMessage,
     GuardrailMessageRole.ASSISTANT: AIMessage,
 }
 
@@ -150,9 +150,7 @@ def _filter_messages_by_roles(
     (backward-compatible: the gateway historically only scanned user messages).
     """
     effective = roles or [GuardrailMessageRole.USER]
-    allowed = tuple(
-        _ROLE_TO_TYPE[r] for r in effective if r in _ROLE_TO_TYPE
-    )
+    allowed = tuple(_ROLE_TO_TYPE[r] for r in effective if r in _ROLE_TO_TYPE)
     if not allowed:
         return []
     return [m for m in messages if isinstance(m, allowed)]
@@ -577,7 +575,9 @@ class GuardrailCheck:
 
             # Filter messages to the roles configured for this guardrail.
             # Default: [user] for backward compatibility.
-            filtered_messages = _filter_messages_by_roles(messages, guardrail.message_roles)
+            filtered_messages = _filter_messages_by_roles(
+                messages, guardrail.message_roles
+            )
             if not filtered_messages:
                 logger.debug(
                     'Guardrail %s: no messages match message_roles=%s — skipping.',
@@ -933,7 +933,9 @@ class GuardrailCheck:
             check_function = self._guardrail_check_mapping.get(guardrail.type)
             if not check_function:
                 continue
-            filtered_messages = _filter_messages_by_roles(messages, guardrail.message_roles)
+            filtered_messages = _filter_messages_by_roles(
+                messages, guardrail.message_roles
+            )
             if not filtered_messages:
                 continue
             try:

--- a/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
+++ b/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
@@ -6,7 +6,13 @@ import re
 from typing import Protocol
 
 import httpx
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from opentelemetry import trace
 from traceloop.sdk.decorators import task, workflow
 
@@ -23,6 +29,7 @@ from radicalbit_ai_gateway.models.guardrails import (
     Guardrail,
     GuardrailBehaviorType,
     GuardrailClass,
+    GuardrailMessageRole,
     GuardrailParameter,
     GuardrailsAIParameter,
     GuardrailType,
@@ -119,6 +126,36 @@ def _blob_from_messages(messages: list[BaseMessage]) -> str:
     """Build a single text blob from messages (safe for spaCy/Presidio)."""
     texts = _texts_from_messages(messages)
     return '\n'.join(texts) if texts else ''
+
+
+# ---------------------------------------------------------------------------
+# Role-based message filtering
+# ---------------------------------------------------------------------------
+
+_ROLE_TO_TYPE: dict[GuardrailMessageRole, type[BaseMessage]] = {
+    GuardrailMessageRole.USER:      HumanMessage,
+    GuardrailMessageRole.SYSTEM:    SystemMessage,
+    GuardrailMessageRole.TOOL:      ToolMessage,
+    GuardrailMessageRole.ASSISTANT: AIMessage,
+}
+
+
+def _filter_messages_by_roles(
+    messages: list[BaseMessage],
+    roles: list[GuardrailMessageRole] | None,
+) -> list[BaseMessage]:
+    """Return only the messages whose LangChain type matches the given roles.
+
+    When *roles* is ``None`` or empty the function defaults to ``[USER]``
+    (backward-compatible: the gateway historically only scanned user messages).
+    """
+    effective = roles or [GuardrailMessageRole.USER]
+    allowed = tuple(
+        _ROLE_TO_TYPE[r] for r in effective if r in _ROLE_TO_TYPE
+    )
+    if not allowed:
+        return []
+    return [m for m in messages if isinstance(m, allowed)]
 
 
 class GuardrailCheck:
@@ -538,10 +575,21 @@ class GuardrailCheck:
                     f'Unknown guardrail type: {guardrail.type}', guardrail
                 )
 
+            # Filter messages to the roles configured for this guardrail.
+            # Default: [user] for backward compatibility.
+            filtered_messages = _filter_messages_by_roles(messages, guardrail.message_roles)
+            if not filtered_messages:
+                logger.debug(
+                    'Guardrail %s: no messages match message_roles=%s — skipping.',
+                    guardrail.name,
+                    guardrail.message_roles,
+                )
+                continue
+
             try:
                 token = self._reason_payload_ctx.set(None)
                 is_triggered = await check_function(
-                    messages,
+                    filtered_messages,
                     guardrail.parameters,
                     route_config,
                     **kwargs,
@@ -885,9 +933,12 @@ class GuardrailCheck:
             check_function = self._guardrail_check_mapping.get(guardrail.type)
             if not check_function:
                 continue
+            filtered_messages = _filter_messages_by_roles(messages, guardrail.message_roles)
+            if not filtered_messages:
+                continue
             try:
                 if await check_function(
-                    messages, guardrail.parameters, route_config, **kwargs
+                    filtered_messages, guardrail.parameters, route_config, **kwargs
                 ):
                     return True
             except Exception:

--- a/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
+++ b/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
@@ -600,6 +600,7 @@ class GuardrailCheck:
                     filtered_messages,
                     guardrail.parameters,
                     route_config,
+                    message_roles=guardrail.message_roles,
                     **kwargs,
                 )
             except Exception as e:
@@ -948,7 +949,11 @@ class GuardrailCheck:
                 continue
             try:
                 if await check_function(
-                    filtered_messages, guardrail.parameters, route_config, **kwargs
+                    filtered_messages,
+                    guardrail.parameters,
+                    route_config,
+                    message_roles=guardrail.message_roles,
+                    **kwargs,
                 ):
                     return True
             except Exception:

--- a/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
+++ b/gateway/radicalbit_ai_gateway/guardrails/guardrail_check.py
@@ -146,11 +146,19 @@ def _filter_messages_by_roles(
 ) -> list[BaseMessage]:
     """Return only the messages whose LangChain type matches the given roles.
 
-    When *roles* is ``None`` or empty the function defaults to ``[USER]``
-    (backward-compatible: the gateway historically only scanned user messages).
+    When *roles* is ``None`` (not configured) the function returns all messages
+    unchanged — preserving the original gateway behavior where all messages in
+    the list are scanned regardless of type.
+
+    When *roles* is an explicit list (even empty) only messages whose type
+    matches an entry in the list are returned.  An empty list returns nothing.
     """
-    effective = roles or [GuardrailMessageRole.USER]
-    allowed = tuple(_ROLE_TO_TYPE[r] for r in effective if r in _ROLE_TO_TYPE)
+    if roles is None:
+        # Not configured: original behavior — no filtering.
+        return messages
+    if not roles:
+        return []
+    allowed = tuple(_ROLE_TO_TYPE[r] for r in roles if r in _ROLE_TO_TYPE)
     if not allowed:
         return []
     return [m for m in messages if isinstance(m, allowed)]

--- a/gateway/radicalbit_ai_gateway/guardrails/guardrail_redact.py
+++ b/gateway/radicalbit_ai_gateway/guardrails/guardrail_redact.py
@@ -7,6 +7,7 @@ from langchain_core.messages import BaseMessage
 from traceloop.sdk.decorators import task, workflow
 
 from radicalbit_ai_gateway.events.events_processor import emit_event
+from radicalbit_ai_gateway.guardrails.guardrail_check import _filter_messages_by_roles
 from radicalbit_ai_gateway.guardrails.presidio import PresidioEngine
 from radicalbit_ai_gateway.metrics.define_metrics import guardrails_triggered_counter
 from radicalbit_ai_gateway.models.event_payload import GuardrailEventPayload
@@ -204,7 +205,7 @@ class GuardrailRedact:
         if not redact_guardrails:
             return messages
 
-        messages_to_redact = messages
+        messages_to_redact = list(messages)
 
         for guardrail in redact_guardrails:
             logger.debug(
@@ -221,9 +222,31 @@ class GuardrailRedact:
                     f'Unknown guardrail type: {guardrail.type}', guardrail
                 )
 
-            redacted_messages, was_redacted = await redact_fn(
-                messages_to_redact, guardrail.parameters
+            # Filter to only the roles this guardrail is scoped to.
+            # Indices track positions so we can reintegrate after redacting.
+            filtered_indexed = [
+                (i, m)
+                for i, m in enumerate(messages_to_redact)
+                if m in _filter_messages_by_roles([m], guardrail.message_roles)
+            ]
+
+            if not filtered_indexed:
+                logger.debug(
+                    'Guardrail %s: no messages match message_roles=%s — skipping.',
+                    guardrail.name,
+                    guardrail.message_roles,
+                )
+                continue
+
+            filtered_only = [m for _, m in filtered_indexed]
+            redacted_filtered, was_redacted = await redact_fn(
+                filtered_only, guardrail.parameters
             )
+
+            # Reintegrate redacted messages into their original positions
+            result = list(messages_to_redact)
+            for (orig_idx, _), redacted_msg in zip(filtered_indexed, redacted_filtered):
+                result[orig_idx] = redacted_msg
 
             if was_redacted:
                 attrs = {
@@ -264,7 +287,7 @@ class GuardrailRedact:
 
                 logger.warning(log_message)
 
-            messages_to_redact = redacted_messages
+            messages_to_redact = result
 
         return messages_to_redact
 

--- a/gateway/radicalbit_ai_gateway/models/guardrails.py
+++ b/gateway/radicalbit_ai_gateway/models/guardrails.py
@@ -31,8 +31,8 @@ class GuardrailMessageRole(str, Enum):
 
     Supported roles: user, system, tool, assistant.
     ``function`` is intentionally excluded — it is deprecated by OpenAI.
-    When ``message_roles`` is not set on a guardrail, only ``user`` messages
-    are scanned (backward-compatible default).
+    When ``message_roles`` is not set on a guardrail, all messages in the
+    list are scanned (original gateway behavior, no role filtering).
     """
 
     USER = 'USER'
@@ -214,10 +214,11 @@ class Guardrail(BaseModel):
         description=(
             'Message roles to apply the guardrail to. '
             'Supported values: user, system, tool, assistant. '
-            'If not set, defaults to [user] (backward-compatible). '
-            'Use a list to target multiple roles, e.g. [user, tool].'
+            'If not set (default), all messages are scanned regardless of role — '
+            'preserving the original gateway behavior. '
+            'Set explicitly to restrict scanning to specific roles, e.g. [user, tool].'
         ),
-        examples=[['user'], ['user', 'tool'], ['system']],
+        examples=[['user'], ['user', 'tool'], ['system'], ['tool']],
     )
 
     @field_validator('type', 'where', 'behavior', mode='before')

--- a/gateway/radicalbit_ai_gateway/models/guardrails.py
+++ b/gateway/radicalbit_ai_gateway/models/guardrails.py
@@ -31,8 +31,10 @@ class GuardrailMessageRole(str, Enum):
 
     Supported roles: user, system, tool, assistant.
     ``function`` is intentionally excluded — it is deprecated by OpenAI.
-    When ``message_roles`` is not set on a guardrail, all messages in the
-    list are scanned (original gateway behavior, no role filtering).
+    When ``message_roles`` is not set (default), no filtering is applied:
+      - Regex and Presidio (PII) scan all messages in the chat history.
+      - LLM Judge scans only human (user) messages in the INPUT phase,
+        preserving original gateway behavior.
     """
 
     USER = 'USER'
@@ -214,8 +216,9 @@ class Guardrail(BaseModel):
         description=(
             'Message roles to apply the guardrail to. '
             'Supported values: user, system, tool, assistant. '
-            'If not set (default), all messages are scanned regardless of role — '
-            'preserving the original gateway behavior. '
+            'If not set (default), no role filtering is applied: '
+            'Regex/Presidio scan all messages, while LLM Judge scans only '
+            'human/user messages in the INPUT phase (preserving original behavior). '
             'Set explicitly to restrict scanning to specific roles, e.g. [user, tool].'
         ),
         examples=[['user'], ['user', 'tool'], ['system'], ['tool']],

--- a/gateway/radicalbit_ai_gateway/models/guardrails.py
+++ b/gateway/radicalbit_ai_gateway/models/guardrails.py
@@ -26,6 +26,21 @@ class GuardrailWhereType(str, Enum):
     IO = 'IO'
 
 
+class GuardrailMessageRole(str, Enum):
+    """Message roles that guardrails can be scoped to.
+
+    Supported roles: user, system, tool, assistant.
+    ``function`` is intentionally excluded — it is deprecated by OpenAI.
+    When ``message_roles`` is not set on a guardrail, only ``user`` messages
+    are scanned (backward-compatible default).
+    """
+
+    USER = 'USER'
+    SYSTEM = 'SYSTEM'
+    TOOL = 'TOOL'
+    ASSISTANT = 'ASSISTANT'
+
+
 class GuardrailBehaviorType(str, Enum):
     BLOCK = 'BLOCK'
     WARN = 'WARN'
@@ -194,10 +209,30 @@ class Guardrail(BaseModel):
         default=True,
         description='Whether the guardrail is enabled or disabled.',
     )
+    message_roles: list[GuardrailMessageRole] | None = Field(
+        default=None,
+        description=(
+            'Message roles to apply the guardrail to. '
+            'Supported values: user, system, tool, assistant. '
+            'If not set, defaults to [user] (backward-compatible). '
+            'Use a list to target multiple roles, e.g. [user, tool].'
+        ),
+        examples=[['user'], ['user', 'tool'], ['system']],
+    )
 
     @field_validator('type', 'where', 'behavior', mode='before')
     def validate_lower_case_enum(cls, value: GuardrailBehaviorType) -> str:
         return value.upper()
+
+    @field_validator('message_roles', mode='before')
+    @classmethod
+    def validate_message_roles(cls, value):
+        """Normalise message_roles values to uppercase strings."""
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return [v.upper() if isinstance(v, str) else v for v in value]
+        return value
 
     def guardrail_class(self):
         if self.type in [

--- a/gateway/radicalbit_ai_gateway/utils/judge/content_extractor.py
+++ b/gateway/radicalbit_ai_gateway/utils/judge/content_extractor.py
@@ -15,13 +15,15 @@ _MEDIA_TYPES = frozenset({'image_url', 'image', 'file'})
 def extract_content_for_judge(messages: list[BaseMessage], **kwargs) -> str:
     """Extract text content from messages based on guardrail phase.
 
-    For INPUT phase: extracts content from all messages provided (role
-    filtering is handled upstream by ``_filter_messages_by_roles``).
+    For INPUT phase: extracts content from messages (filtering by role is
+    handled upstream by ``_filter_messages_by_roles`` if configured; otherwise,
+    falls back to extracting from human/user messages for backward compatibility).
     For OUTPUT phase: extracts content from the last AI (assistant) message.
 
     Args:
         messages: List of LangChain messages.
         **kwargs: Must include 'where' (GuardrailWhereType) to determine phase.
+            Can include 'message_roles' to determine if role filtering is active.
 
     Returns:
         Extracted text content as a string. Returns empty string if no
@@ -32,6 +34,7 @@ def extract_content_for_judge(messages: list[BaseMessage], **kwargs) -> str:
         return ''
 
     where = kwargs.get('where')
+    message_roles = kwargs.get('message_roles')
     if isinstance(where, GuardrailWhereType):
         where_value = where.value
     else:
@@ -40,7 +43,7 @@ def extract_content_for_judge(messages: list[BaseMessage], **kwargs) -> str:
     if where_value == GuardrailWhereType.OUTPUT.value:
         return _extract_output_content(messages)
 
-    return _extract_input_content(messages)
+    return _extract_input_content(messages, message_roles)
 
 
 def _extract_output_content(messages: list[BaseMessage]) -> str:
@@ -53,15 +56,19 @@ def _extract_output_content(messages: list[BaseMessage]) -> str:
     return ''
 
 
-def _extract_input_content(messages: list[BaseMessage]) -> str:
-    """Extract content from all provided messages for INPUT phase.
+def _extract_input_content(
+    messages: list[BaseMessage], message_roles: list | None
+) -> str:
+    """Extract content from provided messages for INPUT phase.
 
-    Role-based filtering (e.g. user-only, tool-only) is applied upstream
-    by ``_filter_messages_by_roles`` before the messages reach this function.
-    No additional type filtering is performed here.
+    If message_roles is None (not configured), falls back to original behavior
+    of only scanning human (user) messages. Otherwise, scans all provided messages
+    since filtering is handled upstream.
     """
     parts: list[str] = []
     for m in messages:
+        if message_roles is None and _get_message_type(m) != 'human':
+            continue
         text = _get_message_text(m)
         if text:
             parts.append(text)
@@ -83,12 +90,14 @@ def _get_message_type(msg: BaseMessage) -> str:
 def extract_media_blocks_for_judge(messages: list[BaseMessage], **kwargs) -> list[dict]:
     """Extract image and file content blocks from messages based on guardrail phase.
 
-    For INPUT phase: collects media blocks from all human messages.
+    For INPUT phase: collects media blocks from messages (filtering by role is
+    handled upstream if configured; otherwise, falls back to human messages).
     For OUTPUT phase: collects media blocks from the last AI message.
 
     Args:
         messages: List of LangChain messages.
         **kwargs: Accepts 'where' (GuardrailWhereType) to determine phase.
+            Can include 'message_roles'.
 
     Returns:
         List of content block dicts with type in {image_url, image, file}.
@@ -99,6 +108,7 @@ def extract_media_blocks_for_judge(messages: list[BaseMessage], **kwargs) -> lis
         return []
 
     where = kwargs.get('where')
+    message_roles = kwargs.get('message_roles')
     if isinstance(where, GuardrailWhereType):
         where_value = where.value
     else:
@@ -106,16 +116,21 @@ def extract_media_blocks_for_judge(messages: list[BaseMessage], **kwargs) -> lis
 
     if where_value == GuardrailWhereType.OUTPUT.value:
         return _extract_output_media_blocks(messages)
-    return _extract_input_media_blocks(messages)
+    return _extract_input_media_blocks(messages, message_roles)
 
 
-def _extract_input_media_blocks(messages: list[BaseMessage]) -> list[dict]:
-    """Extract media blocks from all provided messages for INPUT phase.
+def _extract_input_media_blocks(
+    messages: list[BaseMessage], message_roles: list | None
+) -> list[dict]:
+    """Extract media blocks from provided messages for INPUT phase.
 
-    Role-based filtering is applied upstream; no additional type filtering here.
+    If message_roles is None (not configured), falls back to original behavior
+    of only scanning human (user) messages. Otherwise, scans all provided messages.
     """
     blocks: list[dict] = []
     for m in messages:
+        if message_roles is None and _get_message_type(m) != 'human':
+            continue
         blocks.extend(_get_media_blocks(m))
     return blocks
 

--- a/gateway/radicalbit_ai_gateway/utils/judge/content_extractor.py
+++ b/gateway/radicalbit_ai_gateway/utils/judge/content_extractor.py
@@ -15,7 +15,8 @@ _MEDIA_TYPES = frozenset({'image_url', 'image', 'file'})
 def extract_content_for_judge(messages: list[BaseMessage], **kwargs) -> str:
     """Extract text content from messages based on guardrail phase.
 
-    For INPUT phase: extracts content from human (user) messages.
+    For INPUT phase: extracts content from all messages provided (role
+    filtering is handled upstream by ``_filter_messages_by_roles``).
     For OUTPUT phase: extracts content from the last AI (assistant) message.
 
     Args:
@@ -53,13 +54,17 @@ def _extract_output_content(messages: list[BaseMessage]) -> str:
 
 
 def _extract_input_content(messages: list[BaseMessage]) -> str:
-    """Extract content from human messages for INPUT phase."""
+    """Extract content from all provided messages for INPUT phase.
+
+    Role-based filtering (e.g. user-only, tool-only) is applied upstream
+    by ``_filter_messages_by_roles`` before the messages reach this function.
+    No additional type filtering is performed here.
+    """
     parts: list[str] = []
     for m in messages:
-        if _get_message_type(m) == 'human':
-            text = _get_message_text(m)
-            if text:
-                parts.append(text)
+        text = _get_message_text(m)
+        if text:
+            parts.append(text)
 
     return '\n'.join(parts) if parts else ''
 
@@ -105,10 +110,13 @@ def extract_media_blocks_for_judge(messages: list[BaseMessage], **kwargs) -> lis
 
 
 def _extract_input_media_blocks(messages: list[BaseMessage]) -> list[dict]:
+    """Extract media blocks from all provided messages for INPUT phase.
+
+    Role-based filtering is applied upstream; no additional type filtering here.
+    """
     blocks: list[dict] = []
     for m in messages:
-        if _get_message_type(m) == 'human':
-            blocks.extend(_get_media_blocks(m))
+        blocks.extend(_get_media_blocks(m))
     return blocks
 
 

--- a/gateway/tests/guardrails/judges/test_judge_engine.py
+++ b/gateway/tests/guardrails/judges/test_judge_engine.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.prompts import PromptTemplate
 import pytest
 
@@ -74,7 +74,7 @@ class TestJudgeEngine:
     # extract_content_for_judge tests (INPUT vs OUTPUT)
     # -----------------------------------------------------
     def test_extract_content_input_default(self):
-        """Default behavior (no where) -> INPUT (human only)."""
+        """Default behavior (no where) -> INPUT: extracts all messages."""
         messages = [
             HumanMessage(content='Hello'),
             HumanMessage(content='How are you?'),
@@ -82,15 +82,33 @@ class TestJudgeEngine:
         result = extract_content_for_judge(messages)
         assert result == 'Hello\nHow are you?'
 
-    def test_extract_content_input_ignores_ai(self):
-        """INPUT must ignore AI messages."""
+    def test_extract_content_input_includes_all_message_types(self):
+        """INPUT includes all message types — role filtering is done upstream."""
         messages = [
             HumanMessage(content='Hello'),
             AIMessage(content='Assistant output'),
             HumanMessage(content='How are you?'),
         ]
         result = extract_content_for_judge(messages, where=GuardrailWhereType.INPUT)
-        assert result == 'Hello\nHow are you?'
+        assert result == 'Hello\nAssistant output\nHow are you?'
+
+    def test_extract_content_input_includes_tool_messages(self):
+        """INPUT includes ToolMessage content — typical for tool-role guardrail checks."""
+        messages = [
+            HumanMessage(content='User request'),
+            ToolMessage(content='Tool result with Zeiss data', tool_call_id='c1'),
+        ]
+        result = extract_content_for_judge(messages, where=GuardrailWhereType.INPUT)
+        assert result == 'User request\nTool result with Zeiss data'
+
+    def test_extract_content_input_includes_system_messages(self):
+        """INPUT includes SystemMessage content when passed."""
+        messages = [
+            SystemMessage(content='System context'),
+            HumanMessage(content='User request'),
+        ]
+        result = extract_content_for_judge(messages, where=GuardrailWhereType.INPUT)
+        assert result == 'System context\nUser request'
 
     def test_extract_content_output_picks_ai(self):
         """OUTPUT must pick AI messages (assistant output)."""
@@ -689,8 +707,12 @@ class TestJudgeEngine:
         result = extract_media_blocks_for_judge(messages)
         assert result == []
 
-    def test_extract_media_blocks_ignores_ai_messages_for_input(self):
-        """Media blocks in AI messages are ignored for INPUT phase."""
+    def test_extract_media_blocks_includes_all_message_types_for_input(self):
+        """Media blocks in all message types are included for INPUT phase.
+
+        Role filtering is applied upstream; the extractor processes whatever
+        messages it receives without further type discrimination.
+        """
         image_block = {
             'type': 'image_url',
             'image_url': {'url': 'data:image/png;base64,abc'},
@@ -702,7 +724,7 @@ class TestJudgeEngine:
         result = extract_media_blocks_for_judge(
             messages, where=GuardrailWhereType.INPUT
         )
-        assert result == []
+        assert result == [image_block]
 
     def test_extract_media_blocks_output_picks_last_ai_message(self):
         """Media blocks from the last AI message are returned for OUTPUT phase."""

--- a/gateway/tests/guardrails/judges/test_judge_engine.py
+++ b/gateway/tests/guardrails/judges/test_judge_engine.py
@@ -89,7 +89,11 @@ class TestJudgeEngine:
             AIMessage(content='Assistant output'),
             HumanMessage(content='How are you?'),
         ]
-        result = extract_content_for_judge(messages, where=GuardrailWhereType.INPUT)
+        result = extract_content_for_judge(
+            messages,
+            where=GuardrailWhereType.INPUT,
+            message_roles=['USER', 'ASSISTANT'],
+        )
         assert result == 'Hello\nAssistant output\nHow are you?'
 
     def test_extract_content_input_includes_tool_messages(self):
@@ -98,7 +102,9 @@ class TestJudgeEngine:
             HumanMessage(content='User request'),
             ToolMessage(content='Tool result with Zeiss data', tool_call_id='c1'),
         ]
-        result = extract_content_for_judge(messages, where=GuardrailWhereType.INPUT)
+        result = extract_content_for_judge(
+            messages, where=GuardrailWhereType.INPUT, message_roles=['USER', 'TOOL']
+        )
         assert result == 'User request\nTool result with Zeiss data'
 
     def test_extract_content_input_includes_system_messages(self):
@@ -107,7 +113,9 @@ class TestJudgeEngine:
             SystemMessage(content='System context'),
             HumanMessage(content='User request'),
         ]
-        result = extract_content_for_judge(messages, where=GuardrailWhereType.INPUT)
+        result = extract_content_for_judge(
+            messages, where=GuardrailWhereType.INPUT, message_roles=['USER', 'SYSTEM']
+        )
         assert result == 'System context\nUser request'
 
     def test_extract_content_output_picks_ai(self):
@@ -722,7 +730,9 @@ class TestJudgeEngine:
             AIMessage(content=[{'type': 'text', 'text': 'AI text'}, image_block]),
         ]
         result = extract_media_blocks_for_judge(
-            messages, where=GuardrailWhereType.INPUT
+            messages,
+            where=GuardrailWhereType.INPUT,
+            message_roles=['USER', 'ASSISTANT'],
         )
         assert result == [image_block]
 

--- a/gateway/tests/guardrails/test_message_role_scope.py
+++ b/gateway/tests/guardrails/test_message_role_scope.py
@@ -1,0 +1,269 @@
+"""Tests for the guardrail message role scope feature.
+
+Verifies that _filter_messages_by_roles correctly filters messages by LangChain
+type, and that apply_guardrails / evaluate_warn_triggered respect the
+message_roles configuration field.
+"""
+from unittest.mock import MagicMock
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+import pytest
+
+from radicalbit_ai_gateway.guardrails.guardrail_check import (
+    GuardrailCheck,
+    _filter_messages_by_roles,
+)
+from radicalbit_ai_gateway.models.guardrails import (
+    CheckParameter,
+    Guardrail,
+    GuardrailBehaviorType,
+    GuardrailMessageRole,
+    GuardrailType,
+    GuardrailWhereType,
+)
+from radicalbit_ai_gateway.utils.exceptions import GuardrailBadRequest
+
+# ---------------------------------------------------------------------------
+# _filter_messages_by_roles unit tests
+# ---------------------------------------------------------------------------
+
+BLOCKED_KEYWORD = 'forbidden-keyword'
+SAFE_CONTENT = 'safe and innocuous message'
+
+HUMAN = HumanMessage(content=f'user says {BLOCKED_KEYWORD}')
+SYSTEM = SystemMessage(content=f'system says {BLOCKED_KEYWORD}')
+TOOL = ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1')
+AI = AIMessage(content=f'assistant says {BLOCKED_KEYWORD}')
+
+ALL_MESSAGES = [HUMAN, SYSTEM, TOOL, AI]
+
+
+class TestFilterMessagesByRoles:
+    def test_default_none_returns_only_human(self):
+        """None → defaults to [USER] for backward compatibility."""
+        result = _filter_messages_by_roles(ALL_MESSAGES, None)
+        assert result == [HUMAN]
+
+    def test_empty_list_returns_only_human(self):
+        """Empty list → same default as None."""
+        result = _filter_messages_by_roles(ALL_MESSAGES, [])
+        assert result == [HUMAN]
+
+    def test_user_only(self):
+        result = _filter_messages_by_roles(ALL_MESSAGES, [GuardrailMessageRole.USER])
+        assert result == [HUMAN]
+
+    def test_system_only(self):
+        result = _filter_messages_by_roles(ALL_MESSAGES, [GuardrailMessageRole.SYSTEM])
+        assert result == [SYSTEM]
+
+    def test_tool_only(self):
+        result = _filter_messages_by_roles(ALL_MESSAGES, [GuardrailMessageRole.TOOL])
+        assert result == [TOOL]
+
+    def test_assistant_only(self):
+        result = _filter_messages_by_roles(ALL_MESSAGES, [GuardrailMessageRole.ASSISTANT])
+        assert result == [AI]
+
+    def test_user_and_tool(self):
+        result = _filter_messages_by_roles(
+            ALL_MESSAGES, [GuardrailMessageRole.USER, GuardrailMessageRole.TOOL]
+        )
+        assert result == [HUMAN, TOOL]
+
+    def test_all_roles(self):
+        result = _filter_messages_by_roles(
+            ALL_MESSAGES,
+            [
+                GuardrailMessageRole.USER,
+                GuardrailMessageRole.SYSTEM,
+                GuardrailMessageRole.TOOL,
+                GuardrailMessageRole.ASSISTANT,
+            ],
+        )
+        assert result == ALL_MESSAGES
+
+    def test_empty_messages_returns_empty(self):
+        result = _filter_messages_by_roles([], [GuardrailMessageRole.USER])
+        assert result == []
+
+    def test_no_matching_messages_returns_empty(self):
+        """If none of the messages match the requested roles, return []."""
+        result = _filter_messages_by_roles([SYSTEM, AI], [GuardrailMessageRole.USER])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# apply_guardrails integration tests (using _check_contains internally)
+# ---------------------------------------------------------------------------
+
+
+def _make_guardrail(
+    message_roles: list[GuardrailMessageRole] | None,
+    values: list[str],
+    behavior: GuardrailBehaviorType = GuardrailBehaviorType.BLOCK,
+) -> Guardrail:
+    return Guardrail(
+        name='test_guardrail',
+        type=GuardrailType.CONTAINS,
+        where=GuardrailWhereType.INPUT,
+        behavior=behavior,
+        message_roles=message_roles,
+        parameters=CheckParameter(type='CHECK', values=values),
+    )
+
+
+def _make_route_config(guardrail_name: str = 'test_guardrail'):
+    config = MagicMock()
+    config.guardrails = [guardrail_name]
+    config.route_name = 'test_route'
+    return config
+
+
+def _make_check_engine(guardrail: Guardrail) -> GuardrailCheck:
+    return GuardrailCheck(
+        presidio_engine=MagicMock(),
+        judge_engine=MagicMock(),
+        cost_service=MagicMock(),
+        guardrails_by_name={'test_guardrail': guardrail},
+    )
+
+
+COMMON_KWARGS = {
+    'request_uuid': 'req-1',
+    'api_key_uuid': 'key-1',
+    'group_uuid': 'grp-1',
+    'api_key_name': 'api',
+    'group_name': 'grp',
+    'project_uuid': 'proj-1',
+    'project_name': 'proj',
+}
+
+
+class TestApplyGuardrailsRoleFiltering:
+    """apply_guardrails must respect message_roles."""
+
+    @pytest.mark.asyncio
+    async def test_user_role_triggers_on_human_message(self):
+        """BLOCK guardrail with role=user raises when keyword is in user message."""
+        guardrail = _make_guardrail([GuardrailMessageRole.USER], [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [HumanMessage(content=f'Test {BLOCKED_KEYWORD} optics')]
+        with pytest.raises(GuardrailBadRequest):
+            await engine.apply_guardrails(
+                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                **COMMON_KWARGS,
+            )
+
+    @pytest.mark.asyncio
+    async def test_user_role_does_not_trigger_on_tool_message(self):
+        """Keyword only in tool message, guardrail scoped to user → must NOT trigger."""
+        guardrail = _make_guardrail([GuardrailMessageRole.USER], [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [
+            HumanMessage(content=SAFE_CONTENT),
+            ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
+        ]
+        result = await engine.apply_guardrails(
+            route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+            **COMMON_KWARGS,
+        )
+        assert result is None  # not triggered
+
+    @pytest.mark.asyncio
+    async def test_tool_role_triggers_on_tool_message(self):
+        """BLOCK guardrail with role=tool raises when keyword is in tool message."""
+        guardrail = _make_guardrail([GuardrailMessageRole.TOOL], [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [
+            HumanMessage(content=SAFE_CONTENT),
+            ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
+        ]
+        with pytest.raises(GuardrailBadRequest):
+            await engine.apply_guardrails(
+                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                **COMMON_KWARGS,
+            )
+
+    @pytest.mark.asyncio
+    async def test_tool_role_does_not_trigger_on_human_message(self):
+        """Keyword only in user message, guardrail scoped to tool → must NOT trigger."""
+        guardrail = _make_guardrail([GuardrailMessageRole.TOOL], [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [
+            HumanMessage(content=f'user says {BLOCKED_KEYWORD}'),
+            ToolMessage(content=SAFE_CONTENT, tool_call_id='c1'),
+        ]
+        result = await engine.apply_guardrails(
+            route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+            **COMMON_KWARGS,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_system_role_triggers_on_system_message(self):
+        """BLOCK guardrail with role=system raises when keyword is in system message."""
+        guardrail = _make_guardrail([GuardrailMessageRole.SYSTEM], [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [
+            SystemMessage(content=f'System prompt contains {BLOCKED_KEYWORD}'),
+            HumanMessage(content=SAFE_CONTENT),
+        ]
+        with pytest.raises(GuardrailBadRequest):
+            await engine.apply_guardrails(
+                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                **COMMON_KWARGS,
+            )
+
+    @pytest.mark.asyncio
+    async def test_multi_role_user_and_tool(self):
+        """BLOCK guardrail with roles=[user,tool] raises when keyword is in tool message."""
+        guardrail = _make_guardrail(
+            [GuardrailMessageRole.USER, GuardrailMessageRole.TOOL], [BLOCKED_KEYWORD]
+        )
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [
+            HumanMessage(content=SAFE_CONTENT),
+            ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
+        ]
+        with pytest.raises(GuardrailBadRequest):
+            await engine.apply_guardrails(
+                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                **COMMON_KWARGS,
+            )
+
+    @pytest.mark.asyncio
+    async def test_default_none_only_scans_user(self):
+        """Default (None) must only scan user messages — backward compat."""
+        guardrail = _make_guardrail(None, [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        # keyword in tool but NOT in user → must not trigger
+        messages = [
+            HumanMessage(content=SAFE_CONTENT),
+            ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
+        ]
+        result = await engine.apply_guardrails(
+            route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+            **COMMON_KWARGS,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_default_none_triggers_on_user_message(self):
+        """Default (None) triggers when keyword IS in user message."""
+        guardrail = _make_guardrail(None, [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [HumanMessage(content=f'user says {BLOCKED_KEYWORD}')]
+        with pytest.raises(GuardrailBadRequest):
+            await engine.apply_guardrails(
+                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                **COMMON_KWARGS,
+            )

--- a/gateway/tests/guardrails/test_message_role_scope.py
+++ b/gateway/tests/guardrails/test_message_role_scope.py
@@ -40,15 +40,15 @@ ALL_MESSAGES = [HUMAN, SYSTEM, TOOL, AI]
 
 
 class TestFilterMessagesByRoles:
-    def test_default_none_returns_only_human(self):
-        """None → defaults to [USER] for backward compatibility."""
+    def test_default_none_returns_all_messages(self):
+        """None (not configured) → no filtering, all messages returned."""
         result = _filter_messages_by_roles(ALL_MESSAGES, None)
-        assert result == [HUMAN]
+        assert result == ALL_MESSAGES
 
-    def test_empty_list_returns_only_human(self):
-        """Empty list → same default as None."""
+    def test_empty_list_returns_nothing(self):
+        """Explicit empty list → nothing passes through."""
         result = _filter_messages_by_roles(ALL_MESSAGES, [])
-        assert result == [HUMAN]
+        assert result == []
 
     def test_user_only(self):
         result = _filter_messages_by_roles(ALL_MESSAGES, [GuardrailMessageRole.USER])
@@ -254,27 +254,27 @@ class TestApplyGuardrailsRoleFiltering:
             )
 
     @pytest.mark.asyncio
-    async def test_default_none_only_scans_user(self):
-        """Default (None) must only scan user messages — backward compat."""
+    async def test_default_none_scans_all_messages(self):
+        """Default (None) scans all message types — original gateway behavior."""
         guardrail = _make_guardrail(None, [BLOCKED_KEYWORD])
         engine = _make_check_engine(guardrail)
         route = _make_route_config()
-        # keyword in tool but NOT in user → must not trigger
+        # keyword in tool message → MUST trigger because None = no filtering
         messages = [
             HumanMessage(content=SAFE_CONTENT),
             ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
         ]
-        result = await engine.apply_guardrails(
-            route_config=route,
-            messages=messages,
-            where=GuardrailWhereType.INPUT,
-            **COMMON_KWARGS,
-        )
-        assert result is None
+        with pytest.raises(GuardrailBadRequest):
+            await engine.apply_guardrails(
+                route_config=route,
+                messages=messages,
+                where=GuardrailWhereType.INPUT,
+                **COMMON_KWARGS,
+            )
 
     @pytest.mark.asyncio
     async def test_default_none_triggers_on_user_message(self):
-        """Default (None) triggers when keyword IS in user message."""
+        """Default (None) also triggers when keyword is in user message."""
         guardrail = _make_guardrail(None, [BLOCKED_KEYWORD])
         engine = _make_check_engine(guardrail)
         route = _make_route_config()
@@ -286,3 +286,21 @@ class TestApplyGuardrailsRoleFiltering:
                 where=GuardrailWhereType.INPUT,
                 **COMMON_KWARGS,
             )
+
+    @pytest.mark.asyncio
+    async def test_explicit_user_only_does_not_scan_tool(self):
+        """Explicit [USER] scope: keyword in tool message → must NOT trigger."""
+        guardrail = _make_guardrail([GuardrailMessageRole.USER], [BLOCKED_KEYWORD])
+        engine = _make_check_engine(guardrail)
+        route = _make_route_config()
+        messages = [
+            HumanMessage(content=SAFE_CONTENT),
+            ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
+        ]
+        result = await engine.apply_guardrails(
+            route_config=route,
+            messages=messages,
+            where=GuardrailWhereType.INPUT,
+            **COMMON_KWARGS,
+        )
+        assert result is None

--- a/gateway/tests/guardrails/test_message_role_scope.py
+++ b/gateway/tests/guardrails/test_message_role_scope.py
@@ -4,6 +4,7 @@ Verifies that _filter_messages_by_roles correctly filters messages by LangChain
 type, and that apply_guardrails / evaluate_warn_triggered respect the
 message_roles configuration field.
 """
+
 from unittest.mock import MagicMock
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -62,7 +63,9 @@ class TestFilterMessagesByRoles:
         assert result == [TOOL]
 
     def test_assistant_only(self):
-        result = _filter_messages_by_roles(ALL_MESSAGES, [GuardrailMessageRole.ASSISTANT])
+        result = _filter_messages_by_roles(
+            ALL_MESSAGES, [GuardrailMessageRole.ASSISTANT]
+        )
         assert result == [AI]
 
     def test_user_and_tool(self):
@@ -152,7 +155,9 @@ class TestApplyGuardrailsRoleFiltering:
         messages = [HumanMessage(content=f'Test {BLOCKED_KEYWORD} optics')]
         with pytest.raises(GuardrailBadRequest):
             await engine.apply_guardrails(
-                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                route_config=route,
+                messages=messages,
+                where=GuardrailWhereType.INPUT,
                 **COMMON_KWARGS,
             )
 
@@ -167,7 +172,9 @@ class TestApplyGuardrailsRoleFiltering:
             ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
         ]
         result = await engine.apply_guardrails(
-            route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+            route_config=route,
+            messages=messages,
+            where=GuardrailWhereType.INPUT,
             **COMMON_KWARGS,
         )
         assert result is None  # not triggered
@@ -184,7 +191,9 @@ class TestApplyGuardrailsRoleFiltering:
         ]
         with pytest.raises(GuardrailBadRequest):
             await engine.apply_guardrails(
-                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                route_config=route,
+                messages=messages,
+                where=GuardrailWhereType.INPUT,
                 **COMMON_KWARGS,
             )
 
@@ -199,7 +208,9 @@ class TestApplyGuardrailsRoleFiltering:
             ToolMessage(content=SAFE_CONTENT, tool_call_id='c1'),
         ]
         result = await engine.apply_guardrails(
-            route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+            route_config=route,
+            messages=messages,
+            where=GuardrailWhereType.INPUT,
             **COMMON_KWARGS,
         )
         assert result is None
@@ -216,7 +227,9 @@ class TestApplyGuardrailsRoleFiltering:
         ]
         with pytest.raises(GuardrailBadRequest):
             await engine.apply_guardrails(
-                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                route_config=route,
+                messages=messages,
+                where=GuardrailWhereType.INPUT,
                 **COMMON_KWARGS,
             )
 
@@ -234,7 +247,9 @@ class TestApplyGuardrailsRoleFiltering:
         ]
         with pytest.raises(GuardrailBadRequest):
             await engine.apply_guardrails(
-                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                route_config=route,
+                messages=messages,
+                where=GuardrailWhereType.INPUT,
                 **COMMON_KWARGS,
             )
 
@@ -250,7 +265,9 @@ class TestApplyGuardrailsRoleFiltering:
             ToolMessage(content=f'tool says {BLOCKED_KEYWORD}', tool_call_id='c1'),
         ]
         result = await engine.apply_guardrails(
-            route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+            route_config=route,
+            messages=messages,
+            where=GuardrailWhereType.INPUT,
             **COMMON_KWARGS,
         )
         assert result is None
@@ -264,6 +281,8 @@ class TestApplyGuardrailsRoleFiltering:
         messages = [HumanMessage(content=f'user says {BLOCKED_KEYWORD}')]
         with pytest.raises(GuardrailBadRequest):
             await engine.apply_guardrails(
-                route_config=route, messages=messages, where=GuardrailWhereType.INPUT,
+                route_config=route,
+                messages=messages,
+                where=GuardrailWhereType.INPUT,
                 **COMMON_KWARGS,
             )


### PR DESCRIPTION
## Summary
Adds a new optional field message_roles to Guardrail, allowing each guardrail to be scoped to one or more message roles: user, system, tool, assistant. The role 'function' is intentionally excluded as it is deprecated by OpenAI.

- models/guardrails.py: new GuardrailMessageRole enum (USER, SYSTEM, TOOL, ASSISTANT) and message_roles field with field_validator for uppercase normalisation. Default None → backward-compatible [user]-only scanning.
- guardrails/guardrail_check.py: _ROLE_TO_TYPE mapping, _filter_messages_by_roles() helper; apply_guardrails() and evaluate_warn_triggered() now filter messages per guardrail before dispatching to check functions.
- guardrails/guardrail_redact.py: same role-based filtering with index-aware reintegration so non-filtered messages stay in their original positions.
- tests/guardrails/test_message_role_scope.py: 18 new unit tests covering _filter_messages_by_roles and apply_guardrails role scoping, including backward-compat default and cross-role negative cases.


## Type of Change
- [ ] Bug fix
- [X] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
