### PR TITLE
feat: add prompts/res

### DIFF
--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -2,6 +2,7 @@ import asyncio
 from collections.abc import Mapping
 from importlib.metadata import PackageNotFoundError, version as _package_version
 import logging
+from urllib.parse import quote, unquote
 from uuid import UUID
 
 from fastapi import Request
@@ -27,6 +28,14 @@ LATEST_PROTOCOL_VERSION = '2025-11-25'
 PROTOCOL_VERSION_HEADER = 'mcp-protocol-version'
 MCP_SERVER_NAME = 'radicalbit-ai-gateway-mcp'
 
+# Resources are identified by an arbitrary URI, not a name, so the
+# '{alias}__{name}' prefix used for tools/prompts can't apply directly (an
+# upstream URI's own scheme would collide with it). Instead the alias and the
+# original URI are packed into an opaque, non-hierarchical URI (no '//'
+# authority, like 'mailto:' or 'urn:') with both parts percent-encoded, so the
+# encoding never depends on either's character set.
+RESOURCE_URI_SCHEME = 'mcp-resource'
+
 
 def gateway_version() -> str:
     try:
@@ -46,16 +55,37 @@ def negotiate_protocol_version(requested: object) -> str:
     return LATEST_PROTOCOL_VERSION
 
 
-def split_tool_name(name: str) -> tuple[str, str] | None:
-    """Split ``'{alias}__{tool}'`` on the first separator.
+def split_alias_name(name: str) -> tuple[str, str] | None:
+    """Split ``'{alias}__{name}'`` on the first separator.
 
