### PR TITLE
feat: add cost calculation for the audio transcription endpoint

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -10,7 +10,7 @@ from langchain_core.messages import (
     SystemMessage,
 )
 import numpy as np
-from openai.types.audio.transcription import Transcription
+from openai.types.audio.transcription import Transcription, UsageDuration, UsageTokens
 from openai.types.chat import ChatCompletionToolChoiceOptionParam
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_tool_param import ChatCompletionToolParam
@@ -1624,7 +1624,7 @@ class GatewayRoute:
 
     async def _count_transcription_usage(
         self,
-        usage,
+        usage: UsageTokens | UsageDuration | None,
         model_selected: Model,
     ) -> None:
         """Count budget usage from a transcription response, mirroring _count_usage.
@@ -1637,16 +1637,9 @@ class GatewayRoute:
 
         if usage.type == 'duration':
             if model_selected.input_cost_per_second:
-                # `count_input` is plain count x price; for whisper-1-style
-                # duration billing `token_count` carries seconds (a float) and
-                # `input_cost_per_token` the per-second price. count_input's
-                # arithmetic assumes a plain float price (as chat/embedding
-                # always pass an int token_count against a Decimal price,
-                # relying on int*Decimal support) — cast here rather than in
-                # count_input, so chat/embedding's math stays untouched.
-                await self.budget_limiter.count_input(
-                    token_count=usage.seconds,
-                    input_cost_per_token=float(model_selected.input_cost_per_second),
+                await self.budget_limiter.count_duration(
+                    seconds=usage.seconds,
+                    cost_per_second=float(model_selected.input_cost_per_second),
                 )
             return
 

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -1638,11 +1638,15 @@ class GatewayRoute:
         if usage.type == 'duration':
             if model_selected.input_cost_per_second:
                 # `count_input` is plain count x price; for whisper-1-style
-                # duration billing `token_count` carries seconds and
-                # `input_cost_per_token` the per-second price.
+                # duration billing `token_count` carries seconds (a float) and
+                # `input_cost_per_token` the per-second price. count_input's
+                # arithmetic assumes a plain float price (as chat/embedding
+                # always pass an int token_count against a Decimal price,
+                # relying on int*Decimal support) — cast here rather than in
+                # count_input, so chat/embedding's math stays untouched.
                 await self.budget_limiter.count_input(
                     token_count=usage.seconds,
-                    input_cost_per_token=model_selected.input_cost_per_second,
+                    input_cost_per_token=float(model_selected.input_cost_per_second),
                 )
             return
 

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -723,9 +723,7 @@ class GatewayRoute:
             project_name=self.project_name,
         )
 
-        if self.budget_limiter:
-            # TODO(AG-892): replace 0.0 with the real dollar cost.
-            await self.budget_limiter.count_cost(cost=0.0)
+        await self._count_transcription_usage(result.usage, model_selected)
 
         return result
 
@@ -1621,6 +1619,52 @@ class GatewayRoute:
         if self.budget_limiter and model_selected.output_cost_per_token:
             await self.budget_limiter.count_output(
                 token_count=completion_tokens,
+                output_cost_per_token=model_selected.output_cost_per_token,
+            )
+
+    async def _count_transcription_usage(
+        self,
+        usage,
+        model_selected: Model,
+    ) -> None:
+        """Count budget usage from a transcription response, mirroring _count_usage.
+
+        No token_limiter counting: token/duration limiting isn't applicable to
+        audio (AG-887 analysis).
+        """
+        if not self.budget_limiter or usage is None:
+            return
+
+        if usage.type == 'duration':
+            if model_selected.input_cost_per_second:
+                # `count_input` is plain count x price; for whisper-1-style
+                # duration billing `token_count` carries seconds and
+                # `input_cost_per_token` the per-second price.
+                await self.budget_limiter.count_input(
+                    token_count=usage.seconds,
+                    input_cost_per_token=model_selected.input_cost_per_second,
+                )
+            return
+
+        details = getattr(usage, 'input_token_details', None)
+        audio_tokens = getattr(details, 'audio_tokens', None) or 0
+        text_tokens = getattr(details, 'text_tokens', None)
+        if text_tokens is None:
+            text_tokens = usage.input_tokens
+
+        if audio_tokens > 0 and model_selected.input_cost_per_audio_token:
+            await self.budget_limiter.count_input(
+                token_count=audio_tokens,
+                input_cost_per_token=model_selected.input_cost_per_audio_token,
+            )
+        if text_tokens > 0 and model_selected.input_cost_per_token:
+            await self.budget_limiter.count_input(
+                token_count=text_tokens,
+                input_cost_per_token=model_selected.input_cost_per_token,
+            )
+        if usage.output_tokens > 0 and model_selected.output_cost_per_token:
+            await self.budget_limiter.count_output(
+                token_count=usage.output_tokens,
                 output_cost_per_token=model_selected.output_cost_per_token,
             )
 

--- a/gateway/radicalbit_ai_gateway/db/dao/event_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/event_dao.py
@@ -150,6 +150,41 @@ class EventDAO:
             ),
         )
 
+        transcription_duration = F.sumIf(
+            T.c['COST'],
+            F.and_(
+                T.c['EVENT_TYPE'] == 'INPUT_TOKEN_PROCESSED',
+                T.c['MODEL_TYPE'] == 'transcription',
+                T.c['CACHE_TYPE'] == 'duration',
+            ),
+        )
+
+        transcription_audio = F.sumIf(
+            T.c['COST'],
+            F.and_(
+                T.c['EVENT_TYPE'] == 'INPUT_TOKEN_PROCESSED',
+                T.c['MODEL_TYPE'] == 'transcription',
+                T.c['CACHE_TYPE'] == 'audio',
+            ),
+        )
+
+        transcription_text = F.sumIf(
+            T.c['COST'],
+            F.and_(
+                T.c['EVENT_TYPE'] == 'INPUT_TOKEN_PROCESSED',
+                T.c['MODEL_TYPE'] == 'transcription',
+                T.c['CACHE_TYPE'] == '',
+            ),
+        )
+
+        transcription_output = F.sumIf(
+            T.c['COST'],
+            F.and_(
+                T.c['EVENT_TYPE'] == 'OUTPUT_TOKEN_PROCESSED',
+                T.c['MODEL_TYPE'] == 'transcription',
+            ),
+        )
+
         return [
             chat_input_direct.label('chat_input_direct'),
             chat_input_cached.label('chat_input_cached'),
@@ -160,6 +195,10 @@ class EventDAO:
             embedding_input_total.label('embedding_input_total'),
             embedding_input_direct.label('embedding_input_direct'),
             embedding_input_semantic_cache.label('embedding_input_semantic_cache'),
+            transcription_duration.label('transcription_duration'),
+            transcription_audio.label('transcription_audio'),
+            transcription_text.label('transcription_text'),
+            transcription_output.label('transcription_output'),
         ]
 
     def _get_attrs_per_metric(self, event_type: str) -> list:
@@ -972,6 +1011,10 @@ class EventDAO:
                 'embedding_input_total',
                 'embedding_input_direct',
                 'embedding_input_semantic_cache',
+                'transcription_duration',
+                'transcription_audio',
+                'transcription_text',
+                'transcription_output',
             ]
             return [
                 RouteDetailedCostBreakdown.model_validate(dict(zip(field_names, row)))

--- a/gateway/radicalbit_ai_gateway/db/models/event.py
+++ b/gateway/radicalbit_ai_gateway/db/models/event.py
@@ -188,6 +188,10 @@ class DetailedCostBreakdown(Base):
     embedding_input_total: float = 0.0
     embedding_input_direct: float = 0.0
     embedding_input_semantic_cache: float = 0.0
+    transcription_duration: float = 0.0
+    transcription_audio: float = 0.0
+    transcription_text: float = 0.0
+    transcription_output: float = 0.0
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/gateway/radicalbit_ai_gateway/invocation/model_invoker.py
+++ b/gateway/radicalbit_ai_gateway/invocation/model_invoker.py
@@ -90,7 +90,7 @@ class ModelInvoker:
         route_name: str,
         model: Model,
         model_type: str,
-        token_count: int,
+        token_count: int | float,
         where: str,
         cache_type: str | None,
         is_cached_tokens: bool = False,
@@ -129,6 +129,55 @@ class ModelInvoker:
             token_count,
             {'route_name': route_name, 'model_name': model.model_id},
         )
+        return cost
+
+    def _emit_output_token_metrics(
+        self,
+        request_uuid: str,
+        api_key_uuid: str,
+        api_key_name: str,
+        group_name: str,
+        group_uuid: str,
+        route_name: str,
+        model: Model,
+        model_type: str,
+        token_count: int | float,
+        cache_type: str | None = None,
+        project_uuid: str = '',
+        project_name: str = '',
+    ):
+        cost = self.cost_service.compute_cost(
+            model_id=model.model_id,
+            token_processed=token_count,
+            where='output',
+        )
+        emit_event(
+            OutputTokenProcessedPayload(
+                request_uuid=request_uuid,
+                event_type=EventType.OUTPUT_TOKEN_PROCESSED,
+                route_name=route_name,
+                value=token_count,
+                api_key_uuid=api_key_uuid,
+                group_uuid=group_uuid,
+                api_key_name=api_key_name,
+                group_name=group_name,
+                cost=cost,
+                model_id=model.model_id,
+                model_type=model_type,
+                cache_type=cache_type,
+                project_uuid=project_uuid,
+                project_name=project_name,
+            )
+        )
+        total_tokens_counter_output.add(
+            token_count,
+            {'route_name': route_name, 'model_name': model.model_id},
+        )
+        tokens_per_request_histogram_output.record(
+            token_count,
+            {'route_name': route_name, 'model_name': model.model_id},
+        )
+        return cost
 
     def _record_metrics(
         self,
@@ -213,36 +262,10 @@ class ModelInvoker:
                 )
 
         if token_output_count is not None:
-            cost = self.cost_service.compute_cost(
-                model_id=model.model_id,
-                token_processed=token_output_count,
-                where='output',
-            )
-            emit_event(
-                OutputTokenProcessedPayload(
-                    request_uuid=request_uuid,
-                    event_type=EventType.OUTPUT_TOKEN_PROCESSED,
-                    route_name=route_name,
-                    value=token_output_count,
-                    api_key_uuid=api_key_uuid,
-                    group_uuid=group_uuid,
-                    api_key_name=api_key_name,
-                    group_name=group_name,
-                    cost=cost,
-                    model_id=model.model_id,
-                    model_type=model_type,
-                    cache_type=cache_type,
-                    project_uuid=project_uuid,
-                    project_name=project_name,
-                )
-            )
-            total_tokens_counter_output.add(
-                token_output_count,
-                {'route_name': route_name, 'model_name': model.model_id},
-            )
-            tokens_per_request_histogram_output.record(
-                token_output_count,
-                {'route_name': route_name, 'model_name': model.model_id},
+            self._emit_output_token_metrics(
+                **common,
+                token_count=token_output_count,
+                cache_type=cache_type,
             )
 
         if fallback_triggered:

--- a/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
+++ b/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import logging
 import time
 
@@ -145,5 +146,82 @@ class TranscriptionModelInvoker(ModelInvoker):
             project_uuid=project_uuid,
             project_name=project_name,
         )
+        self._record_transcription_usage_cost(
+            request_uuid=request_uuid,
+            api_key_uuid=api_key_uuid,
+            group_uuid=group_uuid,
+            api_key_name=api_key_name,
+            group_name=group_name,
+            route_name=route_name,
+            model=model,
+            usage=usage,
+            project_uuid=project_uuid,
+            project_name=project_name,
+        )
 
         return body
+
+    def _record_transcription_usage_cost(
+        self,
+        request_uuid: str,
+        api_key_uuid: str,
+        api_key_name: str,
+        group_name: str,
+        group_uuid: str,
+        route_name: str,
+        model: Model,
+        usage,
+        project_uuid: str = '',
+        project_name: str = '',
+    ) -> Decimal:
+        if usage is None:
+            return Decimal(0)
+
+        common = {
+            'request_uuid': request_uuid,
+            'api_key_uuid': api_key_uuid,
+            'api_key_name': api_key_name,
+            'group_name': group_name,
+            'group_uuid': group_uuid,
+            'route_name': route_name,
+            'model': model,
+            'model_type': 'transcription',
+            'project_uuid': project_uuid,
+            'project_name': project_name,
+        }
+
+        if usage.type == 'duration':
+            return self._emit_input_token_metrics(
+                **common,
+                token_count=usage.seconds,
+                where='duration',
+                cache_type='duration',
+            )
+
+        details = getattr(usage, 'input_token_details', None)
+        audio_tokens = getattr(details, 'audio_tokens', None) or 0
+        text_tokens = getattr(details, 'text_tokens', None)
+        if text_tokens is None:
+            text_tokens = usage.input_tokens
+
+        total_cost = Decimal(0)
+        if audio_tokens > 0:
+            total_cost += self._emit_input_token_metrics(
+                **common,
+                token_count=audio_tokens,
+                where='audio',
+                cache_type='audio',
+            )
+        if text_tokens > 0:
+            total_cost += self._emit_input_token_metrics(
+                **common,
+                token_count=text_tokens,
+                where='input',
+                cache_type=None,
+            )
+        if usage.output_tokens > 0:
+            total_cost += self._emit_output_token_metrics(
+                **common,
+                token_count=usage.output_tokens,
+            )
+        return total_cost

--- a/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
+++ b/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
@@ -78,6 +78,15 @@ class BudgetLimiter:
             return
         await self.limiter.hit(self.item, cost=cost)
 
+    async def count_duration(self, seconds: float, cost_per_second: float) -> None:
+        """Duration-based billing (whisper-1 style): seconds and price are
+        both floats, unlike count_input/count_output's int token counts.
+        """
+        cost = int(seconds * cost_per_second * BUDGET_MULTIPLIER)
+        if not self.limiter or not self.item:
+            return
+        await self.limiter.hit(self.item, cost=cost)
+
     @task(name='check_budget_limit')
     async def check_budget(self) -> None:
         """Check if budget counter is exceeded. Raise BudgetLimitExceededError if limit is exceeded."""

--- a/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
+++ b/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
@@ -78,13 +78,6 @@ class BudgetLimiter:
             return
         await self.limiter.hit(self.item, cost=cost)
 
-    async def count_cost(self, cost: float) -> None:
-        """Add a pre-computed dollar cost, bypassing the token×price math of count_input/count_output."""
-        cost_units = int(cost * BUDGET_MULTIPLIER)
-        if not self.limiter or not self.item:
-            return
-        await self.limiter.hit(self.item, cost=cost_units)
-
     @task(name='check_budget_limit')
     async def check_budget(self) -> None:
         """Check if budget counter is exceeded. Raise BudgetLimitExceededError if limit is exceeded."""

--- a/gateway/radicalbit_ai_gateway/services/cost_service.py
+++ b/gateway/radicalbit_ai_gateway/services/cost_service.py
@@ -13,16 +13,19 @@ class CostService:
         self,
         chat_models_by_id: dict | None = None,
         embedding_models_by_id: dict | None = None,
+        transcription_models_by_id: dict | None = None,
     ):
         self.prices = self._extract_model_costs(
             chat_models_by_id or {},
             embedding_models_by_id or {},
+            transcription_models_by_id or {},
         )
 
     @staticmethod
     def _extract_model_costs(
         chat_models_by_id: dict,
         embedding_models_by_id: dict,
+        transcription_models_by_id: dict | None = None,
     ) -> dict:
         results = {}
         for m in chat_models_by_id.values():
@@ -32,6 +35,8 @@ class CostService:
                 m.input_cached_cost_per_token,
                 m.input_cache_creation_5m_cost_per_token,
                 m.input_cache_creation_1h_cost_per_token,
+                m.input_cost_per_second,
+                m.input_cost_per_audio_token,
             )
         for e in embedding_models_by_id.values():
             results[e.model_id] = (
@@ -40,10 +45,24 @@ class CostService:
                 e.input_cached_cost_per_token,
                 e.input_cache_creation_5m_cost_per_token,
                 e.input_cache_creation_1h_cost_per_token,
+                e.input_cost_per_second,
+                e.input_cost_per_audio_token,
+            )
+        for t in (transcription_models_by_id or {}).values():
+            results[t.model_id] = (
+                t.input_cost_per_token,
+                t.output_cost_per_token,
+                t.input_cached_cost_per_token,
+                t.input_cache_creation_5m_cost_per_token,
+                t.input_cache_creation_1h_cost_per_token,
+                t.input_cost_per_second,
+                t.input_cost_per_audio_token,
             )
         return results
 
-    def compute_cost(self, token_processed: int, where: str, model_id: str) -> float:
+    def compute_cost(
+        self, token_processed: int | float, where: str, model_id: str
+    ) -> float:
         try:
             match where:
                 case 'input':
@@ -56,6 +75,10 @@ class CostService:
                     cost_per_token = self.prices[model_id][3]
                 case 'cached_creation_1h':
                     cost_per_token = self.prices[model_id][4]
+                case 'duration':
+                    cost_per_token = self.prices[model_id][5]
+                case 'audio':
+                    cost_per_token = self.prices[model_id][6]
                 case _:
                     raise ValueError(f'Invalid where value: {where}')
         except KeyError:
@@ -63,4 +86,4 @@ class CostService:
                 'Failed to compute cost for %s',
                 model_id,
             )
-        return Decimal(token_processed) * cost_per_token
+        return Decimal(str(token_processed)) * cost_per_token

--- a/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
+++ b/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
@@ -209,6 +209,7 @@ def build_project_route_registrar(
         project_cost_service = CostService(
             chat_models_by_id=project_gateway_config.chat_models_by_id,
             embedding_models_by_id=project_gateway_config.embedding_models_by_id,
+            transcription_models_by_id=project_gateway_config.transcription_models_by_id,
         )
         project_guardrail_engine = GuardrailEngine(
             presidio_engine=presidio_engine,

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -915,10 +915,10 @@ async def test_invoke_transcription_success():
 
 @pytest.mark.asyncio
 async def test_invoke_transcription_counts_budget_duration():
-    """usage.type == 'duration' (whisper-1): budget counted via count_input,
-    seconds standing in for token_count and input_cost_per_second for the
-    per-token price — same count_input/count_output primitives _count_usage
-    uses for chat, just fed a duration instead of a token count.
+    """usage.type == 'duration' (whisper-1): budget counted via the dedicated
+    count_duration (seconds + per-second price, both floats) — a separate
+    method from count_input/count_output, whose int*Decimal arithmetic stays
+    untouched for chat/embedding/token-based transcription billing.
     """
     cost_service = MagicMock(spec_set=CostService)
     whisper_model = Model(
@@ -930,6 +930,7 @@ async def test_invoke_transcription_counts_budget_duration():
     route_cfg = _make_transcription_route_config(max_budget=10.0, window_size=3600)
     budget_limiter = route_cfg.get_budget_limiter()
     budget_limiter.check_budget = AsyncMock()
+    budget_limiter.count_duration = AsyncMock()
     budget_limiter.count_input = AsyncMock()
     budget_limiter.count_output = AsyncMock()
 
@@ -960,12 +961,10 @@ async def test_invoke_transcription_counts_budget_duration():
     )
 
     budget_limiter.check_budget.assert_awaited_once()
