### PR TITLE
feat: add sbom generation and push to dependency track

### DIFF
--- a/.github/actions/python-sbom-dependency-track/action.yml
+++ b/.github/actions/python-sbom-dependency-track/action.yml
@@ -1,0 +1,131 @@
+name: Python SBOM → Dependency-Track (source deps)
+description: >-
+  Generate a CycloneDX 1.6 SBOM from a uv project's resolved dependencies
+  (uv.lock as source of truth via `uv sync --frozen`, then cyclonedx-py) and
+  upload it to Dependency-Track.
+
+inputs:
+  working-directory:
+    description: Path to the uv project (containing pyproject.toml and uv.lock).
+    required: true
+  python-version:
+    description: Python version to use.
+    required: false
+    default: "3.11"
+  uv-version:
+    description: uv version to install.
+    required: false
+    default: "0.7.13"
+  cyclonedx-bom-version:
+    description: cyclonedx-bom (cyclonedx-py) version to run via uvx.
+    required: false
+    default: "7.3.0"
+  project-name:
+    description: Dependency-Track project name.
+    required: true
+  project-version:
+    description: Dependency-Track project version (e.g. the git tag, or "main").
+    required: true
+  is-latest:
+    description: Mark this version as the latest for the project ("true"/"false").
+    required: false
+    default: "false"
+  project-tags:
+    description: Comma-separated tags applied to the Dependency-Track project.
+    required: false
+    default: oss,python,source
+  dt-url:
+    description: Base URL of the Dependency-Track API server.
+    required: true
+  dt-api-key:
+    description: Dependency-Track API key (needs BOM_UPLOAD, PROJECT_CREATION_UPLOAD, VIEW_PORTFOLIO, PORTFOLIO_MANAGEMENT).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Setup uv
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -LsSf https://astral.sh/uv/${{ inputs.uv-version }}/install.sh | sh
+
+    - name: Sync locked (production) dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        # --frozen: use the exact resolution in uv.lock (fails if the lock is stale)
+        # --no-dev: exclude development dependencies from the SBOM
+        uv sync --frozen --no-dev
+
+    - name: Generate SBOM with cyclonedx-py (CycloneDX 1.6)
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        CDX_VERSION: ${{ inputs.cyclonedx-bom-version }}
+      run: |
+        set -euo pipefail
+        uvx --from "cyclonedx-bom==${CDX_VERSION}" cyclonedx-py environment .venv \
+          --pyproject pyproject.toml \
+          --spec-version 1.6 \
+          --output-format JSON \
+          --output-file sbom.cyclonedx.json
+        echo ">> Generated SBOM:"
+        head -c 400 sbom.cyclonedx.json; echo
+
+    - name: Upload SBOM to Dependency-Track
+      id: upload
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        DT_URL: ${{ inputs.dt-url }}
+        DT_API_KEY: ${{ inputs.dt-api-key }}
+        PROJECT_NAME: ${{ inputs.project-name }}
+        PROJECT_VERSION: ${{ inputs.project-version }}
+        IS_LATEST: ${{ inputs.is-latest }}
+        PROJECT_TAGS: ${{ inputs.project-tags }}
+      run: |
+        set -euo pipefail
+        echo ">> Uploading SBOM to ${DT_URL} for ${PROJECT_NAME}@${PROJECT_VERSION} (isLatest=${IS_LATEST})"
+        RESPONSE=$(curl -sSf -X POST "${DT_URL%/}/api/v1/bom" \
+          -H "X-Api-Key: ${DT_API_KEY}" \
+          -F autoCreate=true \
+          -F "projectName=${PROJECT_NAME}" \
+          -F "projectVersion=${PROJECT_VERSION}" \
+          -F "isLatest=${IS_LATEST}" \
+          -F "projectTags=${PROJECT_TAGS}" \
+          -F "bom=@sbom.cyclonedx.json")
+        echo "${RESPONSE}"
+        TOKEN=$(echo "${RESPONSE}" | jq -r '.token // empty')
+        echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for Dependency-Track processing (best-effort)
+      shell: bash
+      env:
+        DT_URL: ${{ inputs.dt-url }}
+        DT_API_KEY: ${{ inputs.dt-api-key }}
+      run: |
+        set -uo pipefail
+        TOKEN="${{ steps.upload.outputs.token }}"
+        if [ -z "${TOKEN}" ]; then
+          echo "No processing token returned; skipping wait."
+          exit 0
+        fi
+        echo ">> Waiting for BOM processing (token ${TOKEN})…"
+        for i in $(seq 1 30); do
+          PROCESSING=$(curl -sSf "${DT_URL%/}/api/v1/bom/token/${TOKEN}" \
+            -H "X-Api-Key: ${DT_API_KEY}" | jq -r '.processing')
+          if [ "${PROCESSING}" = "false" ]; then
+            echo "   BOM processed."
+            exit 0
+          fi
+          echo "   still processing… (${i}/30)"
+          sleep 5
+        done
+        echo "::warning::Timed out waiting for Dependency-Track to finish processing the BOM (upload succeeded)."

