### PR TITLE
feat(ui): config import/export and Configurations page

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@radicalbit/formbit": "2.1.0",
-    "@radicalbit/radicalbit-design-system": "2.16.0",
+    "@radicalbit/radicalbit-design-system": "2.18.2",
     "@reduxjs/toolkit": "^2.8.2",
     "@vitejs/plugin-react": "^4.2.1",
     "ace-builds": "^1.33.2",

--- a/ui/src/api/utils.js
+++ b/ui/src/api/utils.js
@@ -1,7 +1,29 @@
 import axios from 'axios';
 import { API_BASE_URL } from './config';
 
-export const customBaseQuery = () => async ({ baseUrl, url, method, data, headers = {} }) => {
+const DEFAULT_DOWNLOAD_FILENAME = 'download.zip';
+
+const parseFilenameFromContentDisposition = (contentDisposition) => {
+  if (!contentDisposition) {
+    return DEFAULT_DOWNLOAD_FILENAME;
+  }
+
+  const utf8Match = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    return decodeURIComponent(utf8Match[1]);
+  }
+
+  const asciiMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+  if (asciiMatch?.[1]) {
+    return asciiMatch[1];
+  }
+
+  return DEFAULT_DOWNLOAD_FILENAME;
+};
+
+export const customBaseQuery = () => async ({
+  baseUrl, url, method, data, headers = {}, responseType,
+}) => {
   const resolvedBaseUrl = baseUrl !== undefined ? baseUrl : API_BASE_URL;
 
   try {
@@ -10,8 +32,14 @@ export const customBaseQuery = () => async ({ baseUrl, url, method, data, header
       method,
       data,
       headers,
+      responseType,
       withCredentials: true,
     });
+
+    if (responseType === 'blob') {
+      const filename = parseFilenameFromContentDisposition(result.headers['content-disposition']);
+      return { data: { blob: result.data, filename } };
+    }
 
     if (result.headers['x-total-count'] !== undefined) {
       return {

--- a/ui/src/components/modals/edit-project-config/code-editor/header.jsx
+++ b/ui/src/components/modals/edit-project-config/code-editor/header.jsx
@@ -33,7 +33,7 @@ function HeaderSlot({ active, config, onSelectConfig }) {
       <Board
         main={(
           <NewHeader
-            details={{ one: <ConfigStatusTag configStatus={config.configStatus} /> }}
+            details={{ one: <ConfigStatusTag config={config} /> }}
             title={<SectionTitle size="small" title={`Slot ${config.slot}`} />}
           />
         )}

--- a/ui/src/components/modals/edit-project-config/index.jsx
+++ b/ui/src/components/modals/edit-project-config/index.jsx
@@ -1,16 +1,40 @@
 import SomethingWentWrong from '@Components/error-page/something-went-wrong';
+import { notificationErrorJson } from '@Helpers/notificationUtils';
 import useModals from '@Hooks/use-modals';
-import { useGetProjectQuery } from '@State/projects/api';
-import { faArrowLeft, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { actions as notificationActions } from '@State/notification';
+import { useGetProjectQuery, useImportConfigMutation, useLazyExportAllConfigsQuery, useLazyExportConfigQuery } from '@State/projects/api';
+import { faArrowLeft, faFileExport, faFileImport, faFolderOpen } from '@fortawesome/free-solid-svg-icons';
 import { FormbitContextProvider, useFormbitContext } from '@radicalbit/formbit';
 import {
+  Button,
+  Dropdown,
   FontAwesomeIcon,
   NewHeader, RbitModal, SectionTitle, Skeleton,
+  Upload,
 } from '@radicalbit/radicalbit-design-system';
 import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import Chatbot from './chatbot';
 import CodeEditor from './code-editor';
 import { schema } from './schema';
+import useGetActiveConfig from './useGetActiveConfig';
+
+const ACCEPTED_IMPORT_EXTENSIONS = '.yaml,.yml';
+const PREVENT_AUTO_UPLOAD = Upload.LIST_IGNORE ?? false;
+
+const hasYamlExtension = (name = '') => /\.(yaml|yml)$/i.test(name);
+
+const triggerBrowserDownload = ({ blob, filename }) => {
+  const objectUrl = window.URL.createObjectURL(blob);
+  const anchor = window.document.createElement('a');
+
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  window.document.body.appendChild(anchor);
+  anchor.click();
+  window.document.body.removeChild(anchor);
+  window.URL.revokeObjectURL(objectUrl);
+};
 
 function EditProjectConfig() {
   return (
@@ -56,9 +80,126 @@ function Header() {
 
   return (
     <NewHeader
+      details={
+        {
+          one: <ImportButton />,
+          two: <ExportButton />,
+        }
+      }
       prefix={<FontAwesomeIcon icon={faArrowLeft} onClick={hideModal} />}
       title={<SectionTitle subtitle={subtitle} title={title} titlePrefix={<FontAwesomeIcon icon={faFolderOpen} />} />}
     />
+  );
+}
+
+function ImportButton() {
+  const dispatch = useDispatch();
+  const { modalPayload } = useModals();
+  const uuid = modalPayload?.data?.uuid;
+
+  const { activeConfig } = useGetActiveConfig();
+  const configUuid = activeConfig?.uuid;
+
+  const [trigger, { isLoading }] = useImportConfigMutation({ fixedCacheKey: `import-config-${uuid}` });
+
+  const notifyError = (content) => {
+    dispatch(notificationActions.setNotificationMessage(notificationErrorJson({ message: content })));
+  };
+
+  const handleBeforeUpload = (file) => {
+    if (!hasYamlExtension(file.name)) {
+      notifyError('Only YAML files (.yaml, .yml) are allowed.');
+      return PREVENT_AUTO_UPLOAD;
+    }
+
+    if (file.size === 0) {
+      notifyError('The selected file is empty.');
+      return PREVENT_AUTO_UPLOAD;
+    }
+
+    const data = new FormData();
+    data.append('file', file);
+
+    trigger({
+      projectUuid: uuid,
+      configUuid,
+      data,
+      successMessage: `Import ${file.name} file success`,
+    });
+
+    return PREVENT_AUTO_UPLOAD;
+  };
+
+  return (
+    <Upload
+      accept={ACCEPTED_IMPORT_EXTENSIONS}
+      beforeUpload={handleBeforeUpload}
+      disabled={isLoading}
+      showUploadList={false}
+    >
+      <Button disabled={isLoading} icon={<FontAwesomeIcon icon={faFileImport} />} loading={isLoading} onClick={() => {}}>
+        Import
+      </Button>
+    </Upload>
+  );
+}
+
+function ExportButton() {
+  const { modalPayload } = useModals();
+  const uuid = modalPayload?.data?.uuid;
+
+  const { activeConfig } = useGetActiveConfig();
+  const configUuid = activeConfig?.uuid;
+  const slot = activeConfig?.slot;
+
+  const [triggerExportAll, { isLoading: isLoadingAll }] = useLazyExportAllConfigsQuery();
+  const [triggerExport, { isLoading }] = useLazyExportConfigQuery();
+
+  const isExporting = isLoading || isLoadingAll;
+
+  const handleOnExportCurrent = async () => {
+    if (isExporting || !configUuid) {
+      return;
+    }
+
+    const result = await triggerExport({ projectUuid: uuid, configUuid });
+
+    if (result.data) {
+      triggerBrowserDownload(result.data);
+    }
+  };
+
+  const handleOnExportAll = async () => {
+    if (isExporting) {
+      return;
+    }
+
+    const result = await triggerExportAll({ projectUuid: uuid });
+
+    if (result.data) {
+      triggerBrowserDownload(result.data);
+    }
+  };
+
+  const items = [
+    {
+      key: 'export-current',
+      label: `Export Slot ${slot}`,
+      onClick: handleOnExportCurrent,
+    },
+    {
+      key: 'export-all',
+      label: 'Export all slots',
+      onClick: handleOnExportAll,
+    },
+  ];
+
+  return (
+    <Dropdown menu={{ items }} trigger={['hover']}>
+      <Button icon={<FontAwesomeIcon icon={faFileExport} />} loading={isExporting}>
+        Export
+      </Button>
+    </Dropdown>
   );
 }
 

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -13,6 +13,7 @@ const ModalsEnum = {
 
 const PathsEnum = {
   CONFIG: 'config',
+  CONFIGURATIONS: 'configs',
   COSTS: 'costs',
   GROUPS: 'groups',
   CREDENTIALS: 'credentials',
@@ -27,6 +28,7 @@ const SEARCH_PARAMS = {
   groups: 'searchGroup',
   credentials: 'searchCredential',
   projects: 'searchProject',
+  configurations: 'searchConfiguration',
 };
 
 const SortOrderEnum = {
@@ -76,9 +78,24 @@ const DATE_FORMAT = ' DD MMM YYYY, HH:mm:ss';
 const DATE_FORMAT_SHORT = ' DD MMM YYYY';
 
 const ConfigStatusEnum = {
+  EMPTY: 'EMPTY',
   DRAFT: 'DRAFT',
   READY_TO_SERVE: 'READY_TO_SERVE',
   SERVED: 'SERVED',
+};
+
+const ConfigListFilterEnum = {
+  ALL: 'all',
+  PUBLISHED: 'published',
+  REQUEST_TO_PUBLISH: 'request_to_publish',
+  DRAFT: 'draft',
+};
+
+const CONFIG_LIST_FILTER_LABELS = {
+  [ConfigListFilterEnum.ALL]: 'All',
+  [ConfigListFilterEnum.PUBLISHED]: 'Published',
+  [ConfigListFilterEnum.REQUEST_TO_PUBLISH]: 'Request to Publish',
+  [ConfigListFilterEnum.DRAFT]: 'Draft',
 };
 
 const SlotEnum = {
@@ -92,6 +109,8 @@ const ProjectStatusEnum = {
 };
 
 export {
+  ConfigListFilterEnum,
+  CONFIG_LIST_FILTER_LABELS,
   ConfigStatusEnum,
   CHART_COLORS,
   DATE_FORMAT,

--- a/ui/src/container/app/header-content-switch.jsx
+++ b/ui/src/container/app/header-content-switch.jsx
@@ -1,3 +1,4 @@
+import ConfigurationsListHeader from '@Container/pages/configurations/list/header';
 import GroupsListHeader from '@Container/pages/groups/list/header/';
 import KeysListHeader from '@Container/pages/keys/list/header';
 import ProjectsListHeader from '@Container/pages/projects/list/header';
@@ -32,6 +33,8 @@ export default function MainHeaderContentSwitch() {
       <Route element={<UsageListHeader />} path={`/${PathsEnum.USAGE}`} />
 
       <Route element={<ProjectsListHeader />} path={`/${PathsEnum.PROJECTS}`} />
+
+      <Route element={<ConfigurationsListHeader />} path={`/${PathsEnum.CONFIGURATIONS}`} />
     </Routes>
   );
 }

--- a/ui/src/container/app/main-content-switch.jsx
+++ b/ui/src/container/app/main-content-switch.jsx
@@ -1,3 +1,4 @@
+import ConfigurationsList from '@Container/pages/configurations/list/body';
 import GroupsList from '@Container/pages/groups/list/body';
 import KeysList from '@Container/pages/keys/list/body';
 import ProjectsList from '@Container/pages/projects/list/body';
@@ -55,6 +56,11 @@ export default function MainHeaderContentSwitch() {
       <Route
         element={<ProjectsList />}
         path={`/${PathsEnum.PROJECTS}`}
+      />
+
+      <Route
+        element={<ConfigurationsList />}
+        path={`/${PathsEnum.CONFIGURATIONS}`}
       />
 
       <Route

--- a/ui/src/container/layout/index.jsx
+++ b/ui/src/container/layout/index.jsx
@@ -1,6 +1,6 @@
 import { PathsEnum } from '@Src/constants';
 import {
-  faChartBar, faFolderOpen, faKey, faLayerGroup, faMicrochip, faRoute,
+  faChartBar, faFolderOpen, faKey, faLayerGroup, faMicrochip, faRoute, faSliders,
 } from '@fortawesome/free-solid-svg-icons';
 import { Button, FontAwesomeIcon } from '@radicalbit/radicalbit-design-system';
 import { Link } from 'react-router-dom';
@@ -48,8 +48,8 @@ const groupHeader = (key, label, position, hasLeftColumnCollapsed) => {
 };
 
 const setupHeader = (hasLeftColumnCollapsed) => groupHeader('setup-header', 'Setup', 1, hasLeftColumnCollapsed);
-const monitorHeader = (hasLeftColumnCollapsed) => groupHeader('monitor-header', 'Monitor', 4, hasLeftColumnCollapsed);
-const manageHeader = (hasLeftColumnCollapsed) => groupHeader('manage-header', 'Manage', 9, hasLeftColumnCollapsed);
+const monitorHeader = (hasLeftColumnCollapsed) => groupHeader('monitor-header', 'Monitor', 5, hasLeftColumnCollapsed);
+const manageHeader = (hasLeftColumnCollapsed) => groupHeader('manage-header', 'Manage', 10, hasLeftColumnCollapsed);
 
 // GROUPS SEPARATOR
 const separator = (key, position) => ({
@@ -57,8 +57,8 @@ const separator = (key, position) => ({
   key,
   className: 'c-menu-item--separator pointer-events-none !h-[1rem]',
 });
-const separator1 = separator('separator1', 3);
-const separator2 = separator('separator2', 8);
+const separator1 = separator('separator1', 4);
+const separator2 = separator('separator2', 9);
 
 // GROUPS ITEMS
 const projects = (hasLeftColumnCollapsed) => ({
@@ -69,8 +69,16 @@ const projects = (hasLeftColumnCollapsed) => ({
   link: getLink(PathsEnum.PROJECTS),
 });
 
+const configurations = (hasLeftColumnCollapsed) => ({
+  position: 3,
+  title: hasLeftColumnCollapsed ? <CollapsedTitle>Configurations</CollapsedTitle> : 'Configurations',
+  icon: <FontAwesomeIcon icon={faSliders} />,
+  key: PathsEnum.CONFIGURATIONS,
+  link: getLink(PathsEnum.CONFIGURATIONS),
+});
+
 const routes = (hasLeftColumnCollapsed) => ({
-  position: 5,
+  position: 6,
   title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '2', shape: 'circle' }] }}>Routes</CollapsedTitle> : 'Routes',
   icon: <FontAwesomeIcon icon={faMicrochip} />,
   key: PathsEnum.ROUTES,
@@ -78,7 +86,7 @@ const routes = (hasLeftColumnCollapsed) => ({
 });
 
 const usage = (hasLeftColumnCollapsed) => ({
-  position: 6,
+  position: 7,
   title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '3', shape: 'circle' }] }}>Usage</CollapsedTitle> : 'Usage',
   icon: <FontAwesomeIcon icon={faChartBar} />,
   key: PathsEnum.USAGE,
@@ -86,7 +94,7 @@ const usage = (hasLeftColumnCollapsed) => ({
 });
 
 const tracing = (hasLeftColumnCollapsed) => ({
-  position: 7,
+  position: 8,
   title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '4', shape: 'circle' }] }}>Tracing</CollapsedTitle> : 'Tracing',
   icon: <FontAwesomeIcon icon={faRoute} />,
   key: PathsEnum.TRACING,
@@ -94,7 +102,7 @@ const tracing = (hasLeftColumnCollapsed) => ({
 });
 
 const groups = (hasLeftColumnCollapsed) => ({
-  position: 10,
+  position: 11,
   title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '5', shape: 'circle' }] }}>Groups</CollapsedTitle> : 'Groups',
   icon: <FontAwesomeIcon icon={faLayerGroup} />,
   key: PathsEnum.GROUPS,
@@ -102,7 +110,7 @@ const groups = (hasLeftColumnCollapsed) => ({
 });
 
 const keys = (hasLeftColumnCollapsed) => ({
-  position: 11,
+  position: 12,
   title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '6', shape: 'circle' }] }}>Credentials</CollapsedTitle> : 'Credentials',
   icon: <FontAwesomeIcon icon={faKey} />,
   key: PathsEnum.CREDENTIALS,
@@ -113,6 +121,7 @@ const keys = (hasLeftColumnCollapsed) => ({
 const allRoutes = (hasLeftColumnCollapsed) => [
   setupHeader(hasLeftColumnCollapsed),
   projects(hasLeftColumnCollapsed),
+  configurations(hasLeftColumnCollapsed),
 
   separator1,
   monitorHeader(hasLeftColumnCollapsed),

--- a/ui/src/container/pages/configurations/list/body/columns.jsx
+++ b/ui/src/container/pages/configurations/list/body/columns.jsx
@@ -1,0 +1,99 @@
+import ConfigStatusTag from '@Container/pages/projects/components/config-status-tag';
+import { DATE_FORMAT, DATE_FORMAT_SHORT } from '@Src/constants';
+import {
+  DataTableAction,
+  RelativeDateTime,
+  SectionTitle,
+  Truncate,
+} from '@radicalbit/radicalbit-design-system';
+import SlotActions from './slot-actions';
+
+const getColumns = () => [
+  {
+    title: '',
+    dataIndex: 'margin-left',
+    key: 'margin-left',
+    width: '10px',
+  },
+
+  {
+    title: 'Projects',
+    dataIndex: 'name',
+    key: 'name',
+    render: (value, { description }) => (
+      <SectionTitle
+        size="small"
+        subtitle={(
+          <Truncate tooltip={{ title: description, placement: 'topLeft' }}>
+            {description || '--'}
+          </Truncate>
+        )}
+        title={(
+          <Truncate tooltip={{ title: value, placement: 'topLeft' }}>
+            {value}
+          </Truncate>
+        )}
+      />
+    ),
+  },
+
+  {
+    title: 'Last Update',
+    dataIndex: 'updatedAt',
+    key: 'updatedAt',
+    align: 'left',
+    render: (date) => <RelativeDateTime format={DATE_FORMAT_SHORT} formatTooltip={DATE_FORMAT} timestamp={date} withTooltip />,
+  },
+
+  {
+    title: 'Created',
+    dataIndex: 'createdAt',
+    key: 'createdAt',
+    align: 'left',
+    render: (date) => <RelativeDateTime format={DATE_FORMAT_SHORT} formatTooltip={DATE_FORMAT} timestamp={date} withTooltip />,
+  },
+
+  {
+    title: 'Configurations',
+    dataIndex: 'configs',
+    key: 'configs',
+    render: (configs = []) => (
+      <div className="flex flex-col gap-2">
+        {configs.map((config) => (
+          <div key={config.uuid} className="flex items-center gap-4 h-8">
+            <span>{`Slot ${config.slot}`}</span>
+
+            <ConfigStatusTag config={config} />
+          </div>
+        ))}
+      </div>
+    ),
+  },
+
+  {
+    title: '',
+    dataIndex: 'configs',
+    key: 'actions',
+    width: '80px',
+    render: (configs, { uuid, name }) => (
+      <DataTableAction noHide>
+        <div className="flex flex-col gap-2">
+          {(configs ?? []).map((config) => (
+            <div key={config.uuid} className="flex items-center justify-end h-8">
+              <SlotActions config={config} projectName={name} projectUuid={uuid} />
+            </div>
+          ))}
+        </div>
+      </DataTableAction>
+    ),
+  },
+
+  {
+    title: '',
+    dataIndex: 'margin-right',
+    key: 'margin-right',
+    width: '10px',
+  },
+];
+
+export default getColumns;

--- a/ui/src/container/pages/configurations/list/body/index.jsx
+++ b/ui/src/container/pages/configurations/list/body/index.jsx
@@ -1,0 +1,136 @@
+import SomethingWentWrong from '@Components/error-page/something-went-wrong';
+import { WIDE_MAIN_LAYOUT_CONFIGURATION } from '@Container/layout/layout-provider/layout-provider-configuration';
+import useModals, { modals } from '@Hooks/use-modals';
+import { ConfigListFilterEnum, SEARCH_PARAMS } from '@Src/constants';
+import { useGetAllConfigurationsQuery } from '@State/projects/api';
+import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import {
+  Board,
+  DataTable,
+  FontAwesomeIcon,
+  Search,
+  Void,
+} from '@radicalbit/radicalbit-design-system';
+import { useEffect, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import { useSearchParams } from 'react-router-dom';
+import getColumns from './columns';
+import StatusTabs, { STATUS_QP } from './status-tabs';
+
+function ConfigurationsList() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchValue = searchParams.get(SEARCH_PARAMS.configurations) || '';
+
+  const handleSearchChange = (e) => {
+    const { value } = e.target;
+    setSearchParams((prev) => {
+      if (value) {
+        prev.set(SEARCH_PARAMS.configurations, value);
+      } else {
+        prev.delete(SEARCH_PARAMS.configurations);
+      }
+      return prev;
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      <div className="flex flex-row items-center gap-4">
+        <Search
+          allowClear={{ clearIcon: <FontAwesomeIcon icon={faCircleXmark} /> }}
+          onChange={handleSearchChange}
+          placeholder="Search by project name"
+          style={{ width: '300px' }}
+          value={searchValue}
+        />
+
+        <StatusTabs />
+      </div>
+
+      <ConfigurationsTable searchValue={searchValue} />
+    </div>
+  );
+}
+
+function ConfigurationsTable({ searchValue }) {
+  useInitLayoutConfigurations();
+
+  const [searchParams] = useSearchParams();
+  const status = searchParams.get(STATUS_QP) || ConfigListFilterEnum.ALL;
+
+  const { data = [], isError, isLoading, isSuccess } = useGetAllConfigurationsQuery({ status });
+
+  if (isLoading) {
+    return <DataTable loading />;
+  }
+
+  if (isError) {
+    return <Board main={<SomethingWentWrong size="small" />} />;
+  }
+
+  if (!data?.length) {
+    return (
+      <Board
+        borderType="none"
+        main={(
+          <Void
+            description="No configurations found."
+            title="Configurations"
+          />
+        )}
+      />
+    );
+  }
+
+  if (!isSuccess) {
+    return false;
+  }
+
+  return <IsSuccess searchValue={searchValue} status={status} />;
+}
+
+function IsSuccess({ searchValue, status }) {
+  const { showModal } = useModals();
+  const { data = [] } = useGetAllConfigurationsQuery({ status });
+
+  const filteredData = searchValue
+    ? data.filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
+    : data;
+
+  const sortedData = useMemo(
+    () => [...filteredData].sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? '')),
+    [filteredData],
+  );
+
+  const columns = getColumns();
+
+  const handleOnRowClick = (record) => {
+    showModal(modals.EDIT_PROJECT_CONFIG, { uuid: record.uuid });
+  };
+
+  return (
+    <DataTable
+      clickable
+      columns={columns}
+      dataSource={sortedData}
+      onRow={(record) => ({
+        onClick: () => {
+          handleOnRowClick(record);
+        },
+      })}
+      pagination={{ hideOnSinglePage: true }}
+      rowKey={({ uuid }) => uuid}
+      scroll={{ y: 'calc(100vh - 10rem)' }}
+    />
+  );
+}
+
+const useInitLayoutConfigurations = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    WIDE_MAIN_LAYOUT_CONFIGURATION.forEach((action) => dispatch(action()));
+  }, [dispatch]);
+};
+
+export default ConfigurationsList;

--- a/ui/src/container/pages/configurations/list/body/slot-actions.jsx
+++ b/ui/src/container/pages/configurations/list/body/slot-actions.jsx
@@ -1,85 +1,57 @@
 import SuccessMessage from '@Components/success-message';
-import DeleteProject from '@Container/pages/projects/list/delete-project';
-import useGetVisibleConfig from '@Container/pages/projects/use-get-visible-config';
 import useModals, { modals } from '@Hooks/use-modals';
 import { ConfigStatusEnum } from '@Src/constants';
 import {
   useApproveConfigMutation,
   useCancelApprovalMutation,
-  useGetProjectQuery,
   useServeConfigMutation,
   useUnserveConfigMutation,
 } from '@State/projects/api';
 import {
   faCircleStop,
   faCodePullRequest,
+  faEllipsisVertical,
   faPenToSquare,
   faPlay,
   faStop,
-  faTrash,
 } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@radicalbit/radicalbit-design-system';
+import {
+  Button, Dropdown, FontAwesomeIcon,
+} from '@radicalbit/radicalbit-design-system';
 
-export const useGetThreeDotsMenuItems = (uuid) => {
-  const { data, isLoading, isError, isSuccess } = useGetProjectQuery(uuid, { skip: !uuid });
+function SlotActions({ projectUuid, projectName, config }) {
+  const items = useSlotMenuItems({ projectUuid, projectName, config });
 
-  const configs = data?.configs ?? [];
-  const visibleConfig = useGetVisibleConfig(configs);
+  const handleOnClick = (e) => {
+    e.stopPropagation();
+  };
 
-  const editConfigItem = useEditConfigItem(uuid);
-  const visibleConfigActions = useVisibleConfigItems(uuid, visibleConfig);
-  const deleteProjectItems = useDeleteProjectItems(uuid);
-
-  if (!uuid) {
-    return [];
+  if (!items.length) {
+    return false;
   }
 
-  if (isLoading || !isSuccess || isError || !data) {
-    return [];
-  }
+  return (
+    <Dropdown className="c-project-config-menu" menu={{ items }}>
+      <Button onClick={handleOnClick} type="text">
+        <FontAwesomeIcon icon={faEllipsisVertical} />
+      </Button>
+    </Dropdown>
+  );
+}
 
-  const configurationGroupItems = [editConfigItem, ...visibleConfigActions].filter(Boolean);
-
-  const configurationGroup = configurationGroupItems.length
-    ? {
-      key: 'configuration-group',
-      type: 'group',
-      label: 'Configuration',
-      children: configurationGroupItems,
-    }
-    : false;
-
-  return [
-    configurationGroup,
-    ...deleteProjectItems,
-  ].filter(Boolean);
-};
-
-const useEditConfigItem = (uuid) => {
+const useSlotMenuItems = ({ projectUuid, projectName, config }) => {
   const { showModal } = useModals();
 
-  const handleOnClick = () => {
-    showModal(modals.EDIT_PROJECT_CONFIG, { uuid });
-  };
-
-  return {
-    key: 'edit-configuration',
-    icon: <FontAwesomeIcon icon={faPenToSquare} />,
-    label: 'Edit Configuration',
-    onClick: handleOnClick,
-  };
-};
-
-const useVisibleConfigItems = (uuid, config) => {
-  const { data: project } = useGetProjectQuery(uuid, { skip: !uuid });
-
   const configUuid = config?.uuid;
-  const projectName = project?.name ?? '';
 
   const [triggerApprove, approveArgs] = useApproveConfigMutation({ fixedCacheKey: `approve-config-${configUuid}` });
   const [triggerCancel, cancelArgs] = useCancelApprovalMutation({ fixedCacheKey: `cancel-approval-${configUuid}` });
   const [triggerServe, serveArgs] = useServeConfigMutation({ fixedCacheKey: `serve-config-${configUuid}` });
   const [triggerUnserve, unserveArgs] = useUnserveConfigMutation({ fixedCacheKey: `unserve-config-${configUuid}` });
+
+  const handleOnEdit = () => {
+    showModal(modals.EDIT_PROJECT_CONFIG, { uuid: projectUuid });
+  };
 
   const handleOnApprove = async () => {
     if (approveArgs.isLoading) {
@@ -87,7 +59,7 @@ const useVisibleConfigItems = (uuid, config) => {
     }
 
     await triggerApprove({
-      projectUuid: uuid,
+      projectUuid,
       configUuid,
       successMessage: <SuccessMessage prefix="Configuration for" strong={projectName} suffix="sent for publish" />,
     });
@@ -99,7 +71,7 @@ const useVisibleConfigItems = (uuid, config) => {
     }
 
     await triggerCancel({
-      projectUuid: uuid,
+      projectUuid,
       configUuid,
       successMessage: <SuccessMessage prefix="Publish request for" strong={projectName} suffix="cancelled" />,
     });
@@ -111,7 +83,7 @@ const useVisibleConfigItems = (uuid, config) => {
     }
 
     await triggerServe({
-      projectUuid: uuid,
+      projectUuid,
       configUuid,
       successMessage: <SuccessMessage prefix="Configuration for" strong={projectName} suffix="served" />,
     });
@@ -123,7 +95,7 @@ const useVisibleConfigItems = (uuid, config) => {
     }
 
     await triggerUnserve({
-      projectUuid: uuid,
+      projectUuid,
       configUuid,
       successMessage: <SuccessMessage prefix="Configuration for" strong={projectName} suffix="unserved" />,
     });
@@ -133,7 +105,14 @@ const useVisibleConfigItems = (uuid, config) => {
     return [];
   }
 
-  const items = [];
+  const items = [
+    {
+      key: `edit-config-${configUuid}`,
+      icon: <FontAwesomeIcon icon={faPenToSquare} />,
+      label: 'Edit Configuration',
+      onClick: handleOnEdit,
+    },
+  ];
 
   if (config.configStatus === ConfigStatusEnum.DRAFT && config.configFile) {
     items.push({
@@ -172,17 +151,4 @@ const useVisibleConfigItems = (uuid, config) => {
   return items;
 };
 
-const useDeleteProjectItems = (uuid) => [
-  { type: 'divider', key: 'configuration-divider' },
-  {
-    key: 'delete-project',
-    label: (
-      <DeleteProject uuid={uuid}>
-        <div className="is-error flex items-center gap-2">
-          <FontAwesomeIcon icon={faTrash} />
-
-          Delete project
-        </div>
-      </DeleteProject>
-    ),
-  }];
+export default SlotActions;

--- a/ui/src/container/pages/configurations/list/body/status-tabs.jsx
+++ b/ui/src/container/pages/configurations/list/body/status-tabs.jsx
@@ -1,0 +1,51 @@
+import { CONFIG_LIST_FILTER_LABELS, ConfigListFilterEnum } from '@Src/constants';
+import { Board, Button } from '@radicalbit/radicalbit-design-system';
+import { useSearchParams } from 'react-router-dom';
+
+const STATUS_QP = 'status';
+
+function StatusTabs() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeStatus = searchParams.get(STATUS_QP) || ConfigListFilterEnum.ALL;
+
+  const handleOnSelect = (status) => {
+    setSearchParams((prev) => {
+      if (status === ConfigListFilterEnum.ALL) {
+        prev.delete(STATUS_QP);
+      } else {
+        prev.set(STATUS_QP, status);
+      }
+      return prev;
+    });
+  };
+
+  return (
+    <Board
+      height="100%"
+      modifier="justify-center"
+      secondary={(
+        <div className="flex gap-2">
+          {Object.values(ConfigListFilterEnum).map((status) => {
+            const handleOnClick = () => {
+              handleOnSelect(status);
+            };
+
+            return (
+              <Button
+                key={status}
+                onClick={handleOnClick}
+                type={activeStatus === status ? 'primary' : 'text'}
+              >
+                {CONFIG_LIST_FILTER_LABELS[status]}
+              </Button>
+            );
+          })}
+        </div>
+      )}
+      size="xsmall"
+    />
+  );
+}
+
+export { STATUS_QP };
+export default StatusTabs;

--- a/ui/src/container/pages/configurations/list/header/index.jsx
+++ b/ui/src/container/pages/configurations/list/header/index.jsx
@@ -1,0 +1,18 @@
+import { faSliders } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon, NewHeader, SectionTitle } from '@radicalbit/radicalbit-design-system';
+
+function ConfigurationsListHeader() {
+  return (
+    <NewHeader
+      title={(
+        <SectionTitle
+          subtitle="Write, generate, and publish your gateway configuration. AI-assisted or manual YAML."
+          title="Configurations"
+          titlePrefix={<FontAwesomeIcon icon={faSliders} />}
+        />
+      )}
+    />
+  );
+}
+
+export default ConfigurationsListHeader;

--- a/ui/src/container/pages/projects/components/config-status-tag/index.jsx
+++ b/ui/src/container/pages/projects/components/config-status-tag/index.jsx
@@ -2,13 +2,17 @@ import { ConfigStatusEnum } from '@Src/constants';
 import { Tag } from '@radicalbit/radicalbit-design-system';
 
 const CONFIG_STATUS_TAG = {
-  [ConfigStatusEnum.DRAFT]: { label: 'Draft', type: 'secondary-light' },
+  [ConfigStatusEnum.EMPTY]: { label: 'Empty', type: 'secondary-light' },
+  [ConfigStatusEnum.DRAFT]: { label: 'Draft', type: 'secondary' },
   [ConfigStatusEnum.READY_TO_SERVE]: { label: 'Publish Requested', type: 'warning-light' },
   [ConfigStatusEnum.SERVED]: { label: 'Published in Prod', type: 'full' },
 };
 
-function ConfigStatusTag({ configStatus }) {
-  const tag = CONFIG_STATUS_TAG[configStatus];
+function ConfigStatusTag({ config }) {
+  const configStatus = config?.configStatus;
+  const updatedAt = config?.updatedAt;
+
+  const tag = !updatedAt ? CONFIG_STATUS_TAG[ConfigStatusEnum.EMPTY] : CONFIG_STATUS_TAG[configStatus];
 
   if (!tag) {
     return false;

--- a/ui/src/container/pages/projects/list/body/columns.jsx
+++ b/ui/src/container/pages/projects/list/body/columns.jsx
@@ -1,6 +1,7 @@
 import ConfigStatusTag from '@Container/pages/projects/components/config-status-tag';
 import ProjectStatusTag from '@Container/pages/projects/components/project-status-tag';
 import { useGetThreeDotsMenuItems } from '@Container/pages/projects/list/body/three-dots-menu';
+import useGetVisibleConfig from '@Container/pages/projects/use-get-visible-config';
 import { DATE_FORMAT, DATE_FORMAT_SHORT } from '@Src/constants';
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 import {
@@ -22,7 +23,7 @@ const getColumns = () => [
   },
 
   {
-    title: 'Projects Name',
+    title: 'Projects',
     dataIndex: 'name',
     key: 'name',
     render: (value, { description }) => (
@@ -61,21 +62,11 @@ const getColumns = () => [
     title: 'Configurations',
     dataIndex: 'configs',
     key: 'configs',
-    render: (configs = []) => (
-      <div className="flex flex-col gap-1">
-        {configs.map((config) => (
-          <div key={config.uuid} className="flex items-center gap-4">
-            <span>{`Slot ${config.slot}`}</span>
-
-            <ConfigStatusTag configStatus={config.configStatus} />
-          </div>
-        ))}
-      </div>
-    ),
+    render: (configs) => <ConfigurationCell configs={configs} />,
   },
 
   {
-    title: '',
+    title: 'Actions',
     dataIndex: 'uuid',
     key: 'actions',
     width: '100px',
@@ -93,6 +84,22 @@ const getColumns = () => [
     width: '10px',
   },
 ];
+
+function ConfigurationCell({ configs }) {
+  const config = useGetVisibleConfig(configs);
+
+  if (!config) {
+    return '--';
+  }
+
+  return (
+    <div className="flex items-center gap-4">
+      <span>{`Slot ${config.slot}`}</span>
+
+      <ConfigStatusTag config={config} />
+    </div>
+  );
+}
 
 function Actions({ uuid }) {
   const items = useGetThreeDotsMenuItems(uuid);

--- a/ui/src/container/pages/projects/list/body/deploy-status-tabs.jsx
+++ b/ui/src/container/pages/projects/list/body/deploy-status-tabs.jsx
@@ -1,0 +1,59 @@
+import { ProjectStatusEnum } from '@Src/constants';
+import { Board, Button } from '@radicalbit/radicalbit-design-system';
+import { useSearchParams } from 'react-router-dom';
+
+const DEPLOY_STATUS_QP = 'deployStatus';
+
+const DEPLOY_STATUS_ALL = 'all';
+
+const DEPLOY_STATUS_TABS = [
+  { key: DEPLOY_STATUS_ALL, label: 'All' },
+  { key: ProjectStatusEnum.DEV, label: 'Dev' },
+  { key: ProjectStatusEnum.PROD, label: 'Prod' },
+];
+
+function DeployStatusTabs() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeStatus = searchParams.get(DEPLOY_STATUS_QP) || DEPLOY_STATUS_ALL;
+
+  const handleOnSelect = (status) => {
+    setSearchParams((prev) => {
+      if (status === DEPLOY_STATUS_ALL) {
+        prev.delete(DEPLOY_STATUS_QP);
+      } else {
+        prev.set(DEPLOY_STATUS_QP, status);
+      }
+      return prev;
+    });
+  };
+
+  return (
+    <Board
+      height="100%"
+      modifier="justify-center"
+      secondary={(
+        <div className="flex gap-2">
+          {DEPLOY_STATUS_TABS.map(({ key, label }) => {
+            const handleOnClick = () => {
+              handleOnSelect(key);
+            };
+
+            return (
+              <Button
+                key={key}
+                onClick={handleOnClick}
+                type={activeStatus === key ? 'primary' : 'text'}
+              >
+                {label}
+              </Button>
+            );
+          })}
+        </div>
+      )}
+      size="xsmall"
+    />
+  );
+}
+
+export { DEPLOY_STATUS_QP, DEPLOY_STATUS_ALL };
+export default DeployStatusTabs;

--- a/ui/src/container/pages/projects/list/body/index.jsx
+++ b/ui/src/container/pages/projects/list/body/index.jsx
@@ -21,6 +21,14 @@ import {
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import getColumns from './columns';
+import DeployStatusTabs, { DEPLOY_STATUS_ALL, DEPLOY_STATUS_QP } from './deploy-status-tabs';
+
+const filterProjects = (data, { searchValue, deployStatus }) => data.filter((project) => {
+  const matchesSearch = !searchValue || project.name.toLowerCase().includes(searchValue.toLowerCase());
+  const matchesDeployStatus = deployStatus === DEPLOY_STATUS_ALL || project.projectStatus === deployStatus;
+
+  return matchesSearch && matchesDeployStatus;
+});
 
 function ProjectsList() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -49,6 +57,8 @@ function ProjectsList() {
           value={searchValue}
         />
 
+        <DeployStatusTabs />
+
         <ProjectsCount searchValue={searchValue} />
       </div>
 
@@ -58,10 +68,11 @@ function ProjectsList() {
 }
 
 function ProjectsCount({ searchValue }) {
+  const [searchParams] = useSearchParams();
+  const deployStatus = searchParams.get(DEPLOY_STATUS_QP) || DEPLOY_STATUS_ALL;
+
   const { data = [], isSuccess } = useGetProjectsQuery();
-  const filteredData = searchValue
-    ? data.filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
-    : data;
+  const filteredData = filterProjects(data, { searchValue, deployStatus });
   const count = filteredData.length;
 
   if (!isSuccess) {
@@ -121,11 +132,12 @@ function ProjectsTable({ searchValue }) {
 }
 
 function IsSuccess({ searchValue }) {
+  const [searchParams] = useSearchParams();
+  const deployStatus = searchParams.get(DEPLOY_STATUS_QP) || DEPLOY_STATUS_ALL;
+
   const { data = [] } = useGetProjectsQuery();
 
-  const filteredData = searchValue
-    ? data.filter(({ name }) => name.toLowerCase().includes(searchValue.toLowerCase()))
-    : data;
+  const filteredData = filterProjects(data, { searchValue, deployStatus });
 
   const sortedData = useMemo(
     () => [...filteredData].sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? '')),

--- a/ui/src/container/pages/projects/use-get-visible-config.js
+++ b/ui/src/container/pages/projects/use-get-visible-config.js
@@ -1,0 +1,31 @@
+import { ConfigStatusEnum } from '@Src/constants';
+
+const CONFIG_STATUS_SCORE = {
+  [ConfigStatusEnum.DRAFT]: 0,
+  [ConfigStatusEnum.READY_TO_SERVE]: 1,
+  [ConfigStatusEnum.SERVED]: 2,
+};
+
+/**
+ * Picks the single config to surface for a project row.
+ *
+ * Scoring: DRAFT=0, READY_TO_SERVE=1, SERVED=2. The highest score wins; on a
+ * tie the slot with the most recent updatedAt is chosen.
+ */
+const useGetVisibleConfig = (configs = []) => {
+  if (!configs.length) {
+    return null;
+  }
+
+  return [...configs].sort((a, b) => {
+    const scoreDiff = (CONFIG_STATUS_SCORE[b.configStatus] ?? 0) - (CONFIG_STATUS_SCORE[a.configStatus] ?? 0);
+
+    if (scoreDiff !== 0) {
+      return scoreDiff;
+    }
+
+    return (b.updatedAt ?? '').localeCompare(a.updatedAt ?? '');
+  })[0];
+};
+
+export default useGetVisibleConfig;

--- a/ui/src/store/state/projects/api.js
+++ b/ui/src/store/state/projects/api.js
@@ -170,6 +170,59 @@ export const projectsApiSlice = apiService.injectEndpoints({
         return [];
       },
     }),
+
+    importConfig: builder.mutation({
+      query: ({ projectUuid, configUuid, data }) => ({
+        url: `/projects/${projectUuid}/configs/${configUuid}/import`,
+        method: 'patch',
+        data,
+      }),
+      invalidatesTags: (result, error, { projectUuid, configUuid }) => {
+        if (result) {
+          return [
+            { type: API_TAGS.PROJECTS, id: LIST_ID },
+            { type: API_TAGS.PROJECTS, id: projectUuid },
+            { type: API_TAGS.PROJECTS, id: `config-${configUuid}` },
+          ];
+        }
+
+        return [];
+      },
+    }),
+
+    exportConfig: builder.query({
+      query: ({ projectUuid, configUuid }) => ({
+        url: `/projects/${projectUuid}/configs/${configUuid}/export`,
+        method: 'get',
+        responseType: 'blob',
+      }),
+    }),
+
+    exportAllConfigs: builder.query({
+      query: ({ projectUuid }) => ({
+        url: `/projects/${projectUuid}/configs/export`,
+        method: 'get',
+        responseType: 'blob',
+      }),
+    }),
+
+    getAllConfigurations: builder.query({
+      providesTags: () => [{ type: API_TAGS.PROJECTS, id: LIST_ID }],
+      query: ({ status } = {}) => {
+        const searchParams = new URLSearchParams();
+
+        if (status) {
+          searchParams.set('status', status);
+        }
+
+        const queryString = searchParams.toString();
+
+        return {
+          url: queryString ? `/configs/projects?${queryString}` : '/configs/projects',
+          method: 'get',
+        };
+      },
+    }),
   }),
 });
 
@@ -186,6 +239,10 @@ export const {
   useCancelApprovalMutation,
   useServeConfigMutation,
   useUnserveConfigMutation,
+  useImportConfigMutation,
+  useLazyExportConfigQuery,
+  useLazyExportAllConfigsQuery,
+  useGetAllConfigurationsQuery,
 } = projectsApiSlice;
 
 export const selectors = {};

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -575,10 +575,10 @@
     uuid "^10.0.0"
     yup "^1.4.0"
 
-"@radicalbit/radicalbit-design-system@2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@radicalbit/radicalbit-design-system/-/radicalbit-design-system-2.16.0.tgz#147c02e33b540465192229680cee51c824bbbc58"
-  integrity sha512-kd8ievopar8JYAMaTMoT8HJO3qXnoBZPZNIOneillJp48FyKXUOonP3gI0JRLbjqsn43YwCaAO2dp2Og+TENxw==
+"@radicalbit/radicalbit-design-system@2.18.2":
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/@radicalbit/radicalbit-design-system/-/radicalbit-design-system-2.18.2.tgz#c1b637f8cf3aae97decbf39442b9c864f3df3965"
+  integrity sha512-Jj2/Mh71uV+IlOj7IdOTSb8KGC2NcTWc9bm4wYXTX/PaDH9PUBbSUyQ8ehbaQ1RPAmLYTA5fOib52z7ScC5vsA==
   dependencies:
     "@babel/polyfill" "7.12.1"
     "@fortawesome/fontawesome-svg-core" "6.7.2"


### PR DESCRIPTION
- config import/export (blob download support, import/export buttons)
- new Configurations page (list, status tabs, per-slot actions)
- projects table: single visible config, deploy-status tabs
- ConfigStatusTag config={config} signature + EMPTY status
- Configurations nav item + routes; RDS bump to 2.18.2