-    # input_cost_per_second is cast to float here (unlike chat/embedding's
-    # int token_count, whisper's seconds is itself a float, and count_input's
-    # arithmetic can't mix float*Decimal — see _count_transcription_usage).
-    budget_limiter.count_input.assert_awaited_once_with(
-        token_count=3, input_cost_per_token=0.0001
+    budget_limiter.count_duration.assert_awaited_once_with(
+        seconds=3, cost_per_second=0.0001
     )
+    budget_limiter.count_input.assert_not_awaited()
     budget_limiter.count_output.assert_not_awaited()
 
 

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -1,4 +1,5 @@
 import datetime
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun import freeze_time
@@ -842,12 +843,14 @@ async def test_invoke_embeddings_budget_limit_exceeded(
     pook.disable_network()
 
 
-def _make_transcription_route_config(**budget_kwargs) -> GatewayRouteConfig:
+def _make_transcription_route_config(
+    model_id: str = 'whisper-1', **budget_kwargs
+) -> GatewayRouteConfig:
     budget_limiting = BudgetLimiting(**budget_kwargs) if budget_kwargs else None
     return GatewayRouteConfig(
         route_name='rb-gateway',
         chat_models=[],
-        transcription_models=['whisper-1'],
+        transcription_models=[model_id],
         budget_limiting=budget_limiting,
     )
 
@@ -888,7 +891,7 @@ async def test_invoke_transcription_success():
     )
 
     assert result is fake_result
-    # transcribe() now records its own metrics internally (mirroring
+    # transcribe() now records its own metrics/cost internally (mirroring
     # ChatModelInvoker.complete()/EmbeddingModelInvoker.embed()), so
     # ai_gateway just has to wire the identity/project params through.
     ai_gateway.transcription_invoker.transcribe.assert_awaited_once_with(
@@ -911,17 +914,24 @@ async def test_invoke_transcription_success():
 
 
 @pytest.mark.asyncio
-async def test_invoke_transcription_checks_and_counts_budget():
+async def test_invoke_transcription_counts_budget_duration():
+    """usage.type == 'duration' (whisper-1): budget counted via count_input,
+    seconds standing in for token_count and input_cost_per_second for the
+    per-token price — same count_input/count_output primitives _count_usage
+    uses for chat, just fed a duration instead of a token count.
+    """
     cost_service = MagicMock(spec_set=CostService)
     whisper_model = Model(
         model_id='whisper-1',
         model='openai/whisper-1',
         credentials=Credentials(api_key='sk-test'),
+        input_cost_per_second=Decimal('0.0001'),
     )
     route_cfg = _make_transcription_route_config(max_budget=10.0, window_size=3600)
     budget_limiter = route_cfg.get_budget_limiter()
     budget_limiter.check_budget = AsyncMock()
-    budget_limiter.count_cost = AsyncMock()
+    budget_limiter.count_input = AsyncMock()
+    budget_limiter.count_output = AsyncMock()
 
     ai_gateway = GatewayRoute(
         gateway_route_config=route_cfg,
@@ -950,7 +960,82 @@ async def test_invoke_transcription_checks_and_counts_budget():
     )
 
     budget_limiter.check_budget.assert_awaited_once()
-    budget_limiter.count_cost.assert_awaited_once_with(cost=0.0)
+    budget_limiter.count_input.assert_awaited_once_with(
+        token_count=3, input_cost_per_token=Decimal('0.0001')
+    )
+    budget_limiter.count_output.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invoke_transcription_counts_budget_tokens():
+    """usage.type == 'tokens' (gpt-4o-transcribe family): audio and text
+    tokens both counted via count_input (two separate calls, one per price),
+    output tokens via count_output — mirrors _count_usage's gating on each
+    price being non-zero before counting.
+    """
+    cost_service = MagicMock(spec_set=CostService)
+    gpt4o_model = Model(
+        model_id='gpt4o-transcribe',
+        model='openai/gpt-4o-transcribe',
+        credentials=Credentials(api_key='sk-test'),
+        input_cost_per_million_tokens=Decimal('2.5'),
+        output_cost_per_million_tokens=Decimal('10.0'),
+        input_cost_per_audio_token=Decimal('0.000006'),
+    )
+    route_cfg = _make_transcription_route_config(
+        model_id='gpt4o-transcribe', max_budget=10.0, window_size=3600
+    )
+    budget_limiter = route_cfg.get_budget_limiter()
+    budget_limiter.check_budget = AsyncMock()
+    budget_limiter.count_input = AsyncMock()
+    budget_limiter.count_output = AsyncMock()
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=[gpt4o_model],
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=None,
+        cost_service=cost_service,
+        budget_limiter=budget_limiter,
+    )
+
+    fake_result = MagicMock(
+        usage=MagicMock(
+            type='tokens',
+            input_tokens=87,
+            output_tokens=38,
+            input_token_details=MagicMock(audio_tokens=82, text_tokens=5),
+        )
+    )
+    ai_gateway.transcription_invoker.transcribe = AsyncMock(return_value=fake_result)
+
+    await ai_gateway.invoke_transcription(
+        request_uuid=str(REQUEST_UUID),
+        api_key_uuid=str(API_KEY_UUID),
+        group_uuid=str(GROUP_UUID),
+        api_key_name='rb-key',
+        group_name='test-group',
+        route_name='rb-gateway',
+        audio_bytes=b'fake-audio',
+        filename='test.wav',
+        content_type='audio/wav',
+    )
+
+    budget_limiter.check_budget.assert_awaited_once()
+    count_input_calls = budget_limiter.count_input.call_args_list
+    assert len(count_input_calls) == 2
+    assert {
+        (c.kwargs['token_count'], c.kwargs['input_cost_per_token'])
+        for c in count_input_calls
+    } == {
+        (82, gpt4o_model.input_cost_per_audio_token),
+        (5, gpt4o_model.input_cost_per_token),
+    }
+    budget_limiter.count_output.assert_awaited_once_with(
+        token_count=38, output_cost_per_token=gpt4o_model.output_cost_per_token
+    )
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -960,8 +960,11 @@ async def test_invoke_transcription_counts_budget_duration():
     )
 
     budget_limiter.check_budget.assert_awaited_once()