--- a/.github/actions/sbom-dependency-track/action.yml
+++ b/.github/actions/sbom-dependency-track/action.yml
@@ -1,0 +1,98 @@
+name: SBOM → Dependency-Track (container)
+description: Generate a CycloneDX 1.6 SBOM from a container image with Syft and upload it to Dependency-Track.
+
+inputs:
+  image-ref:
+    description: Full image reference to scan, including the @sha256 digest.
+    required: true
+  project-name:
+    description: Dependency-Track project name.
+    required: true
+  project-version:
+    description: Dependency-Track project version (e.g. the git tag, or "main").
+    required: true
+  is-latest:
+    description: Mark this version as the latest for the project ("true"/"false").
+    required: false
+    default: "false"
+  project-tags:
+    description: Comma-separated tags applied to the Dependency-Track project.
+    required: false
+    default: oss,container,docker
+  platform:
+    description: Platform to scan from a multi-arch image.
+    required: false
+    default: linux/amd64
+  dt-url:
+    description: Base URL of the Dependency-Track API server.
+    required: true
+  dt-api-key:
+    description: Dependency-Track API key (needs BOM_UPLOAD, PROJECT_CREATION_UPLOAD, VIEW_PORTFOLIO, PORTFOLIO_MANAGEMENT).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@v0.24.0
+
+    - name: Generate SBOM with Syft (CycloneDX 1.6)
+      shell: bash
+      env:
+        IMAGE_REF: ${{ inputs.image-ref }}
+        PLATFORM: ${{ inputs.platform }}
+      run: |
+        set -euo pipefail
+        syft "registry:${IMAGE_REF}" \
+          --platform "${PLATFORM}" \
+          -o cyclonedx-json@1.6=sbom.cyclonedx.json
+
+    - name: Upload SBOM to Dependency-Track
+      id: upload
+      shell: bash
+      env:
+        DT_URL: ${{ inputs.dt-url }}
+        DT_API_KEY: ${{ inputs.dt-api-key }}
+        PROJECT_NAME: ${{ inputs.project-name }}
+        PROJECT_VERSION: ${{ inputs.project-version }}
+        IS_LATEST: ${{ inputs.is-latest }}
+        PROJECT_TAGS: ${{ inputs.project-tags }}
+      run: |
+        set -euo pipefail
+        echo ">> Uploading SBOM to ${DT_URL} for ${PROJECT_NAME}@${PROJECT_VERSION} (isLatest=${IS_LATEST})"
+        RESPONSE=$(curl -sSf -X POST "${DT_URL%/}/api/v1/bom" \
+          -H "X-Api-Key: ${DT_API_KEY}" \
+          -F autoCreate=true \
+          -F "projectName=${PROJECT_NAME}" \
+          -F "projectVersion=${PROJECT_VERSION}" \
+          -F "isLatest=${IS_LATEST}" \
+          -F "projectTags=${PROJECT_TAGS}" \
+          -F "bom=@sbom.cyclonedx.json")
+        echo "${RESPONSE}"
+        TOKEN=$(echo "${RESPONSE}" | jq -r '.token // empty')
+        echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for Dependency-Track processing (best-effort)
+      shell: bash
+      env:
+        DT_URL: ${{ inputs.dt-url }}
+        DT_API_KEY: ${{ inputs.dt-api-key }}
+      run: |
+        set -uo pipefail
+        TOKEN="${{ steps.upload.outputs.token }}"
+        if [ -z "${TOKEN}" ]; then
+          echo "No processing token returned; skipping wait."
+          exit 0
+        fi
+        echo ">> Waiting for BOM processing (token ${TOKEN})…"
+        for i in $(seq 1 30); do
+          PROCESSING=$(curl -sSf "${DT_URL%/}/api/v1/bom/token/${TOKEN}" \
+            -H "X-Api-Key: ${DT_API_KEY}" | jq -r '.processing')
+          if [ "${PROCESSING}" = "false" ]; then
+            echo "   BOM processed."
+            exit 0
+          fi
+          echo "   still processing… (${i}/30)"
+          sleep 5
+        done
+        echo "::warning::Timed out waiting for Dependency-Track to finish processing the BOM (upload succeeded)."