-    Returns ``(alias, tool)`` or ``None`` when the name carries no alias
-    prefix. Tool names containing further ``'__'`` keep them intact.
+    Returns ``(alias, name)`` or ``None`` when the name carries no alias
+    prefix. Names containing further ``'__'`` keep them intact. Used for both
+    tool and prompt names, which share the same ``{alias}__{name}`` scheme.
     """
-    alias, sep, tool = name.partition(ALIAS_TOOL_SEPARATOR)
-    if not sep or not alias or not tool:
+    alias, sep, rest = name.partition(ALIAS_TOOL_SEPARATOR)
+    if not sep or not alias or not rest:
         return None
-    return alias, tool
+    return alias, rest
+
+
+def encode_resource_uri(alias: str, uri: str) -> str:
+    """Wrap an upstream resource URI so ``resources/read`` can route it back."""
+    return f'{RESOURCE_URI_SCHEME}:{quote(alias, safe="")}/{quote(uri, safe="")}'
+
+
+def decode_resource_uri(uri: str) -> tuple[str, str] | None:
+    """Reverse :func:`encode_resource_uri`.
+
+    Returns ``(alias, original_uri)`` or ``None`` if ``uri`` isn't one of our
+    wrapped resource URIs.
+    """
+    prefix = f'{RESOURCE_URI_SCHEME}:'
+    if not uri.startswith(prefix):
+        return None
+    alias_enc, sep, uri_enc = uri[len(prefix) :].partition('/')
+    if not sep or not alias_enc or not uri_enc:
+        return None
+    return unquote(alias_enc), unquote(uri_enc)
 
 
 class _McpMethodError(Exception):
@@ -181,6 +211,16 @@ class McpService:
                 result = await self._tools_list(servers, client_headers)
             elif method == 'tools/call':
                 result = await self._tools_call(params or {}, servers, client_headers)
+            elif method == 'prompts/list':
+                result = await self._prompts_list(servers, client_headers)
+            elif method == 'prompts/get':
+                result = await self._prompts_get(params or {}, servers, client_headers)
+            elif method == 'resources/list':
+                result = await self._resources_list(servers, client_headers)
+            elif method == 'resources/read':
+                result = await self._resources_read(
+                    params or {}, servers, client_headers
+                )
             else:
                 return McpDispatchResult(
                     status_code=200,
@@ -217,7 +257,7 @@ class McpService:
             'protocolVersion': negotiate_protocol_version(
                 params.get('protocolVersion')
             ),
-            'capabilities': {'tools': {}},
+            'capabilities': {'tools': {}, 'prompts': {}, 'resources': {}},
             'serverInfo': {'name': MCP_SERVER_NAME, 'version': gateway_version()},
         }
 
@@ -285,7 +325,7 @@ class McpService:
             raise _McpMethodError(
                 jsonrpc.INVALID_PARAMS, 'params.arguments must be an object'
             )
-        split = split_tool_name(name)
+        split = split_alias_name(name)
         server = (
             next((s for s in servers if s.alias == split[0]), None) if split else None
         )
@@ -295,6 +335,156 @@ class McpService:
             server, split[1], arguments, client_headers=client_headers
         )
         return result.model_dump(mode='json', by_alias=True, exclude_none=True)
+
+    async def _prompts_list(
+        self,
+        servers: list[AnyMcpServer],
+        client_headers: Mapping[str, str] | None,
+    ) -> dict:
+        """Fan out to the route's upstreams and merge their prompts.
+
+        Same shape as :meth:`_tools_list`: each prompt name is prefixed
+        ``'{alias}__{name}'``; a failing upstream yields a partial list
+        (logged), unless every upstream failed.
+        """
+        if not servers:
+            return {'prompts': []}
+        results = await asyncio.gather(
+            *(
+                self._upstream_client.list_prompts(s, client_headers=client_headers)
+                for s in servers
+            ),
+            return_exceptions=True,
+        )
+        prompts: list[dict] = []
+        failed: list[str] = []
+        for server, result in zip(servers, results, strict=True):
+            if isinstance(result, BaseException):
+                failed.append(server.alias)
+                continue
+            for prompt in result.prompts:
+                data = prompt.model_dump(mode='json', by_alias=True, exclude_none=True)
+                data['name'] = f'{server.alias}{ALIAS_TOOL_SEPARATOR}{prompt.name}'
+                prompts.append(data)
+        if failed:
+            if len(failed) == len(servers):
+                raise _McpMethodError(
+                    JSON_RPC_UPSTREAM_ERROR, 'All upstream MCP servers failed'
+                )
+            logger.warning(
+                'prompts/list: partial result, upstream MCP servers failed: %s',
+                ', '.join(failed),
+            )
+        return {'prompts': prompts}
+
+    async def _prompts_get(
+        self,
+        params: dict,
+        servers: list[AnyMcpServer],
+        client_headers: Mapping[str, str] | None,
+    ) -> dict:
+        """Resolve the ``'{alias}__{name}'`` prefix and forward the call.
+
+        Same shape as :meth:`_tools_call`.
+        """
+        name = params.get('name')
+        if not isinstance(name, str) or not name:
+            raise _McpMethodError(
+                jsonrpc.INVALID_PARAMS, 'prompts/get requires a string params.name'
+            )
+        arguments = params.get('arguments')
+        if arguments is not None and not isinstance(arguments, dict):
+            raise _McpMethodError(
+                jsonrpc.INVALID_PARAMS, 'params.arguments must be an object'
+            )
+        split = split_alias_name(name)
+        server = (
+            next((s for s in servers if s.alias == split[0]), None) if split else None
+        )
+        if split is None or server is None:
+            raise _McpMethodError(jsonrpc.INVALID_PARAMS, f'Unknown prompt: {name}')
+        result = await self._upstream_client.get_prompt(
+            server, split[1], arguments, client_headers=client_headers
+        )
+        return result.model_dump(mode='json', by_alias=True, exclude_none=True)
+
+    async def _resources_list(
+        self,
+        servers: list[AnyMcpServer],
+        client_headers: Mapping[str, str] | None,
+    ) -> dict:
+        """Fan out to the route's upstreams and merge their resources.
+
+        Each resource ``uri`` is wrapped via :func:`encode_resource_uri` so
+        ``resources/read`` can route it back to the right upstream; a failing
+        upstream yields a partial list (logged), unless every upstream failed.
+        """
+        if not servers:
+            return {'resources': []}
+        results = await asyncio.gather(
+            *(
+                self._upstream_client.list_resources(s, client_headers=client_headers)
+                for s in servers
+            ),
+            return_exceptions=True,
+        )
+        resources: list[dict] = []
+        failed: list[str] = []
+        for server, result in zip(servers, results, strict=True):
+            if isinstance(result, BaseException):
+                failed.append(server.alias)
+                continue
+            for resource in result.resources:
+                data = resource.model_dump(
+                    mode='json', by_alias=True, exclude_none=True
+                )
+                data['uri'] = encode_resource_uri(server.alias, data['uri'])
+                resources.append(data)
+        if failed:
+            if len(failed) == len(servers):
+                raise _McpMethodError(
+                    JSON_RPC_UPSTREAM_ERROR, 'All upstream MCP servers failed'
+                )
+            logger.warning(
+                'resources/list: partial result, upstream MCP servers failed: %s',
+                ', '.join(failed),
+            )
+        return {'resources': resources}
+
+    async def _resources_read(
+        self,
+        params: dict,
+        servers: list[AnyMcpServer],
+        client_headers: Mapping[str, str] | None,
+    ) -> dict:
+        """Unwrap the aliased ``uri`` and forward the read.
+
+        The returned ``contents[].uri`` is re-wrapped so the raw upstream URI
+        never reaches the client (mirrors how ``tools/list``'s prefix keeps
+        the upstream's raw tool name from being client-visible).
+        """
+        uri = params.get('uri')
+        if not isinstance(uri, str) or not uri:
+            raise _McpMethodError(
+                jsonrpc.INVALID_PARAMS, 'resources/read requires a string params.uri'
+            )
+        decoded = decode_resource_uri(uri)
+        server = (
+            next((s for s in servers if s.alias == decoded[0]), None)
+            if decoded
+            else None
+        )
+        if decoded is None or server is None:
+            raise _McpMethodError(jsonrpc.INVALID_PARAMS, f'Unknown resource: {uri}')
+        alias, upstream_uri = decoded
+        result = await self._upstream_client.read_resource(
+            server, upstream_uri, client_headers=client_headers
+        )
+        data = result.model_dump(mode='json', by_alias=True, exclude_none=True)
+        for content in data.get('contents', []):
+            if 'uri' in content:
+                content['uri'] = encode_resource_uri(alias, content['uri'])
+        return data
 
     def _validate_origin(self, request: Request) -> None:
         """DNS-rebinding defense: reject browser Origins not in the allowlist.

--- a/gateway/tests/mcp/test_mcp_service.py
+++ b/gateway/tests/mcp/test_mcp_service.py
@@ -10,8 +10,10 @@ from radicalbit_ai_gateway.services.mcp_service import (
     LATEST_PROTOCOL_VERSION,
     MCP_SERVER_NAME,
     McpService,
+    decode_resource_uri,
+    encode_resource_uri,
     negotiate_protocol_version,
-    split_tool_name,
+    split_alias_name,
 )
 
 GITHUB = McpHttpServer(alias='github', url='https://github.example.com/mcp/')
@@ -25,6 +27,14 @@ def _tool(name: str, description: str = 'a tool') -> types.Tool:
         description=description,
         inputSchema={'type': 'object', 'properties': {}},
     )