+    # input_cost_per_second is cast to float here (unlike chat/embedding's
+    # int token_count, whisper's seconds is itself a float, and count_input's
+    # arithmetic can't mix float*Decimal — see _count_transcription_usage).
     budget_limiter.count_input.assert_awaited_once_with(
-        token_count=3, input_cost_per_token=Decimal('0.0001')
+        token_count=3, input_cost_per_token=0.0001
     )
     budget_limiter.count_output.assert_not_awaited()
 

--- a/gateway/tests/dao/event_dao_test.py
+++ b/gateway/tests/dao/event_dao_test.py
@@ -2266,6 +2266,57 @@ class EventDAOTest(DatabaseIntegrationClickhouse):
         # Embedding input semantic cache: 0.6
         assert res.embedding_input_semantic_cache == 0.6
 
+    def test_detailed_cost_breakdown_transcription(self):
+        base_time = datetime.datetime(
+            2025, 1, 10, 12, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        test_events = [
+            # whisper-1 style: duration-based input
+            db_mock.get_sample_event(
+                event_type='INPUT_TOKEN_PROCESSED',
+                timestamp=base_time,
+                cost=0.000825,
+                model_type='transcription',
+                cache_type='duration',
+            ),
+            # gpt-4o-transcribe style: audio-token input
+            db_mock.get_sample_event(
+                event_type='INPUT_TOKEN_PROCESSED',
+                timestamp=base_time,
+                cost=0.000492,
+                model_type='transcription',
+                cache_type='audio',
+            ),
+            # gpt-4o-transcribe style: text-token input
+            db_mock.get_sample_event(
+                event_type='INPUT_TOKEN_PROCESSED',
+                timestamp=base_time,
+                cost=0.0000125,
+                model_type='transcription',
+                cache_type='',
+            ),
+            # gpt-4o-transcribe style: output tokens
+            db_mock.get_sample_event(
+                event_type='OUTPUT_TOKEN_PROCESSED',
+                timestamp=base_time,
+                cost=0.00038,
+                model_type='transcription',
+            ),
+        ]
+        self.insert(test_events)
+
+        _from = base_time
+        _to = base_time + datetime.timedelta(hours=1)
+
+        res = self.event_dao.get_detailed_cost_breakdown(
+            None, ['rb-gateway'], _from, _to
+        )
+        assert res is not None
+        assert res.transcription_duration == 0.000825
+        assert res.transcription_audio == 0.000492
+        assert res.transcription_text == 0.0000125
+        assert res.transcription_output == 0.00038
+
     def test_get_all_routes_detailed_cost_breakdown(self):
         base_time = datetime.datetime(
             2025, 1, 10, 12, 0, 0, tzinfo=datetime.timezone.utc
@@ -2324,6 +2375,22 @@ class EventDAOTest(DatabaseIntegrationClickhouse):
                 model_type='embeddings',
                 cache_type='semantic',
             ),
+            # route-D: transcription
+            db_mock.get_sample_event(
+                event_type='INPUT_TOKEN_PROCESSED',
+                route_name='route-D',
+                timestamp=base_time,
+                cost=0.000825,
+                model_type='transcription',
+                cache_type='duration',
+            ),
+            db_mock.get_sample_event(
+                event_type='OUTPUT_TOKEN_PROCESSED',
+                route_name='route-D',
+                timestamp=base_time,
+                cost=0.00038,
+                model_type='transcription',
+            ),
         ]
         self.insert(test_events)
 