--- a/.github/workflows/gateway-workflow.yaml
+++ b/.github/workflows/gateway-workflow.yaml
@@ -21,6 +21,10 @@ env:
   APP_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway
   MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-migrations
   IMAGES_TAG: main
+  # Dependency-Track project names (registry-independent, stable across builds)
+  APP_PROJECT: radicalbit-ai-gateway
+  MIGRATIONS_PROJECT: radicalbit-ai-gateway-migrations
+  GATEWAY_PYTHON_PROJECT: radicalbit-ai-gateway-python
 
 jobs:
   test:
@@ -119,7 +123,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # needed for keyless signing with the GitHub OIDC token
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -128,6 +135,8 @@ jobs:
           merge-multiple: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
       - name: Log in to container registry
         uses: docker/login-action@v3
         with:
@@ -148,3 +157,75 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ env.IMAGES_TAG }}
           docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }}
+
+      - name: Get app manifest digest
+        id: app-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      - name: Get migrations manifest digest
+        id: migrations-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: SBOM → Dependency-Track (app)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.APP_IMAGE }}@${{ steps.app-manifest.outputs.digest }}
+          project-name: ${{ env.APP_PROJECT }}
+          project-version: ${{ env.IMAGES_TAG }}
+          is-latest: "false"
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: SBOM → Dependency-Track (migrations)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.MIGRATIONS_IMAGE }}@${{ steps.migrations-manifest.outputs.digest }}
+          project-name: ${{ env.MIGRATIONS_PROJECT }}
+          project-version: ${{ env.IMAGES_TAG }}
+          is-latest: "false"
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+
+      - name: Sign images with Cosign (keyless)
+        env:
+          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
+        run: |
+          cosign sign --yes "${{ env.APP_IMAGE }}@${APP_DIGEST}"
+          cosign sign --yes "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"
+      - name: Verify signatures
+        env:
+          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
+        run: |
+          for REF in \
+            "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
+            "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"; do
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          done
+
+  source-sbom:
+    runs-on: ubuntu-22.04
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Python source SBOM → Dependency-Track (gateway)
+        uses: ./.github/actions/python-sbom-dependency-track
+        with:
+          working-directory: ./gateway
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          project-name: ${{ env.GATEWAY_PYTHON_PROJECT }}
+          project-version: ${{ env.IMAGES_TAG }}
+          is-latest: "false"
+          project-tags: oss,python,source
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}

--- a/.github/workflows/metrics-worker-workflow.yaml
+++ b/.github/workflows/metrics-worker-workflow.yaml
@@ -23,6 +23,10 @@ env:
   WORKER_IMAGE: ${{ secrets.IMAGE_PREFIX }}/metrics-worker
   CLICKHOUSE_MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-clickhouse-migrations
   IMAGES_TAG: main
+  # Dependency-Track project names (registry-independent, stable across builds)
+  WORKER_PROJECT: metrics-worker
+  CLICKHOUSE_MIGRATIONS_PROJECT: radicalbit-ai-gateway-clickhouse-migrations
+  WORKER_PYTHON_PROJECT: metrics-worker-python
 
 jobs:
   test:
@@ -118,7 +122,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # needed for keyless signing with the GitHub OIDC token
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -127,6 +134,8 @@ jobs:
           merge-multiple: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
       - name: Log in to container registry
         uses: docker/login-action@v3
         with:
@@ -147,3 +156,75 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ env.IMAGES_TAG }}
           docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }}
