### PR TITLE
feat(ci): add UI SBOM generation and push to Dependency-Track

### DIFF
--- a/.github/actions/ui-sbom-dependency-track/action.yml
+++ b/.github/actions/ui-sbom-dependency-track/action.yml
@@ -1,0 +1,100 @@
+name: UI SBOM → Dependency-Track (source deps)
+description: >-
+  Generate a CycloneDX 1.6 SBOM from the UI's yarn.lock with Syft and upload it
+  to Dependency-Track. Syft reads the yarn v1 lockfile directly, so no install
+  or lockfile conversion is required. All dependencies are included.
+
+inputs:
+  working-directory:
+    description: Path to the UI project (containing package.json and yarn.lock).
+    required: false
+    default: ./ui
+  project-name:
+    description: Dependency-Track project name.
+    required: true
+  project-version:
+    description: Dependency-Track project version (e.g. the git tag, or "main").
+    required: true
+  is-latest:
+    description: Mark this version as the latest for the project ("true"/"false").
+    required: false
+    default: "false"
+  project-tags:
+    description: Comma-separated tags applied to the Dependency-Track project.
+    required: false
+    default: oss,npm,source
+  dt-url:
+    description: Base URL of the Dependency-Track API server.
+    required: true
+  dt-api-key:
+    description: Dependency-Track API key (needs BOM_UPLOAD, PROJECT_CREATION_UPLOAD, VIEW_PORTFOLIO, PORTFOLIO_MANAGEMENT).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Syft
+      uses: anchore/sbom-action/download-syft@v0.24.0
+
+    - name: Generate SBOM with Syft (CycloneDX 1.6)
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        # Scan the source directory: Syft parses yarn.lock (v1) natively and
+        # enumerates the full dependency tree. No node_modules / install needed.
+        syft dir:. \
+          -o cyclonedx-json@1.6=sbom.cyclonedx.json
+        echo ">> Generated SBOM:"
+        head -c 400 sbom.cyclonedx.json; echo
+
+    - name: Upload SBOM to Dependency-Track
+      id: upload
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        DT_URL: ${{ inputs.dt-url }}
+        DT_API_KEY: ${{ inputs.dt-api-key }}
+        PROJECT_NAME: ${{ inputs.project-name }}
+        PROJECT_VERSION: ${{ inputs.project-version }}
+        IS_LATEST: ${{ inputs.is-latest }}
+        PROJECT_TAGS: ${{ inputs.project-tags }}
+      run: |
+        set -euo pipefail
+        echo ">> Uploading SBOM to ${DT_URL} for ${PROJECT_NAME}@${PROJECT_VERSION} (isLatest=${IS_LATEST})"
+        RESPONSE=$(curl -sSf -X POST "${DT_URL%/}/api/v1/bom" \
+          -H "X-Api-Key: ${DT_API_KEY}" \
+          -F autoCreate=true \
+          -F "projectName=${PROJECT_NAME}" \
+          -F "projectVersion=${PROJECT_VERSION}" \
+          -F "isLatest=${IS_LATEST}" \
+          -F "projectTags=${PROJECT_TAGS}" \
+          -F "bom=@sbom.cyclonedx.json")
+        echo "${RESPONSE}"
+        TOKEN=$(echo "${RESPONSE}" | jq -r '.token // empty')
+        echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
+
+    - name: Wait for Dependency-Track processing (best-effort)
+      shell: bash
+      env:
+        DT_URL: ${{ inputs.dt-url }}
+        DT_API_KEY: ${{ inputs.dt-api-key }}
+      run: |
+        set -uo pipefail
+        TOKEN="${{ steps.upload.outputs.token }}"
+        if [ -z "${TOKEN}" ]; then
+          echo "No processing token returned; skipping wait."
+          exit 0
+        fi
+        echo ">> Waiting for BOM processing (token ${TOKEN})…"
+        for i in $(seq 1 30); do
+          PROCESSING=$(curl -sSf "${DT_URL%/}/api/v1/bom/token/${TOKEN}" \
+            -H "X-Api-Key: ${DT_API_KEY}" | jq -r '.processing')
+          if [ "${PROCESSING}" = "false" ]; then
+            echo "   BOM processed."
+            exit 0
+          fi
+          echo "   still processing… (${i}/30)"
+          sleep 5
+        done
+        echo "::warning::Timed out waiting for Dependency-Track to finish processing the BOM (upload succeeded)."

--- a/.github/workflows/gateway-workflow.yaml
+++ b/.github/workflows/gateway-workflow.yaml
@@ -25,6 +25,7 @@ env:
   APP_PROJECT: radicalbit-ai-gateway
   MIGRATIONS_PROJECT: radicalbit-ai-gateway-migrations
   GATEWAY_PYTHON_PROJECT: radicalbit-ai-gateway-python
+  UI_PROJECT: radicalbit-ai-gateway-ui
 
 jobs:
   test:
@@ -227,5 +228,15 @@ jobs:
           project-version: ${{ env.IMAGES_TAG }}
           is-latest: "false"
           project-tags: oss,python,source
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: UI source SBOM → Dependency-Track
+        uses: ./.github/actions/ui-sbom-dependency-track
+        with:
+          working-directory: ./ui
+          project-name: ${{ env.UI_PROJECT }}
+          project-version: ${{ env.IMAGES_TAG }}
+          is-latest: "false"
+          project-tags: oss,npm,source
           dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
           dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ env:
   WORKER_PROJECT: metrics-worker
   GATEWAY_PYTHON_PROJECT: radicalbit-ai-gateway-python
   WORKER_PYTHON_PROJECT: metrics-worker-python
+  UI_PROJECT: radicalbit-ai-gateway-ui
 
 jobs:
   prep:
@@ -324,6 +325,16 @@ jobs:
           project-version: ${{ needs.prep.outputs.version }}
           is-latest: ${{ needs.prep.outputs.is_semver }}
           project-tags: oss,python,source
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: UI source SBOM → Dependency-Track
+        uses: ./.github/actions/ui-sbom-dependency-track
+        with:
+          working-directory: ./ui
+          project-name: ${{ env.UI_PROJECT }}
+          project-version: ${{ needs.prep.outputs.version }}
+          is-latest: ${{ needs.prep.outputs.is_semver }}
+          project-tags: oss,npm,source
           dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
           dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
       - name: Python source SBOM → Dependency-Track (metrics-worker)


### PR DESCRIPTION
Generate a CycloneDX 1.6 SBOM from the UI's yarn.lock with Syft (which parses the yarn v1 lockfile natively, no install or lockfile conversion) and upload it to Dependency-Track. Wired into the source-sbom job of both the main-branch and release workflows, mirroring the existing Python source SBOM, under a new radicalbit-ai-gateway-ui project.