@@ -2371,6 +2438,18 @@ class EventDAOTest(DatabaseIntegrationClickhouse):
         assert by_route['route-C'].embedding_input_total == 1.0
         assert by_route['route-C'].embedding_input_direct == 0.4
         assert by_route['route-C'].embedding_input_semantic_cache == 0.6
+        assert by_route['route-C'].transcription_duration == 0.0
+        assert by_route['route-C'].transcription_output == 0.0
+
+        # route-D: transcription — confirms the field_names/columns alignment
+        # (chat/embedding fields must stay 0 for this route)
+        assert 'route-D' in by_route
+        assert by_route['route-D'].chat_input_direct == 0.0
+        assert by_route['route-D'].embedding_input_total == 0.0
+        assert by_route['route-D'].transcription_duration == 0.000825
+        assert by_route['route-D'].transcription_audio == 0.0
+        assert by_route['route-D'].transcription_text == 0.0
+        assert by_route['route-D'].transcription_output == 0.00038
 
     def test_get_all_routes_detailed_cost_breakdown_empty(self):
         now = datetime.datetime.now(datetime.timezone.utc)

--- a/gateway/tests/invoker/test_transcription_model_invoker.py
+++ b/gateway/tests/invoker/test_transcription_model_invoker.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -196,6 +197,120 @@ class TestTranscriptionModelInvoker(unittest.IsolatedAsyncioTestCase):
     def test_model_map_initialization(self):
         invoker = self._build_invoker(WHISPER_MODEL)
         assert 'whisper' in invoker.model_map