+
+
+def _prompt(name: str, description: str = 'a prompt') -> types.Prompt:
+    return types.Prompt(name=name, description=description)
+
+
+def _resource(uri: str, name: str = 'a resource') -> types.Resource:
+    return types.Resource(uri=uri, name=name)
 
 
 def _service(upstream_client=None) -> McpService:
@@ -57,13 +67,31 @@ def test_negotiate_falls_back_to_latest(version):
     assert negotiate_protocol_version(version) == LATEST_PROTOCOL_VERSION
 
 
-def test_split_tool_name():
-    assert split_tool_name('github__get_issue') == ('github', 'get_issue')
-    # only the first '__' separates alias and tool
-    assert split_tool_name('github__ns__tool') == ('github', 'ns__tool')
-    assert split_tool_name('no_separator') is None
-    assert split_tool_name('__tool') is None
-    assert split_tool_name('alias__') is None
+def test_split_alias_name():
+    assert split_alias_name('github__get_issue') == ('github', 'get_issue')
+    # only the first '__' separates alias and name
+    assert split_alias_name('github__ns__tool') == ('github', 'ns__tool')
+    assert split_alias_name('no_separator') is None
+    assert split_alias_name('__tool') is None
+    assert split_alias_name('alias__') is None
+
+
+def test_resource_uri_round_trips():
+    encoded = encode_resource_uri('github', 'https://example.com/a/b?x=1')
+    assert decode_resource_uri(encoded) == ('github', 'https://example.com/a/b?x=1')
+
+
+def test_resource_uri_round_trips_reserved_characters():
+    encoded = encode_resource_uri('my alias/x', 'file:///etc/hosts#frag')
+    assert decode_resource_uri(encoded) == ('my alias/x', 'file:///etc/hosts#frag')
+
+
+@pytest.mark.parametrize(
+    'uri',
+    ['https://example.com/plain', 'mcp-resource:no-slash', 'mcp-resource:/', ''],
+)
+def test_decode_resource_uri_rejects_foreign_or_malformed(uri):
+    assert decode_resource_uri(uri) is None
 
 
 # ---------------------------------------------------------------------------