+
+      - name: Get metrics-worker manifest digest
+        id: worker-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      - name: Get clickhouse-migrations manifest digest
+        id: clickhouse-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: SBOM → Dependency-Track (metrics-worker)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.WORKER_IMAGE }}@${{ steps.worker-manifest.outputs.digest }}
+          project-name: ${{ env.WORKER_PROJECT }}
+          project-version: ${{ env.IMAGES_TAG }}
+          is-latest: "false"
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: SBOM → Dependency-Track (clickhouse-migrations)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${{ steps.clickhouse-manifest.outputs.digest }}
+          project-name: ${{ env.CLICKHOUSE_MIGRATIONS_PROJECT }}
+          project-version: ${{ env.IMAGES_TAG }}
+          is-latest: "false"
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+
+      - name: Sign images with Cosign (keyless)
+        env:
+          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
+        run: |
+          cosign sign --yes "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"
+          cosign sign --yes "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"
+      - name: Verify signatures
+        env:
+          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
+        run: |
+          for REF in \
+            "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}" \
+            "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"; do
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          done
+
+  source-sbom:
+    runs-on: ubuntu-22.04
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Python source SBOM → Dependency-Track (metrics-worker)
+        uses: ./.github/actions/python-sbom-dependency-track
+        with:
+          working-directory: ./metrics-worker
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          project-name: ${{ env.WORKER_PYTHON_PROJECT }}
+          project-version: ${{ env.IMAGES_TAG }}
+          is-latest: "false"
+          project-tags: oss,python,source
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,13 @@ env:
   MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-migrations
   CLICKHOUSE_MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-clickhouse-migrations
   WORKER_IMAGE: ${{ secrets.IMAGE_PREFIX }}/metrics-worker
+  # Dependency-Track project names (registry-independent, stable across builds)
+  APP_PROJECT: radicalbit-ai-gateway
+  MIGRATIONS_PROJECT: radicalbit-ai-gateway-migrations
+  CLICKHOUSE_MIGRATIONS_PROJECT: radicalbit-ai-gateway-clickhouse-migrations
+  WORKER_PROJECT: metrics-worker
+  GATEWAY_PYTHON_PROJECT: radicalbit-ai-gateway-python
+  WORKER_PYTHON_PROJECT: metrics-worker-python
 
 jobs:
   prep:
@@ -142,7 +149,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # needed for keyless signing with the GitHub OIDC token
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -151,6 +161,8 @@ jobs:
           merge-multiple: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
       - name: Log in to container registry
         uses: docker/login-action@v3
         with:
@@ -205,3 +217,124 @@ jobs:
           if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
             echo "   Latest tags also created for semantic version"
           fi
+
+      - name: Get app manifest digest
+        id: app-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      - name: Get migrations manifest digest
+        id: migrations-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      - name: Get clickhouse-migrations manifest digest
+        id: clickhouse-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      - name: Get metrics-worker manifest digest
+        id: worker-manifest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: SBOM → Dependency-Track (app)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.APP_IMAGE }}@${{ steps.app-manifest.outputs.digest }}
+          project-name: ${{ env.APP_PROJECT }}
+          project-version: ${{ needs.prep.outputs.version }}
+          is-latest: ${{ needs.prep.outputs.is_semver }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: SBOM → Dependency-Track (migrations)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.MIGRATIONS_IMAGE }}@${{ steps.migrations-manifest.outputs.digest }}
+          project-name: ${{ env.MIGRATIONS_PROJECT }}
+          project-version: ${{ needs.prep.outputs.version }}
+          is-latest: ${{ needs.prep.outputs.is_semver }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: SBOM → Dependency-Track (clickhouse-migrations)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${{ steps.clickhouse-manifest.outputs.digest }}
+          project-name: ${{ env.CLICKHOUSE_MIGRATIONS_PROJECT }}
+          project-version: ${{ needs.prep.outputs.version }}
+          is-latest: ${{ needs.prep.outputs.is_semver }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: SBOM → Dependency-Track (metrics-worker)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.WORKER_IMAGE }}@${{ steps.worker-manifest.outputs.digest }}
+          project-name: ${{ env.WORKER_PROJECT }}
+          project-version: ${{ needs.prep.outputs.version }}
+          is-latest: ${{ needs.prep.outputs.is_semver }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+
+      - name: Sign images with Cosign (keyless)
+        env:
+          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
+          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
+        run: |
+          cosign sign --yes "${{ env.APP_IMAGE }}@${APP_DIGEST}"
+          cosign sign --yes "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"
+          cosign sign --yes "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"
+          cosign sign --yes "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"
+      - name: Verify signatures
+        env:
+          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
+          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
+        run: |
+          for REF in \
+            "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
+            "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}" \
+            "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}" \
+            "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"; do
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/tags/.+" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          done
+
+  source-sbom:
+    runs-on: ubuntu-22.04
+    needs: prep
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Python source SBOM → Dependency-Track (gateway)
+        uses: ./.github/actions/python-sbom-dependency-track
+        with:
+          working-directory: ./gateway
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          project-name: ${{ env.GATEWAY_PYTHON_PROJECT }}
+          project-version: ${{ needs.prep.outputs.version }}
+          is-latest: ${{ needs.prep.outputs.is_semver }}
+          project-tags: oss,python,source
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: Python source SBOM → Dependency-Track (metrics-worker)
+        uses: ./.github/actions/python-sbom-dependency-track
+        with:
+          working-directory: ./metrics-worker
+          python-version: ${{ env.PYTHON_VERSION }}
+          uv-version: ${{ env.UV_VERSION }}
+          project-name: ${{ env.WORKER_PYTHON_PROJECT }}
+          project-version: ${{ needs.prep.outputs.version }}
+          is-latest: ${{ needs.prep.outputs.is_semver }}
+          project-tags: oss,python,source
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}