+
+    def test_record_transcription_usage_cost_duration(self):
+        invoker = self._build_invoker(WHISPER_MODEL)
+        invoker.cost_service.compute_cost.return_value = Decimal('0.000825')
+        usage = MagicMock(type='duration', seconds=8.25)
+
+        total_cost = invoker._record_transcription_usage_cost(
+            request_uuid='req',
+            api_key_uuid='key',
+            api_key_name='rb-key',
+            group_name='test-group',
+            group_uuid='grp',
+            route_name='test-route',
+            model=WHISPER_MODEL,
+            usage=usage,
+        )
+
+        assert total_cost == Decimal('0.000825')
+        invoker.cost_service.compute_cost.assert_called_once_with(
+            model_id='whisper', token_processed=8.25, where='duration'
+        )
+        assert self.mock_emit_event.call_count == 1
+        payload = self.mock_emit_event.call_args.args[0]
+        assert payload.cache_type == 'duration'
+        assert payload.value == 8.25
+
+    def test_record_transcription_usage_cost_tokens_with_details(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+
+        def _side_effect(**kwargs):
+            return {
+                'audio': Decimal('0.000492'),
+                'input': Decimal('0.0000125'),
+                'output': Decimal('0.00038'),
+            }[kwargs['where']]
+
+        invoker.cost_service.compute_cost.side_effect = _side_effect
+        usage = MagicMock(
+            type='tokens',
+            input_tokens=87,
+            output_tokens=38,
+            input_token_details=MagicMock(audio_tokens=82, text_tokens=5),
+        )
+
+        total_cost = invoker._record_transcription_usage_cost(
+            request_uuid='req',
+            api_key_uuid='key',
+            api_key_name='rb-key',
+            group_name='test-group',
+            group_uuid='grp',
+            route_name='test-route',
+            model=GPT4O_TRANSCRIBE_MODEL,
+            usage=usage,
+        )
+
+        assert total_cost == (
+            Decimal('0.000492') + Decimal('0.0000125') + Decimal('0.00038')
+        )
+        compute_calls = invoker.cost_service.compute_cost.call_args_list
+        where_args = {c.kwargs['where'] for c in compute_calls}
+        assert where_args == {'audio', 'input', 'output'}
+        audio_call = next(c for c in compute_calls if c.kwargs['where'] == 'audio')
+        assert audio_call.kwargs['token_processed'] == 82
+        text_call = next(c for c in compute_calls if c.kwargs['where'] == 'input')
+        assert text_call.kwargs['token_processed'] == 5
+        output_call = next(c for c in compute_calls if c.kwargs['where'] == 'output')
+        assert output_call.kwargs['token_processed'] == 38
+        assert self.mock_emit_event.call_count == 3
+
+    def test_record_transcription_usage_cost_tokens_without_details(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        invoker.cost_service.compute_cost.return_value = Decimal('0.0001')
+        usage = MagicMock(
+            type='tokens',
+            input_tokens=50,
+            output_tokens=0,
+            input_token_details=None,
+        )
+
+        total_cost = invoker._record_transcription_usage_cost(
+            request_uuid='req',
+            api_key_uuid='key',
+            api_key_name='rb-key',
+            group_name='test-group',
+            group_uuid='grp',
+            route_name='test-route',
+            model=GPT4O_TRANSCRIBE_MODEL,
+            usage=usage,
+        )
+
+        # No input_token_details: all input treated as text-priced;
+        # output_tokens == 0 is skipped.
+        invoker.cost_service.compute_cost.assert_called_once_with(
+            model_id='gpt4o-transcribe', token_processed=50, where='input'
+        )
+        assert total_cost == Decimal('0.0001')
+        assert self.mock_emit_event.call_count == 1
+
+    def test_record_transcription_usage_cost_no_usage(self):
+        invoker = self._build_invoker(WHISPER_MODEL)
+
+        total_cost = invoker._record_transcription_usage_cost(
+            request_uuid='req',
+            api_key_uuid='key',
+            api_key_name='rb-key',
+            group_name='test-group',
+            group_uuid='grp',
+            route_name='test-route',
+            model=WHISPER_MODEL,
+            usage=None,
+        )
+
+        assert total_cost == Decimal(0)
+        invoker.cost_service.compute_cost.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/gateway/tests/limiting/test_budget_limiting.py
+++ b/gateway/tests/limiting/test_budget_limiting.py
@@ -86,6 +86,25 @@ class TestBudgetLimiter:
         assert '[action=BLOCK]' in msg
 
     @pytest.mark.asyncio
+    async def test_count_duration_exceeds_limit(self):
+        """count_duration is a dedicated method for whisper-1-style duration
+        billing, where both operands are floats — unlike count_input/count_output's
+        int token counts.
+        """
+        config = Limiting(max_budget=0.0005, window_size='1 minute')
+        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+
+        await limiter.count_duration(8.25, 0.0001)
+
+        with pytest.raises(BudgetLimitExceededError) as exc:
+            await limiter.check_budget()
+
+        msg = getattr(exc.value, 'log_message', str(exc.value))
+        assert '[BUDGET LIMIT]' in msg
+        assert '[route=rb-gateway]' in msg
+        assert '[limit=0.0005]' in msg
+
+    @pytest.mark.asyncio
     async def test_combined_input_output_exhausts_budget(self):
         """Input + output costs together exhaust the shared budget."""
         config = Limiting(max_budget=1, window_size='1 minute')

--- a/gateway/tests/services/cost_service_test.py
+++ b/gateway/tests/services/cost_service_test.py
@@ -10,7 +10,21 @@ from tests.common.mocked_gateway_config import (
 )
 
 from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
+from radicalbit_ai_gateway.models.model import Model
 from radicalbit_ai_gateway.services.cost_service import CostService
+
+WHISPER_MODEL = Model(
+    model_id='whisper',
+    model='openai/whisper-1',
+    input_cost_per_second=Decimal('0.0001'),
+)
+GPT4O_TRANSCRIBE_MODEL = Model(
+    model_id='gpt4o-transcribe',
+    model='openai/gpt-4o-transcribe',
+    input_cost_per_million_tokens=Decimal('2.5'),
+    output_cost_per_million_tokens=Decimal('10.0'),
+    input_cost_per_audio_token=Decimal('0.000006'),
+)
 
 
 class CostServiceTest(unittest.TestCase):
@@ -23,6 +37,7 @@ class CostServiceTest(unittest.TestCase):
         cls.gateway_config = GatewayConfig(
             chat_models=gw_a.chat_models,
             embedding_models=gw_a.embedding_models,
+            transcription_models=[WHISPER_MODEL, GPT4O_TRANSCRIBE_MODEL],
             routes={'route-A': gw_a.routes['route-A']},
             guardrails=global_guardrails,
             cache=get_default_cache_config(),
@@ -30,12 +45,14 @@ class CostServiceTest(unittest.TestCase):
         cls.cost_service = CostService(
             chat_models_by_id=cls.gateway_config.chat_models_by_id,
             embedding_models_by_id=cls.gateway_config.embedding_models_by_id,
+            transcription_models_by_id=cls.gateway_config.transcription_models_by_id,
         )
 
     def test_extract_model_costs(self):
         prices = CostService._extract_model_costs(
             self.gateway_config.chat_models_by_id,
             self.gateway_config.embedding_models_by_id,
+            self.gateway_config.transcription_models_by_id,
         )
         assert prices is not None
         assert isinstance(prices, dict)
@@ -46,11 +63,15 @@ class CostServiceTest(unittest.TestCase):
                 Decimal('3e-08'),
                 Decimal('0'),
                 Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
             ),
             'azure': (
                 Decimal('2.e-07'),
                 Decimal('0.0'),
                 Decimal('2.e-08'),
+                Decimal('0'),
+                Decimal('0'),
                 Decimal('0'),
                 Decimal('0'),
             ),
@@ -60,6 +81,8 @@ class CostServiceTest(unittest.TestCase):
                 Decimal('0.0'),
                 Decimal('0'),
                 Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
             ),
             'text-embedding-3-small': (
                 Decimal('2e-08'),
@@ -67,8 +90,48 @@ class CostServiceTest(unittest.TestCase):
                 Decimal('0.0'),
                 Decimal('0'),
                 Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
+            ),
+            'whisper': (
+                Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
+                Decimal('0.0001'),
+                Decimal('0'),
+            ),
+            'gpt4o-transcribe': (
+                Decimal('2.5e-6'),
+                Decimal('1e-5'),
+                Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
+                Decimal('0'),
+                Decimal('0.000006'),
             ),
         }
