### PR TITLE
fix: change import endpoint method

### DIFF
--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -212,7 +212,7 @@ class ProjectRoute:
                 headers={'Content-Disposition': f'attachment; filename="{filename}"'},
             )
 
-        @router.post(
+        @router.patch(
             '/projects/{project_uuid}/configs/{config_uuid}/import',
             status_code=200,
             response_model=ProjectOut,

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -193,7 +193,7 @@ class TestProjectRoute(unittest.TestCase):
         self.project_service.import_config = MagicMock(
             return_value=db_mock.get_sample_project_out(uuid=pid)
         )
-        res = self.client.post(
+        res = self.client.patch(
             f'{self.prefix}/projects/{pid}/configs/{cid}/import',
             files={'file': ('c.yaml', b'yaml-bytes', 'application/x-yaml')},
         )
@@ -207,7 +207,7 @@ class TestProjectRoute(unittest.TestCase):
         self.project_service.import_config = MagicMock(
             side_effect=ProjectNotFoundError('nope')
         )
-        res = self.client.post(
+        res = self.client.patch(
             f'{self.prefix}/projects/{pid}/configs/{cid}/import',
             files={'file': ('c.yaml', b'yaml-bytes', 'application/x-yaml')},
         )
@@ -218,7 +218,7 @@ class TestProjectRoute(unittest.TestCase):
         self.project_service.import_config = MagicMock(
             side_effect=ProjectConfigValidationError('invalid')
         )
-        res = self.client.post(
+        res = self.client.patch(
             f'{self.prefix}/projects/{pid}/configs/{cid}/import',
             files={'file': ('c.yaml', b'yaml-bytes', 'application/x-yaml')},
         )
@@ -226,13 +226,13 @@ class TestProjectRoute(unittest.TestCase):
 
     def test_import_config_missing_file_returns_422(self):
         pid, cid = uuid.uuid4(), uuid.uuid4()
-        res = self.client.post(f'{self.prefix}/projects/{pid}/configs/{cid}/import')
+        res = self.client.patch(f'{self.prefix}/projects/{pid}/configs/{cid}/import')
         assert res.status_code == 422
 
     def test_import_config_wrong_extension_returns_400(self):
         pid, cid = uuid.uuid4(), uuid.uuid4()
         self.project_service.import_config = MagicMock()
-        res = self.client.post(
+        res = self.client.patch(
             f'{self.prefix}/projects/{pid}/configs/{cid}/import',
             files={'file': ('c.json', b'{}', 'application/json')},
         )
@@ -243,7 +243,7 @@ class TestProjectRoute(unittest.TestCase):
         pid, cid = uuid.uuid4(), uuid.uuid4()
         self.project_service.import_config = MagicMock()
         oversized = b'x' * (2 * 1024 * 1024 + 1)
-        res = self.client.post(
+        res = self.client.patch(
             f'{self.prefix}/projects/{pid}/configs/{cid}/import',
             files={'file': ('c.yaml', oversized, 'application/x-yaml')},
         )


### PR DESCRIPTION
## Summary

Changes the HTTP method of the config-import endpoint from `POST` to `PATCH`, aligning the backend with the UI client (which already issues `PATCH`) and with the other config state-transition endpoints on the same resource (`approve`, `unserve`, etc.). No DTOs, request bodies, or responses change.

---

## DTO Changes

**None.** Request body (multipart `file` upload) and response (`ProjectOut`) are unchanged.

---

## Affected Endpoints

### `PATCH /public/api/v1/projects/{project_uuid}/configs/{config_uuid}/import` (MODIFIED)

**Changes:**
```diff
? method: POST -> PATCH  (verb changed; path, body, and response unchanged)
```

**Example request:**
```
PATCH /public/api/v1/projects/550e8400-e29b-41d4-a716-446655440000/configs/11111111-1111-1111-1111-111111111111/import
Content-Type: multipart/form-data

file=@config.yaml
```

```bash
curl -X PATCH \
  "http://localhost:8000/public/api/v1/projects/{project_uuid}/configs/{config_uuid}/import" \
  -F "file=@config.yaml"
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `config_uuid` | string | yes | Config slot UUID (path) |
| `file` | file (multipart) | yes | The `.yaml` / `.yml` config file to import |

**Responses (unchanged):**

| Status | When |
|--------|------|
| `200` | Import succeeded; returns the updated `ProjectOut` (slot set to `DRAFT`) |
| `400` | Wrong extension, file larger than 2 MB, non-UTF-8, invalid YAML/schema/secrets, or served slot |
| `404` | Unknown project or config UUID |
| `422` | Missing `file` field |

---

## Other Changes

- `routes/project_route.py` — `import_config` route decorator changed from `@router.post(...)` to `@router.patch(...)`.
- `tests/routes/test_project_route.py` — updated all six `import_config` test cases to call `client.patch(...)` instead of `client.post(...)` (returns-project, not-found, invalid-400, missing-file-422, wrong-extension-400, too-large-400).

## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