### PR DESCRIPTION
# Add container image signing (Cosign) and SBOM generation → Dependency-Track

## Summary

This PR adds supply-chain hardening to the release pipeline. For every Docker image we publish (UI excluded), the pipeline now:

1. **Generates a CycloneDX 1.6 SBOM** from the built image with **Syft** and uploads it to **Dependency-Track**.
2. **Signs the image with Cosign** (keyless / GitHub OIDC) and verifies the signature.

In addition, we produce **source-level dependency SBOMs** for the two Python services (gateway backend and metrics-worker) directly from their `uv.lock`, and upload those to Dependency-Track as well.

This applies to both `main` builds and tagged releases.

## What changed

### New composite actions (`.github/actions/`)

- **`sbom-dependency-track`** — runs Syft against a container image (by digest) to produce a CycloneDX 1.6 SBOM and uploads it to Dependency-Track (`autoCreate`, project name/version/tags, `isLatest`, best-effort wait for processing).
- **`python-sbom-dependency-track`** — resolves production dependencies with `uv sync --frozen --no-dev` (using `uv.lock` as the source of truth) and generates a CycloneDX 1.6 SBOM with `cyclonedx-py environment`, then uploads it to Dependency-Track.

### Workflows

- **`gateway-workflow.yaml`** (main): the `merge` job now derives each image's manifest digest, uploads a Syft SBOM, and signs + verifies `radicalbit-ai-gateway` and `radicalbit-ai-gateway-migrations`. A new `source-sbom` job uploads the gateway Python dependency SBOM.
- **`metrics-worker-workflow.yaml`** (main): the same treatment for `metrics-worker` and `radicalbit-ai-gateway-clickhouse-migrations`. A new `source-sbom` job uploads the metrics-worker Python dependency SBOM.
- **`release.yaml`** (tags): signs + SBOMs all four images, with `isLatest` set for semver tags; a new `source-sbom` job uploads the gateway and metrics-worker Python dependency SBOMs, versioned by the git tag.

## Why `cyclonedx-py environment` (and not the requirements export)

`uv sync --frozen` pins to the exact resolution in `uv.lock` (and fails on a stale lock), so it is our source of truth. Running `cyclonedx-py environment` against the resulting virtual environment yields high-fidelity components — exact installed versions, proper PURLs, and **license data** — which gives Dependency-Track the best possible vulnerability and license matching. The requirements-export approach produces low-fidelity, license-less components, so it was not used.

## Dependency-Track project layout

Dependency-Track **replaces** a project's BOM on each upload to the same project + version, so the container SBOM and the Python source SBOM of the same service cannot share a project. Each artifact therefore gets its own project:

| Project | Source | Tags |
|---|---|---|
| `radicalbit-ai-gateway` | Syft (image) | `oss,container,docker` |
| `radicalbit-ai-gateway-migrations` | Syft (image) | `oss,container,docker` |
| `radicalbit-ai-gateway-clickhouse-migrations` | Syft (image) | `oss,container,docker` |
| `metrics-worker` | Syft (image) | `oss,container,docker` |
| `radicalbit-ai-gateway-python` | cyclonedx-py (source deps) | `oss,python,source` |
| `metrics-worker-python` | cyclonedx-py (source deps) | `oss,python,source` |

- **Version** = the git tag for releases, or `main` for main builds.
- **`isLatest`** = `true` only for semver tags.

## Image signing

Cosign keyless signing over the multi-arch manifest digest, using the GitHub OIDC token (`id-token: write`). Signatures are verified in-pipeline against:

- `…/.github/workflows/.+@refs/heads/main` for main builds
- `…/.github/workflows/.+@refs/tags/.+` for tagged releases

## Notes

- UI is intentionally excluded from this change.
- Path filters are unchanged: a `main` push touching only one service refreshes that service's SBOMs only.


## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [x] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
