### PR TITLE
feat(AG-896): add transcription_models as a new config category

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -98,6 +98,7 @@ class GatewayRoute:
         token_limiter: TokenLimiter | None = None,
         rate_limiter: RequestRateLimiter | None = None,
         budget_limiter: BudgetLimiter | None = None,
+        transcription_models: list[Model] | None = None,
         project_uuid: str = '',
         project_name: str = '',
     ):
@@ -106,6 +107,7 @@ class GatewayRoute:
         self.project_name = project_name
         self._chat_models = chat_models
         self._embedding_models = embedding_models or []
+        self._transcription_models = transcription_models or []
         self.router = router
         self.guardrail_engine = guardrail_engine
         self.gateway_cache = gateway_cache

--- a/gateway/radicalbit_ai_gateway/models/gateway_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config.py
@@ -39,12 +39,40 @@ def get_model_from_model_id(
     raise ValueError(f'Model {model_id} not found for route {route_name}')
 
 
+def _check_unique_ids(ids: list[str], label: str, scope: str = '') -> None:
+    """Raise ValueError if `ids` contains duplicates."""
+    if len(ids) != len(set(ids)):
+        raise ValueError(f'{scope}All {label} must have unique model_id.')
+
+
+def _check_disjoint_ids(groups: list[tuple[str, list[str]]], scope: str = '') -> None:
+    """Raise ValueError if any two (label, ids) groups share a model_id."""
+    for i, (label_a, ids_a) in enumerate(groups):
+        for label_b, ids_b in groups[i + 1 :]:
+            if set(ids_a) & set(ids_b):
+                raise ValueError(
+                    f'{scope}{label_a} and {label_b} must have globally unique model_id.'
+                )
+
+
+def _check_missing_references(
+    ids: list[str], defined: set[str], label: str, scope: str = ''
+) -> None:
+    """Raise ValueError if any of `ids` isn't in the top-level `defined` set."""
+    missing = sorted(mid for mid in ids if mid not in defined)
+    if missing:
+        raise ValueError(
+            f'{scope}{label} not declared in top-level {label}: {", ".join(missing)}'
+        )
+
+
 class GatewayConfig(BaseModel):
     model_config = ConfigDict(extra='forbid')
 
     routes: dict[str, GatewayRouteConfig] = {}
     chat_models: list[Model]
     embedding_models: list[Model] | None = None
+    transcription_models: list[Model] | None = None
     cache: CacheConfig | None = None
     guardrails: list[Guardrail] | None = None
     routing: list[AnyRoutingConfig] | None = None
@@ -56,6 +84,10 @@ class GatewayConfig(BaseModel):
     @property
     def embedding_models_by_id(self) -> dict[str, Model]:
         return {m.model_id: m for m in (self.embedding_models or [])}
+
+    @property
+    def transcription_models_by_id(self) -> dict[str, Model]:
+        return {m.model_id: m for m in (self.transcription_models or [])}
 
     @property
     def routing_by_name(self) -> dict[str, AnyRoutingConfig]:
@@ -110,52 +142,53 @@ class GatewayConfig(BaseModel):
     def validate_models_and_routes(self) -> Self:
         chat_ids = [m.model_id for m in self.chat_models]
         emb_ids = [m.model_id for m in (self.embedding_models or [])]
+        transcription_ids = [m.model_id for m in (self.transcription_models or [])]
 
-        if len(chat_ids) != len(set(chat_ids)):
-            raise ValueError('All chat_models must have unique model_id.')
-        if len(emb_ids) != len(set(emb_ids)):
-            raise ValueError('All embedding_models must have unique model_id.')
-        if set(chat_ids) & set(emb_ids):
-            raise ValueError(
-                'chat_models and embedding_models must have globally unique model_id.'
-            )
+        _check_unique_ids(chat_ids, 'chat_models')
+        _check_unique_ids(emb_ids, 'embedding_models')
+        _check_unique_ids(transcription_ids, 'transcription_models')
+        _check_disjoint_ids(
+            [
+                ('chat_models', chat_ids),
+                ('embedding_models', emb_ids),
+                ('transcription_models', transcription_ids),
+            ]
+        )
 
         chat_defined = set(self.chat_models_by_id.keys())
         emb_defined = set(self.embedding_models_by_id.keys())
+        transcription_defined = set(self.transcription_models_by_id.keys())
 
         # Route-level reference validation
         for route_name, route in self.routes.items():
             route_chat_ids = route.chat_models
             route_emb_ids = list(route.embedding_models or [])
+            route_transcription_ids = list(route.transcription_models or [])
+            scope = f'Route {route_name}: '
 
-            if len(route_chat_ids) != len(set(route_chat_ids)):
-                raise ValueError(
-                    f'Route {route_name}: chat_models must have unique ids.'
-                )
-            if len(route_emb_ids) != len(set(route_emb_ids)):
-                raise ValueError(
-                    f'Route {route_name}: embedding_models must have unique ids.'
-                )
-            if set(route_chat_ids) & set(route_emb_ids):
-                raise ValueError(
-                    f'Route {route_name}: chat_models and embedding_models must have globally unique model_id.'
-                )
-
-            missing_chat = sorted(
-                [mid for mid in route_chat_ids if mid not in chat_defined]
+            _check_unique_ids(route_chat_ids, 'chat_models', scope)
+            _check_unique_ids(route_emb_ids, 'embedding_models', scope)
+            _check_unique_ids(route_transcription_ids, 'transcription_models', scope)
+            _check_disjoint_ids(
+                [
+                    ('chat_models', route_chat_ids),
+                    ('embedding_models', route_emb_ids),
+                    ('transcription_models', route_transcription_ids),
+                ],
+                scope,
             )
-            if missing_chat:
-                raise ValueError(
-                    f'Route {route_name}: chat_models not declared in top-level chat_models: {", ".join(missing_chat)}'
-                )
-
-            missing_emb = sorted(
-                [mid for mid in route_emb_ids if mid not in emb_defined]
+            _check_missing_references(
+                route_chat_ids, chat_defined, 'chat_models', scope
             )
-            if missing_emb:
-                raise ValueError(
-                    f'Route {route_name}: embedding_models not declared in top-level embedding_models: {", ".join(missing_emb)}'
-                )
+            _check_missing_references(
+                route_emb_ids, emb_defined, 'embedding_models', scope
+            )
+            _check_missing_references(
+                route_transcription_ids,
+                transcription_defined,
+                'transcription_models',
+                scope,
+            )
 
             # Fallback validation
             if route.fallback:

--- a/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
@@ -197,6 +197,7 @@ AnyRoutingConfigOut = Annotated[
 class GatewayRouteConfigOut(GatewayRouteConfig):
     chat_models: list[ModelOut]
     embedding_models: list[ModelOut] | None
+    transcription_models: list[ModelOut] | None
     rate_limiting: RateLimitingOut | None
     token_limiting: TokenLimitingOut | None
     fallback: list[FallbackOut] | None

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -28,6 +28,10 @@ class GatewayRouteConfig(BaseModel):
         default=None,
         description='List of embedding model IDs for the route.',
     )
+    transcription_models: list[str] | None = Field(
+        default=None,
+        description='List of transcription model IDs for the route.',
+    )
     rate_limiting: RateLimiting | None = Field(
         default=None,
         description='Rate limiting configuration for the route.',

--- a/gateway/radicalbit_ai_gateway/models/model.py
+++ b/gateway/radicalbit_ai_gateway/models/model.py
@@ -234,7 +234,9 @@ class Model(BaseModel):
             if cost_per_second:
                 self.input_cost_per_second = Decimal(str(cost_per_second))
         if not self.input_cost_per_audio_token:
-            cost_per_audio_token = costs.get(model, {}).get('input_cost_per_audio_token')
+            cost_per_audio_token = costs.get(model, {}).get(
+                'input_cost_per_audio_token'
+            )
             if cost_per_audio_token:
                 self.input_cost_per_audio_token = Decimal(str(cost_per_audio_token))
         return self

--- a/gateway/radicalbit_ai_gateway/models/model.py
+++ b/gateway/radicalbit_ai_gateway/models/model.py
@@ -95,6 +95,14 @@ class Model(BaseModel):
         default=Decimal(),
         description='Cost for a million cache-creation input tokens — 1-hour TTL (Anthropic-specific).',
     )
+    input_cost_per_second: Decimal = Field(
+        default=Decimal(),
+        description='Cost per second of audio input (duration-based billing, e.g. whisper-1).',
+    )
+    input_cost_per_audio_token: Decimal = Field(
+        default=Decimal(),
+        description='Cost for an audio input token, distinct from a text input token (e.g. gpt-4o-transcribe family).',
+    )
 
     @field_validator(
         'input_cost_per_million_tokens', 'output_cost_per_million_tokens', mode='before'
@@ -170,12 +178,6 @@ class Model(BaseModel):
 
     @model_validator(mode='after')
     def set_costs(self) -> Self:
-        if (
-            self.input_cost_per_million_tokens
-            and self.output_cost_per_million_tokens
-            and self.input_cached_cost_per_million_tokens
-        ):
-            return self
         try:
             with open('radicalbit_ai_gateway/resources/model_prices.json') as f:
                 costs = json.load(f)
@@ -227,6 +229,14 @@ class Model(BaseModel):
                 self.input_cache_creation_1h_cost_per_million_tokens = Decimal(
                     str(cost_per_token)
                 ) * Decimal('1000000')
+        if not self.input_cost_per_second:
+            cost_per_second = costs.get(model, {}).get('input_cost_per_second')
+            if cost_per_second:
+                self.input_cost_per_second = Decimal(str(cost_per_second))
+        if not self.input_cost_per_audio_token:
+            cost_per_audio_token = costs.get(model, {}).get('input_cost_per_audio_token')
+            if cost_per_audio_token:
+                self.input_cost_per_audio_token = Decimal(str(cost_per_audio_token))
         return self
 
     @model_validator(mode='after')

--- a/gateway/radicalbit_ai_gateway/services/event_service.py
+++ b/gateway/radicalbit_ai_gateway/services/event_service.py
@@ -467,7 +467,9 @@ class EventService:
 
         chat_by_id = {m.model_id: m for m in config.chat_models}
         embed_by_id = {m.model_id: m for m in (config.embedding_models or [])}
-        transcription_by_id = {m.model_id: m for m in (config.transcription_models or [])}
+        transcription_by_id = {
+            m.model_id: m for m in (config.transcription_models or [])
+        }
 
         chat_ids: list[str] = route_dict.get('chat_models')
         resolved_chat: list[dict] = []

--- a/gateway/radicalbit_ai_gateway/services/event_service.py
+++ b/gateway/radicalbit_ai_gateway/services/event_service.py
@@ -467,6 +467,7 @@ class EventService:
 
         chat_by_id = {m.model_id: m for m in config.chat_models}
         embed_by_id = {m.model_id: m for m in (config.embedding_models or [])}
+        transcription_by_id = {m.model_id: m for m in (config.transcription_models or [])}
 
         chat_ids: list[str] = route_dict.get('chat_models')
         resolved_chat: list[dict] = []
@@ -498,6 +499,23 @@ class EventService:
                     continue
                 resolved_embed.append(embedding_model.model_dump())
             route_dict['embedding_models'] = resolved_embed
+
+        transcription_ids: list[str] | None = route_dict.get('transcription_models')
+        if transcription_ids is None:
+            route_dict['transcription_models'] = None
+        else:
+            resolved_transcription: list[dict] = []
+            for mid in transcription_ids:
+                transcription_model = transcription_by_id.get(mid)
+                if transcription_model is None:
+                    logger.warning(
+                        'Transcription model_id %s referenced by route %s not found in top-level transcription_models registry',
+                        mid,
+                        route_config.route_name,
+                    )
+                    continue
+                resolved_transcription.append(transcription_model.model_dump())
+            route_dict['transcription_models'] = resolved_transcription
 
         routing_name: str | None = route_dict.get('routing')
         if routing_name:

--- a/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
+++ b/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
@@ -100,12 +100,21 @@ def build_gateway_routes_from_config(
     routes: dict[str, GatewayRoute] = {}
     chat_by_id = gateway_config.chat_models_by_id
     emb_by_id = gateway_config.embedding_models_by_id
+    transcription_by_id = gateway_config.transcription_models_by_id
 
     for route_name, route_config in gateway_config.routes.items():
         chat_models = [chat_by_id[mid] for mid in route_config.chat_models]
         embedding_models = (
             [emb_by_id[mid] for mid in (route_config.embedding_models or [])]
             if route_config.embedding_models
+            else None
+        )
+        transcription_models = (
+            [
+                transcription_by_id[mid]
+                for mid in (route_config.transcription_models or [])
+            ]
+            if route_config.transcription_models
             else None
         )
         cache_client = get_proper_cache(route_config, redis_client)
@@ -151,6 +160,7 @@ def build_gateway_routes_from_config(
             gateway_route_config=route_config,
             chat_models=chat_models,
             embedding_models=embedding_models,
+            transcription_models=transcription_models,
             guardrail_engine=guardrail_engine,
             gateway_cache=gateway_cache,
             cost_service=cost_service,

--- a/gateway/tests/models/test_gateway_config.py
+++ b/gateway/tests/models/test_gateway_config.py
@@ -101,6 +101,60 @@ def test_invalid_cron_raises_error():
         GatewayConfig.model_validate(raw)
 
 
+def test_transcription_models_valid_config():
+    raw = {
+        'chat_models': [{'model_id': 'c1', 'model': 'openai/gpt-4o-mini'}],
+        'transcription_models': [{'model_id': 'w1', 'model': 'openai/whisper-1'}],
+        'routes': {
+            'r': {'chat_models': ['c1'], 'transcription_models': ['w1']},
+        },
+    }
+    gateway_config = GatewayConfig.model_validate(raw)
+    assert list(gateway_config.transcription_models_by_id.keys()) == ['w1']
+    assert gateway_config.routes['r'].transcription_models == ['w1']
+
+
+def test_transcription_models_reject_missing_route_reference():
+    raw = {
+        'chat_models': [{'model_id': 'c1', 'model': 'openai/gpt-4o-mini'}],
+        'transcription_models': [{'model_id': 'w1', 'model': 'openai/whisper-1'}],
+        'routes': {
+            'r': {'chat_models': ['c1'], 'transcription_models': ['unknown']},
+        },
+    }
+    with pytest.raises(
+        ValueError,
+        match='transcription_models not declared in top-level transcription_models',
+    ):
+        GatewayConfig.model_validate(raw)
+
+
+def test_transcription_models_reject_duplicate_ids_across_categories():
+    raw = {
+        'chat_models': [{'model_id': 'dup', 'model': 'openai/gpt-4o-mini'}],
+        'transcription_models': [{'model_id': 'dup', 'model': 'openai/whisper-1'}],
+    }
+    with pytest.raises(
+        ValueError,
+        match='chat_models and transcription_models must have globally unique model_id',
+    ):
+        GatewayConfig.model_validate(raw)
+
+
+def test_transcription_models_reject_duplicate_ids_within_list():
+    raw = {
+        'chat_models': [{'model_id': 'c1', 'model': 'openai/gpt-4o-mini'}],
+        'transcription_models': [
+            {'model_id': 'w1', 'model': 'openai/whisper-1'},
+            {'model_id': 'w1', 'model': 'openai/whisper-1'},
+        ],
+    }
+    with pytest.raises(
+        ValueError, match='All transcription_models must have unique model_id'
+    ):
+        GatewayConfig.model_validate(raw)
+
+
 def test_time_routing_model_id_not_in_route():
     raw = {
         'chat_models': [

--- a/gateway/tests/utils/test_gateway_route_factory.py
+++ b/gateway/tests/utils/test_gateway_route_factory.py
@@ -101,6 +101,49 @@ def test_build_gateway_routes_from_config_keys():
     assert isinstance(routes['my-route'], GatewayRoute)
 
 
+_PROJECT_CONFIG_WITH_TRANSCRIPTION_YAML = """\
+chat_models:
+  - model_id: openai-gpt4o
+    model: openai/gpt-4o-mini
+    credentials:
+      api_key: sk-test-key
+transcription_models:
+  - model_id: openai-whisper
+    model: openai/whisper-1
+    credentials:
+      api_key: sk-test-key
+routes:
+  my-route:
+    chat_models:
+      - openai-gpt4o
+    transcription_models:
+      - openai-whisper
+"""
+
+
+def test_build_gateway_routes_from_config_resolves_transcription_models():
+    """Step 3: a route's transcription_models resolve to Model instances on
+    the GatewayRoute. No invoker is built yet (that's AG-891's job — this
+    ticket, AG-896, only covers config schema + wiring).
+    """
+    resolved = resolve_secrets_from_string(_PROJECT_CONFIG_WITH_TRANSCRIPTION_YAML)
+    config = GatewayConfig.model_validate(resolved)
+    cost_service = MagicMock(spec_set=CostService)
+
+    routes = build_gateway_routes_from_config(
+        config,
+        guardrail_engine=_make_guardrail_engine(),
+        redis_client=None,
+        cost_service=cost_service,
+        httpx_client=None,
+    )
+
+    route = routes['my-route']
+    assert [m.model_id for m in route._transcription_models] == ['openai-whisper']
+    # chat_invoker is unaffected by the new wiring
+    assert route.chat_invoker is not None
+
+
 def test_build_gateway_routes_empty_config():
     """Step 3: an empty config produces an empty routes dict."""
     config = GatewayConfig.model_validate({'routes': {}, 'chat_models': []})


### PR DESCRIPTION
# PR Summary: AG-896

Extends the gateway's `config.yaml` schema with a new **`transcription_models`** category, mirroring the existing `chat_models`/`embedding_models` pattern (own top-level list, own per-route reference list, cross-category uniqueness checks). It also resolves route-level `transcription_models` references into full model objects in the dashboard API response, exactly like `chat_models`/`embedding_models` already are. This is a config-schema + read-model change: no invoker is built and no `/v1/audio/transcriptions` HTTP endpoint is added here — that's AG-891, tracked separately.

---

## Config Schema Changes

These are internal Pydantic models used to parse/validate `config.yaml`, not HTTP request/response DTOs — shown as YAML rather than JSON since that's how they're actually authored.

### `GatewayConfig` (MODIFIED)

**Changes:**
```diff
  chat_models: Model[]
  embedding_models: Model[] | null
+ transcription_models: Model[] | null  (added)
  cache: CacheConfig | null
  guardrails: Guardrail[] | null
  routing: RoutingConfig[] | null
```

| Field | Type | Description |
|-------|------|-------------|
| `chat_models` | object[] | Chat model definitions (unchanged) |
| `embedding_models` | object[] \| null | Embedding model definitions (unchanged) |
| `transcription_models` **NEW** | object[] \| null | Transcription model definitions. No allowlist of supported model names — any identifier is accepted, same as chat/embedding |
| `routes` | object | Per-route config (see `GatewayRouteConfig` below) |

**Example config:**
```yaml
chat_models:
  - model_id: openai-gpt4o
    model: openai/gpt-4o-mini
    credentials:
      api_key: sk-test-key

transcription_models:
  - model_id: openai-whisper
    model: openai/whisper-1
    credentials:
      api_key: sk-test-key

routes:
  my-route:
    chat_models:
      - openai-gpt4o
    transcription_models:
      - openai-whisper
```

**New property:** `GatewayConfig.transcription_models_by_id -> dict[str, Model]` — mirrors `chat_models_by_id`/`embedding_models_by_id`.

**Validation added** (in `validate_models_and_routes`): `transcription_models` now participates in the same checks already applied to chat/embedding —
- unique `model_id` within the top-level list and within each route's reference list
- globally unique `model_id` across all three categories (a model can't be declared as both e.g. `chat_models` and `transcription_models`)
- every route-level `transcription_models` reference must exist in the top-level list

To keep the validator readable with a third category, the duplicated unique/disjoint/missing-reference logic was extracted into three small module-level helpers (`_check_unique_ids`, `_check_disjoint_ids`, `_check_missing_references`), reused for chat/embedding/transcription alike.

---

### `GatewayRouteConfig` (MODIFIED)

**Changes:**
```diff
  chat_models: string[]
  embedding_models: string[] | null
+ transcription_models: string[] | null  (added)
  rate_limiting: RateLimiting | null
  ...
```

| Field | Type | Description |
|-------|------|-------------|
| `transcription_models` **NEW** | string[] \| null | Transcription model IDs referenced by this route (must exist in the top-level `transcription_models` list) |

---

### `Model` (MODIFIED)

**Changes:**
```diff
  input_cost_per_million_tokens: decimal
  output_cost_per_million_tokens: decimal
  input_cached_cost_per_million_tokens: decimal
  input_cache_creation_5m_cost_per_million_tokens: decimal
  input_cache_creation_1h_cost_per_million_tokens: decimal
+ input_cost_per_second: decimal  (added)
+ input_cost_per_audio_token: decimal  (added)
```

| Field | Type | Description |
|-------|------|-------------|
| `input_cost_per_second` **NEW** | decimal | Cost per second of audio input (duration-based billing, e.g. `whisper-1`) |
| `input_cost_per_audio_token` **NEW** | decimal | Cost of an audio input token, distinct from a text input token (e.g. `gpt-4o-transcribe` family) |

Both are auto-populated from `resources/model_prices.json` in the `set_costs` validator, same mechanism already used for the existing token-cost fields — no formula/calculation logic is added here (that's AG-892); these are just the raw price points made available on `Model`.

**Note:** the `set_costs` validator's early-return short-circuit (skip reading `model_prices.json` when the three original cost fields were all already explicitly set) was removed. It was a pure performance optimization that would have silently prevented the two new fields from being populated whenever a config explicitly set `input_cost_per_million_tokens`/`output_cost_per_million_tokens`/`input_cached_cost_per_million_tokens` (e.g. for `gpt-4o-transcribe`, which does have real per-token pricing). Removing it only means the price file is read once per `Model` at startup, with no behavior change for existing chat/embedding configs (all covered by the existing test suite).

---

## DTO Changes

### `GatewayRouteConfigOut` (MODIFIED)

**Changes:**
```diff
  chat_models: ModelOut[]
  embedding_models: ModelOut[] | null
+ transcription_models: ModelOut[] | null  (added)
  rate_limiting: RateLimitingOut | null
  ...
```

| Field | Type | Description |
|-------|------|-------------|
| `transcriptionModels` **NEW** | object[] \| null | Transcription models referenced by the route, fully resolved (same shape/masking as `chatModels`/`embeddingModels`) |

`EventService._build_route_config_out` now resolves a route's `transcription_models` id list into full `ModelOut` objects (looked up from the top-level `transcription_models` registry), mirroring the pre-existing `chat_models`/`embedding_models` resolution exactly — including a warning log if a route references a transcription model id that doesn't exist in the top-level registry (defensive; blocked at config-validation time already).

**Example response** (`GET /dashboard/projects/{projectUuid}/routes/{routeName}`, `configuration` field only):
```json
{
  "routeName": "my-route",
  "configuration": {
    "routeName": "my-route",
    "chatModels": [
      {
        "modelId": "openai-gpt4o",
        "model": "openai/gpt-4o-mini",
        "credentials": { "apiKey": "**********" }
      }
    ],
    "embeddingModels": null,
    "transcriptionModels": [
      {
        "modelId": "openai-whisper",
        "model": "openai/whisper-1",
        "credentials": { "apiKey": "**********" },
        "inputCostPerSecond": "0.0001",
        "inputCostPerAudioToken": "0"
      }
    ]
  }
}
```

**Used by:** `GET /dashboard/projects/{projectUuid}/routes` and `GET /dashboard/projects/{projectUuid}/routes/{routeName}` (both via `GatewayRouteOut.configuration`).

---

## Affected Endpoints

No new endpoints or path/query/body signature changes. The two existing dashboard endpoints below now additionally return `transcriptionModels` inside `configuration` whenever a route has them configured:

- `GET /dashboard/projects/{projectUuid}/routes`
- `GET /dashboard/projects/{projectUuid}/routes/{routeName}`

The `/v1/audio/transcriptions` endpoint (and the invoker that calls providers) is implemented separately on top of this branch (AG-891).

---

## Other Changes

- `ai_gateway.py` — `GatewayRoute.__init__` accepts `transcription_models: list[Model] | None` and stores it on `self._transcription_models`. No invoker is constructed from it in this PR.
- `utils/gateway_route_factory.py` — `build_gateway_routes_from_config` resolves a route's `transcription_models` IDs into `Model` instances via `transcription_models_by_id` and passes them to `GatewayRoute`.
- `tests/models/test_gateway_config.py` — new tests: valid config with `transcription_models`, missing route reference, duplicate ids across categories, duplicate ids within a list.
- `tests/utils/test_gateway_route_factory.py` — new test verifying a route's `transcription_models` resolve to the correct `Model` instances end-to-end (YAML → `GatewayConfig` → `build_gateway_routes_from_config`).