+
+    def test_compute_cost_duration_seconds(self):
+        # whisper model has duration cost of 0.0001 per second
+        cost = self.cost_service.compute_cost(
+            token_processed=8.25,
+            where='duration',
+            model_id='whisper',
+        )
+        expected_cost = Decimal('8.25') * Decimal('0.0001')
+        assert cost == expected_cost
+
+    def test_compute_cost_audio_tokens(self):
+        # gpt4o-transcribe model has audio-token cost of 0.000006 per token
+        cost = self.cost_service.compute_cost(
+            token_processed=82,
+            where='audio',
+            model_id='gpt4o-transcribe',
+        )
+        expected_cost = Decimal('82') * Decimal('0.000006')
+        assert cost == expected_cost
 
     def test_compute_cost_input_tokens(self):
         # openai model has input cost of 3e-07 per token


### PR DESCRIPTION
# PR Summary: AG-892

Adds real cost calculation for the audio transcription endpoint (`whisper-1` and `gpt-4o-transcribe` family), which previously always counted a `0.0` placeholder cost. This is a purely internal change — no DTO or endpoint changes are part of this PR; API exposure of the new cost breakdown is scoped separately (AG-893).

---

## DTO Changes

None. `radicalbit_ai_gateway/models/` and `radicalbit_ai_gateway/routes/` are untouched by this PR.

