### PR TITLE
feat: expose transcription cost breakdown in CostDataDTO

### DIFF
--- a/gateway/radicalbit_ai_gateway/models/event_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/event_dto.py
@@ -581,10 +581,12 @@ class InputCostBreakdownDTO(BaseModel):
 
 class TotalCostDTO(BaseModel):
     input: float = Field(
-        description='Total input costs from all model types (chat + embedding)'
+        description='Total input costs from all model types (chat + embedding + transcription)'
     )
     cached_input: float = Field(description='Total cached input costs from chat models')
-    output: float = Field(description='Total output costs from chat models')
+    output: float = Field(
+        description='Total output costs from chat and transcription models'
+    )
     saved: float | None = Field(
         default=None, description='Total amount saved from caching'
     )
@@ -703,6 +705,50 @@ class EmbeddingModelsCostDTO(BaseModel):
     )
 
 
+class TranscriptionModelsInputBreakdownDTO(BaseModel):
+    total: float = Field(
+        default=0,
+        description='Total input costs for transcription models (duration + audio + text)',
+    )
+    duration: float = Field(
+        default=0,
+        description='Duration-based input costs (e.g. whisper-1, priced per second)',
+    )
+    audio: float = Field(
+        default=0,
+        description='Audio-token input costs (e.g. gpt-4o-transcribe family)',
+    )
+    text: float = Field(
+        default=0,
+        description='Text-token input costs (e.g. gpt-4o-transcribe family)',
+    )
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=to_camel,
+        protected_namespaces=(),
+    )
+
+
+class TranscriptionModelsCostDTO(BaseModel):
+    input: TranscriptionModelsInputBreakdownDTO = Field(
+        description='Input costs broken down by duration/audio/text'
+    )
+    output: float = Field(
+        default=0,
+        description='Output token costs for transcription models (e.g. gpt-4o-transcribe family)',
+    )
+    total: float = Field(
+        description='Sum of all transcription model costs (input + output)'
+    )
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=to_camel,
+        protected_namespaces=(),
+    )
+
+
 class CostDataDTO(BaseModel):
     input_cost: Annotated[
         float,
@@ -793,6 +839,10 @@ class CostDataDTO(BaseModel):
         default=None,
         description='Cost breakdown for embedding models (direct + semantic cache)',
     )
+    transcription_models: TranscriptionModelsCostDTO | None = Field(
+        default=None,
+        description='Cost breakdown for transcription models (duration/audio/text input + output)',
+    )
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -809,6 +859,7 @@ class CostDataDTO(BaseModel):
         has_judges: bool = False,
         has_embedding_models: bool = False,
         has_semantic_cache: bool = False,
+        has_transcription_models: bool = False,
     ) -> 'CostDataDTO':
         cache_triggered: int | None = None
         input_cost = cost_data.input_cost
@@ -888,6 +939,7 @@ class CostDataDTO(BaseModel):
         total_all: float | None = None
         chat_models_cost: ChatModelsCostDTO | None = None
         embedding_models_cost: EmbeddingModelsCostDTO | None = None
+        transcription_models_cost: TranscriptionModelsCostDTO | None = None
 
         if detailed_breakdown:
             # Calculate chat models breakdown (None if no chat models)
@@ -940,27 +992,59 @@ class CostDataDTO(BaseModel):
                     total=detailed_breakdown.embedding_input_total,
                 )
 
+            # Calculate transcription models breakdown (None if no transcription models)
+            if has_transcription_models:
+                transcription_input_total = (
+                    detailed_breakdown.transcription_duration
+                    + detailed_breakdown.transcription_audio
+                    + detailed_breakdown.transcription_text
+                )
+                transcription_models_cost = TranscriptionModelsCostDTO(
+                    input=TranscriptionModelsInputBreakdownDTO(
+                        total=transcription_input_total,
+                        duration=detailed_breakdown.transcription_duration,
+                        audio=detailed_breakdown.transcription_audio,
+                        text=detailed_breakdown.transcription_text,
+                    ),
+                    output=detailed_breakdown.transcription_output,
+                    total=transcription_input_total
+                    + detailed_breakdown.transcription_output,
+                )
+
             # Calculate total DTO
             chat_input_total = chat_models_cost.input.total if chat_models_cost else 0
             embed_input_total = (
                 embedding_models_cost.input.total if embedding_models_cost else 0
             )