@@ -118,10 +146,10 @@ async def test_notifications_get_202_and_no_body():
 
 
 async def test_unknown_method_is_32601():
-    result = await _service()._dispatch(_request('resources/list'), SERVERS, None)
+    result = await _service()._dispatch(_request('completion/complete'), SERVERS, None)
     assert result.status_code == 200
     assert result.payload['error']['code'] == -32601
-    assert 'resources/list' in result.payload['error']['message']
+    assert 'completion/complete' in result.payload['error']['message']
 
 
 async def test_non_object_params_is_32602():
@@ -137,7 +165,7 @@ async def test_non_object_params_is_32602():
 # ---------------------------------------------------------------------------
 
 
-async def test_initialize_advertises_tools_only():
+async def test_initialize_advertises_capabilities():
     result = await _service()._dispatch(
         _request('initialize', params={'protocolVersion': '2025-06-18'}),
         SERVERS,
@@ -146,7 +174,12 @@ async def test_initialize_advertises_tools_only():
     assert result.status_code == 200
     payload_result = result.payload['result']
     assert payload_result['protocolVersion'] == '2025-06-18'
-    assert payload_result['capabilities'] == {'tools': {}}  # no listChanged
+    # no listChanged on any of the three
+    assert payload_result['capabilities'] == {
+        'tools': {},
+        'prompts': {},
+        'resources': {},
+    }
     assert payload_result['serverInfo']['name'] == MCP_SERVER_NAME
     assert payload_result['serverInfo']['version']
 
@@ -337,3 +370,308 @@ async def test_unexpected_exception_is_sanitized_internal_error():
     assert result.status_code == 200
     assert result.payload['error']['code'] == -32603
     assert 'secret detail' not in result.payload['error']['message']
+
+
+# ---------------------------------------------------------------------------
+# prompts/list
+# ---------------------------------------------------------------------------
+
+
+async def test_prompts_list_fans_out_and_prefixes():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_prompts = AsyncMock(
+        side_effect=[
+            types.ListPromptsResult(
+                prompts=[_prompt('summarize'), _prompt('translate')]
+            ),
+            types.ListPromptsResult(prompts=[_prompt('search')]),
+        ]
+    )
+    headers = {'x-user-jwt': 'jwt-1'}
+
+    result = await _service(client)._dispatch(
+        _request('prompts/list'), SERVERS, headers
+    )
+
+    assert result.status_code == 200
+    prompts = result.payload['result']['prompts']
+    assert [p['name'] for p in prompts] == [
+        'github__summarize',
+        'github__translate',
+        'jira__search',
+    ]
+    assert prompts[0]['description'] == 'a prompt'
+    for call, server in zip(client.list_prompts.await_args_list, SERVERS, strict=True):
+        assert call.args == (server,)
+        assert call.kwargs['client_headers'] == headers
+
+
+async def test_prompts_list_without_servers_is_empty():
+    result = await _service()._dispatch(_request('prompts/list'), [], None)
+    assert result.status_code == 200
+    assert result.payload['result'] == {'prompts': []}
+
+
+async def test_prompts_list_tolerates_one_failing_upstream():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_prompts = AsyncMock(
+        side_effect=[
+            McpUpstreamError('github', 'boom'),
+            types.ListPromptsResult(prompts=[_prompt('search')]),
+        ]
+    )
+    result = await _service(client)._dispatch(_request('prompts/list'), SERVERS, None)
+    assert result.status_code == 200
+    assert [p['name'] for p in result.payload['result']['prompts']] == ['jira__search']
+
+
+async def test_prompts_list_all_upstreams_failing_is_32000():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_prompts = AsyncMock(side_effect=McpUpstreamError('github', 'boom'))
+    result = await _service(client)._dispatch(_request('prompts/list'), SERVERS, None)
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32000
+
+
+# ---------------------------------------------------------------------------
+# prompts/get
+# ---------------------------------------------------------------------------
+
+
+async def test_prompts_get_forwards_and_passes_result_through():
+    result = types.GetPromptResult(
+        description='a rendered prompt',
+        messages=[
+            types.PromptMessage(
+                role='user', content=types.TextContent(type='text', text='hello')
+            )
+        ],
+    )
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.get_prompt = AsyncMock(return_value=result)
+    headers = {'x-user-jwt': 'jwt-1'}
+
+    dispatch_result = await _service(client)._dispatch(
+        _request(
+            'prompts/get',
+            params={'name': 'github__summarize', 'arguments': {'id': '42'}},
+        ),
+        SERVERS,
+        headers,
+    )
+
+    assert dispatch_result.status_code == 200
+    assert dispatch_result.payload['result']['description'] == 'a rendered prompt'
+    client.get_prompt.assert_awaited_once_with(
+        GITHUB, 'summarize', {'id': '42'}, client_headers=headers
+    )
+
+
+async def test_prompts_get_splits_on_first_separator_only():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.get_prompt = AsyncMock(return_value=types.GetPromptResult(messages=[]))
+    await _service(client)._dispatch(
+        _request('prompts/get', params={'name': 'github__ns__prompt'}), SERVERS, None
+    )
+    assert client.get_prompt.await_args.args[1] == 'ns__prompt'
+
+
+@pytest.mark.parametrize(
+    'name', ['unknown__prompt', 'no_separator', 'github', '', 'confluence__x']
+)
+async def test_prompts_get_unknown_prompt_is_32602(name):
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.get_prompt = AsyncMock()
+    result = await _service(client)._dispatch(
+        _request('prompts/get', params={'name': name}), SERVERS, None
+    )
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32602
+    client.get_prompt.assert_not_awaited()
+
+
+async def test_prompts_get_alias_outside_scope_is_32602():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.get_prompt = AsyncMock()
+    result = await _service(client)._dispatch(
+        _request('prompts/get', params={'name': 'jira__search'}), [GITHUB], None
+    )
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32602
+    client.get_prompt.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    'params',
+    [{}, {'name': 7}, {'name': 'github__x', 'arguments': 'not-a-dict'}],
+)
+async def test_prompts_get_bad_params_is_32602(params):
+    result = await _service()._dispatch(
+        _request('prompts/get', params=params), SERVERS, None
+    )
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32602
+
+
+async def test_prompts_get_upstream_error_maps_to_jsonrpc_error():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.get_prompt = AsyncMock(
+        side_effect=McpUpstreamError('github', "Upstream MCP server 'github' timed out")
+    )
+    result = await _service(client)._dispatch(
+        _request('prompts/get', params={'name': 'github__summarize'}), SERVERS, None
+    )
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32000
+    assert 'timed out' in result.payload['error']['message']
+
+
+# ---------------------------------------------------------------------------
+# resources/list
+# ---------------------------------------------------------------------------
+
+
+async def test_resources_list_fans_out_and_aliases_uris():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_resources = AsyncMock(
+        side_effect=[
+            types.ListResourcesResult(
+                resources=[_resource('https://github.example.com/readme')]
+            ),
+            types.ListResourcesResult(
+                resources=[_resource('https://jira.example.com/board')]
+            ),
+        ]
+    )
+    headers = {'x-user-jwt': 'jwt-1'}
+
+    result = await _service(client)._dispatch(
+        _request('resources/list'), SERVERS, headers
+    )
+
+    assert result.status_code == 200
+    resources = result.payload['result']['resources']
+    assert decode_resource_uri(resources[0]['uri']) == (
+        'github',
+        'https://github.example.com/readme',
+    )
+    assert decode_resource_uri(resources[1]['uri']) == (
+        'jira',
+        'https://jira.example.com/board',
+    )
+    assert resources[0]['name'] == 'a resource'
+    for call, server in zip(
+        client.list_resources.await_args_list, SERVERS, strict=True
+    ):
+        assert call.args == (server,)
+        assert call.kwargs['client_headers'] == headers
+
+
+async def test_resources_list_without_servers_is_empty():
+    result = await _service()._dispatch(_request('resources/list'), [], None)
+    assert result.status_code == 200
+    assert result.payload['result'] == {'resources': []}
+
+
+async def test_resources_list_tolerates_one_failing_upstream():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_resources = AsyncMock(
+        side_effect=[
+            McpUpstreamError('github', 'boom'),
+            types.ListResourcesResult(
+                resources=[_resource('https://jira.example.com/board')]
+            ),
+        ]
+    )
+    result = await _service(client)._dispatch(_request('resources/list'), SERVERS, None)
+    assert result.status_code == 200
+    resources = result.payload['result']['resources']
+    assert len(resources) == 1
+    assert decode_resource_uri(resources[0]['uri'])[0] == 'jira'
+
+
+async def test_resources_list_all_upstreams_failing_is_32000():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_resources = AsyncMock(side_effect=McpUpstreamError('github', 'boom'))
+    result = await _service(client)._dispatch(_request('resources/list'), SERVERS, None)
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32000
+
+
+# ---------------------------------------------------------------------------
+# resources/read
+# ---------------------------------------------------------------------------
+
+
+async def test_resources_read_forwards_and_realiases_result():
+    upstream_uri = 'https://github.example.com/readme'
+    result = types.ReadResourceResult(
+        contents=[
+            types.TextResourceContents(
+                uri=upstream_uri, text='hello', mimeType='text/plain'
+            )
+        ]
+    )
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.read_resource = AsyncMock(return_value=result)
+    headers = {'x-user-jwt': 'jwt-1'}
+    encoded = encode_resource_uri('github', upstream_uri)
+
+    dispatch_result = await _service(client)._dispatch(
+        _request('resources/read', params={'uri': encoded}), SERVERS, headers
+    )
+
+    assert dispatch_result.status_code == 200
+    contents = dispatch_result.payload['result']['contents']
+    assert contents[0]['text'] == 'hello'
+    assert decode_resource_uri(contents[0]['uri']) == ('github', upstream_uri)
+    client.read_resource.assert_awaited_once_with(
+        GITHUB, upstream_uri, client_headers=headers
+    )
+
+
+@pytest.mark.parametrize(
+    'params',
+    [
+        {},
+        {'uri': 7},
+        {'uri': ''},
+        {'uri': 'https://example.com/plain'},  # not one of our wrapped URIs
+        {'uri': encode_resource_uri('confluence', 'https://x')},  # out of scope
+    ],
+)
+async def test_resources_read_bad_or_unknown_uri_is_32602(params):
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.read_resource = AsyncMock()
+    result = await _service(client)._dispatch(
+        _request('resources/read', params=params), SERVERS, None
+    )
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32602
+    client.read_resource.assert_not_awaited()
+
+
+async def test_resources_read_alias_outside_scope_is_32602():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.read_resource = AsyncMock()
+    encoded = encode_resource_uri('jira', 'https://jira.example.com/board')
+    result = await _service(client)._dispatch(
+        _request('resources/read', params={'uri': encoded}), [GITHUB], None
+    )
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32602
+    client.read_resource.assert_not_awaited()
+
+
+async def test_resources_read_upstream_error_maps_to_jsonrpc_error():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.read_resource = AsyncMock(
+        side_effect=McpUpstreamError('github', "Upstream MCP server 'github' timed out")
+    )
+    encoded = encode_resource_uri('github', 'https://github.example.com/readme')
+    result = await _service(client)._dispatch(
+        _request('resources/read', params={'uri': encoded}), SERVERS, None
+    )
+    assert result.status_code == 200
+    assert result.payload['error']['code'] == -32000
+    assert 'timed out' in result.payload['error']['message']