---

## Affected Endpoints

None directly modified. `POST /v1/audio/transcriptions` (added in a prior PR) now has its budget/cost side effects wired up correctly, but its request/response shape is unchanged.

---

## Other Changes

### Cost calculation — `services/cost_service.py`
- `CostService` gains a `transcription_models_by_id` price table alongside the existing chat/embedding ones. Each model's price tuple grows from 5 to 7 entries, with `input_cost_per_second` and `input_cost_per_audio_token` appended.
- `compute_cost` gains two new `where` cases: `'duration'` (whisper-1, billed per second) and `'audio'` (gpt-4o-transcribe family, billed per audio token).
- `compute_cost`'s final multiplication now does `Decimal(str(token_processed))` instead of `Decimal(token_processed)`, since transcription duration is a `float` (fractional seconds) rather than an `int` token count.
- An unknown `model_id` still raises `UnboundLocalError` as before (existing, intentional fail-loud behavior) — transcription models simply stop being "unknown" once wired into the price table.

### Metrics & cost recording — `invocation/transcription_model_invoker.py`, `invocation/model_invoker.py`
- `TranscriptionModelInvoker.transcribe()` now records its own metrics and cost internally via a new `_record_transcription_usage_cost`, mirroring how `ChatModelInvoker.complete()`/`EmbeddingModelInvoker.embed()` already do it. It branches on OpenAI's `usage.type` (`'duration'` vs `'tokens'`), falling back to text-only pricing when `input_token_details` is absent.
- `ModelInvoker._emit_input_token_metrics` now returns the computed cost; the output-token emission logic was extracted into a new reusable `_emit_output_token_metrics` (behavior-preserving refactor, verified against the existing chat/embedding test suites).