+            transcription_input_grand_total = (
+                transcription_models_cost.input.total
+                if transcription_models_cost
+                else 0
+            )
             chat_cached_total = (
                 chat_models_cost.cached_input.total if chat_models_cost else 0
             )
             chat_output_total = chat_models_cost.output.total if chat_models_cost else 0
+            transcription_output_total = (
+                transcription_models_cost.output if transcription_models_cost else 0
+            )
 
             total_dto = TotalCostDTO(
-                input=chat_input_total + embed_input_total,
+                input=chat_input_total
+                + embed_input_total
+                + transcription_input_grand_total,
                 cached_input=chat_cached_total,
-                output=chat_output_total,
+                output=chat_output_total + transcription_output_total,
                 saved=total_saved_amount,
             )
 
             # Calculate grand total
             chat_total = chat_models_cost.total if chat_models_cost else 0
             embed_total = embedding_models_cost.total if embedding_models_cost else 0
-            total_all = chat_total + embed_total
+            transcription_total = (
+                transcription_models_cost.total if transcription_models_cost else 0
+            )
+            total_all = chat_total + embed_total + transcription_total
 
         return CostDataDTO(
             input_cost=input_cost,
@@ -977,6 +1061,7 @@ class CostDataDTO(BaseModel):
             totals=total_dto,
             chat_models=chat_models_cost,
             embedding_models=embedding_models_cost,
+            transcription_models=transcription_models_cost,
         )
 
 

--- a/gateway/radicalbit_ai_gateway/models/gateway_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config.py
@@ -126,11 +126,12 @@ class GatewayConfig(BaseModel):
 
     def get_route_feature_flags(
         self, route_config: GatewayRouteConfig
-    ) -> tuple[bool, bool, bool, bool]:
+    ) -> tuple[bool, bool, bool, bool, bool]:
         """Detect route feature flags based on configuration.
 
         Returns:
-            Tuple of (has_chat_models, has_judges, has_embedding_models, has_semantic_cache)
+            Tuple of (has_chat_models, has_judges, has_embedding_models,
+            has_semantic_cache, has_transcription_models)
 
         """
         has_chat_models = bool(route_config.chat_models)
@@ -140,7 +141,14 @@ class GatewayConfig(BaseModel):
             and len(route_config.embedding_models) > 0
         )
         has_semantic_cache = isinstance(route_config.caching, SemanticCaching)
-        return has_chat_models, has_judges, has_embedding_models, has_semantic_cache
+        has_transcription_models = bool(route_config.transcription_models)
+        return (
+            has_chat_models,
+            has_judges,
+            has_embedding_models,
+            has_semantic_cache,
+            has_transcription_models,
+        )
 
     @model_validator(mode='before')
     @classmethod

--- a/gateway/radicalbit_ai_gateway/services/event_service.py
+++ b/gateway/radicalbit_ai_gateway/services/event_service.py
@@ -791,6 +791,7 @@ class EventService:
         has_judges = False
         has_embedding_models = False
         has_semantic_cache = False
+        has_transcription_models = False
         for rn in routes_to_query:
             route_config = config.routes.get(rn)
             if route_config is None:
@@ -802,11 +803,15 @@ class EventService:
                 route_has_judge,
                 route_has_embedding_models,
                 route_has_semantic_cache,