--- a/gateway/tests/routes/test_mcp_route.py
+++ b/gateway/tests/routes/test_mcp_route.py
@@ -219,7 +219,7 @@ def test_initialize_lifecycle():
     assert res.status_code == 200
     result = res.json()['result']
     assert result['protocolVersion'] == '2025-06-18'
-    assert result['capabilities'] == {'tools': {}}
+    assert result['capabilities'] == {'tools': {}, 'prompts': {}, 'resources': {}}
 
     res = client.post(
         PATH,
@@ -237,7 +237,7 @@ def test_unknown_method_is_32601_over_200():
     client, _ = _make_client()
     res = client.post(
         PATH,
-        json={'jsonrpc': '2.0', 'id': 1, 'method': 'prompts/list'},
+        json={'jsonrpc': '2.0', 'id': 1, 'method': 'completion/complete'},
         headers=AUTH,
     )
     assert res.status_code == 200


### PR DESCRIPTION
## Summary

Extends the inbound MCP proxy (`McpService`) to support the `prompts/list`, `prompts/get`, `resources/list`, and `resources/read` JSON-RPC methods, in addition to the existing `tools/list`/`tools/call`. External MCP clients can now discover and fetch prompts and resources exposed by a route's upstream MCP servers, fanned out and merged the same way tools already are.

## Description

The proxy previously only surfaced `tools/*`. This PR wires the service-level dispatch for prompts and resources on top of the `list_prompts`/`get_prompt`/`list_resources`/`read_resource` methods already present on `McpUpstreamClient` (added in a prior PR). Prompts follow the exact same shape as tools: names are namespaced as `'{alias}__{name}'`, fan-out tolerates partial upstream failure, and an all-failed fan-out surfaces as a JSON-RPC error.

`split_tool_name` was renamed to `split_alias_name` since it's now shared by both tools and prompts (same `{alias}__{name}` scheme). `initialize` now advertises `prompts: {}` and `resources: {}` capabilities alongside `tools: {}` (no `listChanged` support on any of the three).

## Key Changes

- `radicalbit_ai_gateway/services/mcp_service.py`:
  - Renamed `split_tool_name` → `split_alias_name` (used by both tool and prompt name resolution).
  - Added `RESOURCE_URI_SCHEME`, `encode_resource_uri`, `decode_resource_uri` for opaque, round-trippable resource URI aliasing.
  - Added `_prompts_list` / `_prompts_get`, structured identically to `_tools_list` / `_tools_call` (concurrent fan-out, partial-failure tolerance, alias-prefix resolution).
  - Added `_resources_list` / `_resources_read`: list responses get their `uri` wrapped via `encode_resource_uri`; reads unwrap the incoming `uri` to resolve the upstream server, then re-wrap every `contents[].uri` in the result before returning it.
  - `_dispatch` routes the four new methods; `_initialize` capabilities now include `prompts` and `resources`.
- `tests/mcp/test_mcp_service.py`: full coverage for the new methods — happy path, empty servers, one-upstream failure, all-upstreams failure, malformed/missing params, and out-of-route-scope alias rejection for both prompts and resources, plus round-trip and rejection tests for `encode_resource_uri`/`decode_resource_uri`. Updated existing tests for the `split_alias_name` rename and the expanded `capabilities` payload.
- `tests/routes/test_mcp_route.py`: updated the `initialize` capabilities assertion and swapped the "unknown method" fixture from `resources/list` (now implemented) to `completion/complete`.


## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