### Budget counting — `ai_gateway.py`, `limiting/budget_limiting.py`
- New `GatewayRoute._count_transcription_usage`, mirroring the existing `_count_usage`: reads the selected model's own prices (`input_cost_per_second`, `input_cost_per_audio_token`, `input_cost_per_token`, `output_cost_per_token`) directly and counts against the route's budget, each gated on the corresponding price being non-zero.
- `BudgetLimiter` gains a **dedicated** `count_duration(seconds: float, cost_per_second: float)` method for whisper-1's duration billing, kept deliberately separate from `count_input`/`count_output` (whose arithmetic assumes `int` token counts multiplied against a `Decimal` price — mixing in a `float` there raises a `TypeError`). `count_input`/`count_output` are otherwise untouched.
- `BudgetLimiter.count_cost` (the old placeholder-cost method, `cost=0.0` in the prior PR) is removed — dead code now that real per-model-type counting exists.

### ClickHouse cost breakdown — `db/models/event.py`, `db/dao/event_dao.py`
- `DetailedCostBreakdown` gains four new fields parallel to the existing `embedding_*` ones: `transcription_duration`, `transcription_audio`, `transcription_text`, `transcription_output` (all `float`, default `0.0`).
- `event_dao.py` computes these via the same `sumIf` pattern already used for chat/embedding, filtered on `MODEL_TYPE = 'transcription'` — no ClickHouse schema migration needed (`MODEL_TYPE`/`CACHE_TYPE` are free-form strings, not an enum).

### Tests
- `tests/services/cost_service_test.py` — new tests for the `'duration'`/`'audio'` `compute_cost` cases and the extended price tuple.
- `tests/invoker/test_transcription_model_invoker.py` — new tests for `_record_transcription_usage_cost` covering duration billing, token billing (with and without `input_token_details`), and the no-usage case.
- `tests/ai_gateway_test.py` — new tests for `_count_transcription_usage`, covering both the duration path (asserting `count_duration` is called, not `count_input`/`count_output`) and the token path (audio/text via `count_input`, output via `count_output`).
- `tests/limiting/test_budget_limiting.py` — new test for `count_duration` exceeding the configured budget.
- `tests/dao/event_dao_test.py` — integration tests (real ClickHouse via testcontainers) for the four new breakdown columns.