+                route_has_transcription_models,
             ) = config.get_route_feature_flags(route_config)
             has_chat_models = has_chat_models or route_has_chat_models
             has_judges = has_judges or route_has_judge
             has_embedding_models = has_embedding_models or route_has_embedding_models
             has_semantic_cache = has_semantic_cache or route_has_semantic_cache
+            has_transcription_models = (
+                has_transcription_models or route_has_transcription_models
+            )
 
         dao_route_names = None if route_names is None else routes_to_query
 
@@ -841,6 +846,7 @@ class EventService:
             has_judges=has_judges,
             has_embedding_models=has_embedding_models,
             has_semantic_cache=has_semantic_cache,
+            has_transcription_models=has_transcription_models,
         )
 
     def get_token_chart_data(
@@ -976,9 +982,13 @@ class EventService:
                 DetailedCostBreakdown(),
             )
 
-            has_chat_models, has_judges, has_embedding_models, has_semantic_cache = (
-                config.get_route_feature_flags(route_config)
-            )
+            (
+                has_chat_models,
+                has_judges,
+                has_embedding_models,
+                has_semantic_cache,
+                has_transcription_models,
+            ) = config.get_route_feature_flags(route_config)
 
             cost_dto = CostDataDTO.from_dao(
                 cost_data,
@@ -988,6 +998,7 @@ class EventService:
                 has_judges=has_judges,
                 has_embedding_models=has_embedding_models,
                 has_semantic_cache=has_semantic_cache,
+                has_transcription_models=has_transcription_models,
             )
 
             total += (

--- a/gateway/tests/models/test_event.py
+++ b/gateway/tests/models/test_event.py
@@ -179,9 +179,7 @@ def test_from_dao_with_transcription_models():
     assert result.transcription_models.input.duration == 0.000825
     assert result.transcription_models.input.audio == 0.000492
     assert result.transcription_models.input.text == 0.0000125
-    assert result.transcription_models.input.total == (
-        0.000825 + 0.000492 + 0.0000125
-    )
+    assert result.transcription_models.input.total == (0.000825 + 0.000492 + 0.0000125)
     assert result.transcription_models.output == 0.00038
     assert result.transcription_models.total == (
         0.000825 + 0.000492 + 0.0000125 + 0.00038

--- a/gateway/tests/models/test_event.py
+++ b/gateway/tests/models/test_event.py
@@ -4,7 +4,11 @@ from tests.common.mocked_gateway_config import (
     get_gateway_with_routing,
 )
 
-from radicalbit_ai_gateway.db.models.event import CostData, SemanticCacheCostData
+from radicalbit_ai_gateway.db.models.event import (
+    CostData,
+    DetailedCostBreakdown,
+    SemanticCacheCostData,
+)
 from radicalbit_ai_gateway.models.event_dto import CostDataDTO, EventsDTO
 
 
@@ -149,3 +153,52 @@ def test_from_dao_semantic_cache_zero_values():
     assert result.input_cost == 10.0
     assert result.output_cost == 20.0
     assert result.total_cost == 30.0
+
+
+def test_from_dao_with_transcription_models():
+    """CostDataDTO.from_dao builds a transcription_models breakdown parallel to
+    chat/embedding, and folds it into totals/total when has_transcription_models.
+    """
+    cost_data = CostData(input_cost=0.0, output_cost=0.0, total_cost=0.0)
+    detailed_breakdown = DetailedCostBreakdown(
+        transcription_duration=0.000825,
+        transcription_audio=0.000492,
+        transcription_text=0.0000125,
+        transcription_output=0.00038,
+    )
+
+    result = CostDataDTO.from_dao(
+        cost_data,
+        None,
+        detailed_breakdown,
+        has_chat_models=False,
+        has_transcription_models=True,
+    )
+
+    assert result.transcription_models is not None
+    assert result.transcription_models.input.duration == 0.000825
+    assert result.transcription_models.input.audio == 0.000492
+    assert result.transcription_models.input.text == 0.0000125
+    assert result.transcription_models.input.total == (
+        0.000825 + 0.000492 + 0.0000125
+    )
+    assert result.transcription_models.output == 0.00038
+    assert result.transcription_models.total == (
+        0.000825 + 0.000492 + 0.0000125 + 0.00038
+    )
+    assert result.totals is not None
+    assert result.totals.input == result.transcription_models.input.total
+    assert result.totals.output == 0.00038
+    assert result.total == result.transcription_models.total
+
+
+def test_from_dao_without_transcription_models_is_none():
+    """has_transcription_models=False (default) keeps transcription_models unset."""
+    cost_data = CostData(input_cost=0.0, output_cost=0.0, total_cost=0.0)
+    detailed_breakdown = DetailedCostBreakdown()
+
+    result = CostDataDTO.from_dao(
+        cost_data, None, detailed_breakdown, has_chat_models=False
+    )
+
+    assert result.transcription_models is None


### PR DESCRIPTION
# PR Summary: AG-893

Exposes the transcription cost breakdown (calculated in AG-892, already merged) through `CostDataDTO` — the same DTO already used for chat and embedding models. Adds a new `transcriptionModels` field parallel to the existing `chatModels`/`embeddingModels`, and folds transcription costs into the route-level `totals`. No new endpoints; three existing endpoints that already return `CostDataDTO`/wrap it now include the new field automatically.

---

## DTO Changes

### `TranscriptionModelsInputBreakdownDTO` (NEW)

| Field | Type | Description |
|-------|------|-------------|
| `total` | float | Total input costs for transcription models (duration + audio + text) |
| `duration` | float | Duration-based input costs (e.g. whisper-1, priced per second) |
| `audio` | float | Audio-token input costs (e.g. gpt-4o-transcribe family) |
| `text` | float | Text-token input costs (e.g. gpt-4o-transcribe family) |

Unlike `EmbeddingInputBreakdownDTO.semanticCache`, none of `duration`/`audio`/`text` are nullable — they default to `0` rather than being omitted, so all three are always present once the parent object exists. A route billed purely by duration (whisper-1) will still show `audio: 0, text: 0` rather than omitting them.

**Example response:**
```json
{
  "total": 0.0004,
  "duration": 0.0004,
  "audio": 0,
  "text": 0
}
```

---

### `TranscriptionModelsCostDTO` (NEW)

| Field | Type | Description |
|-------|------|-------------|
| `input` | TranscriptionModelsInputBreakdownDTO | Input costs broken down by duration/audio/text |
| `output` | float | Output token costs for transcription models (e.g. gpt-4o-transcribe family) |
| `total` | float | Sum of all transcription model costs (`input.total + output`) |

**Example response:**
```json
{
  "input": { "total": 0.0004, "duration": 0.0004, "audio": 0, "text": 0 },
  "output": 0,
  "total": 0.0004
}
```

---

### `TotalCostDTO` (MODIFIED)

**Changes:**
```diff
  input: float   (description updated: now includes transcription costs too)
  output: float  (description updated: now includes transcription costs too)
```

No field additions/removals — only the `input`/`output` descriptions changed, since their computed values now fold in transcription costs alongside chat/embedding.

| Field | Type | Description |
|-------|------|-------------|
| `input` | float | Total input costs from all model types (chat + embedding + **transcription**) |
| `cachedInput` | float | Total cached input costs from chat models |
| `output` | float | Total output costs from **chat and transcription** models |
| `saved` | float \| null | Total amount saved from caching |

---

### `CostDataDTO` (MODIFIED)

**Changes:**
```diff
+ transcriptionModels: TranscriptionModelsCostDTO | null  (added)
```

| Field | Type | Description |
|-------|------|-------------|
| `total` | float \| null | Grand total of all costs |
| `totals` | TotalCostDTO \| null | Aggregated totals across input, cachedInput, output, saved |
| `chatModels` | ChatModelsCostDTO \| null | Cost breakdown for chat models (direct + judges) |
| `embeddingModels` | EmbeddingModelsCostDTO \| null | Cost breakdown for embedding models (direct + semantic cache) |
| `transcriptionModels` **NEW** | TranscriptionModelsCostDTO \| null | Cost breakdown for transcription models (duration/audio/text input + output) |
| `inputCost`, `outputCost`, `totalCost`, `cacheTriggered`, `cacheSavedTokensInput`, `cacheSavedTokensOutput`, `savedAmountInput`, `savedAmountOutput`, `totalCachedTokens`, `totalSavedAmount` | various | Deprecated legacy fields, unchanged by this PR |

`transcriptionModels` is entirely **absent** from the JSON (not `null`) when the route has no `transcription_models` configured — same convention as `chatModels`/`embeddingModels`, driven by a new `has_transcription_models` flag threaded through `EventService`/`GatewayConfig.get_route_feature_flags` (which now returns a 5-tuple instead of 4).

**Example response** (route with a whisper-1 model configured):
```json
{
  "total": 30.4004,
  "totals": {
    "input": 12.3404,
    "cachedInput": 1.2,
    "output": 5.6,
    "saved": 0.3
  },
  "chatModels": {
    "input": { "total": 10.0, "direct": 8.5, "judges": 1.5 },
    "cachedInput": { "total": 1.2, "direct": 1.2, "judges": null },
    "output": { "total": 5.6, "direct": 5.6, "judges": null },
    "total": 16.8
  },
  "embeddingModels": {
    "input": { "total": 2.34, "embedding": 2.04, "semanticCache": 0.3 },
    "total": 2.34
  },
  "transcriptionModels": {
    "input": { "total": 0.0004, "duration": 0.0004, "audio": 0, "text": 0 },
    "output": 0,
    "total": 0.0004
  }
}
```

---

## Affected Endpoints

No new endpoints. Three existing endpoints return `CostDataDTO` (directly or nested) and now include `transcriptionModels` automatically — FastAPI regenerates the OpenAPI schema from the DTO, no route code changes were needed beyond threading the new flag through.

### `GET /public/api/v1/projects/{project_uuid}/routes/{route_name}/costs/summary` (MODIFIED — response body only)

**Example request:**
```
GET /public/api/v1/projects/550e8400-e29b-41d4-a716-446655440000/routes/my-route/costs/summary?_from=1704067200&_to=1704153600
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `route_name` | string | yes | Route name (path) |
| `_from` | integer | no | Start timestamp (Unix seconds) |
| `_to` | integer | no | End timestamp (Unix seconds) |
| `_with_saved_tokens` | boolean | no | Whether to include cache-savings fields |

### `GET /public/api/v1/projects/{project_uuid}/routes/costs/summary/stream` (MODIFIED — response body only)

SSE stream of the same `CostDataDTO` shape, re-emitted periodically; same query parameters as above plus `routes` (repeatable) and `_gte` (relative lookback, mutually exclusive with `_from`/`_to`).

### `GET /public/api/v1/projects/{project_uuid}/usage/costs` (MODIFIED — response body only)

Returns `UsageCostsDTO`, which nests `CostDataDTO` per route via `RouteCostDTO.summary` — gains `transcriptionModels` the same way, no shape change of its own.

---

## Other Changes

- `models/gateway_config.py` — `GatewayConfig.get_route_feature_flags` now returns a 5-tuple `(has_chat_models, has_judges, has_embedding_models, has_semantic_cache, has_transcription_models)` instead of 4.
- `services/event_service.py` — both call sites of `get_route_feature_flags` (per-route summary and multi-route aggregation) updated to unpack 5 values and pass `has_transcription_models` through to `CostDataDTO.from_dao`.
- `tests/models/test_event.py` — new/extended tests covering `TranscriptionModelsCostDTO` construction and its contribution to `totals`/grand total.
