### PR TITLE
feat: define tracing strategy for transcription requests

### DIFF
--- a/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
+++ b/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
@@ -6,6 +6,7 @@ import openai
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai.types.audio.transcription import Transcription
 from openai.types.audio.transcription_verbose import TranscriptionVerbose
+from opentelemetry import trace
 from traceloop.sdk.decorators import task
 
 from radicalbit_ai_gateway.invocation.model_invoker import ModelInvoker
@@ -25,6 +26,52 @@ app_config = get_app_config()
 logger = logging.getLogger(app_config.log_config.logger_name)
 
 WHISPER_FAMILY_PREFIX = 'whisper'
+
+
+def _set_transcription_request_attributes(
+    filename: str,
+    content_type: str | None,
+    audio_size_bytes: int,
+    model_id: str,
+) -> None:
+    """Metadata only — never the raw audio bytes."""
+    try:
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute('transcription.request.filename', filename)
+            span.set_attribute('transcription.request.content_type', content_type or '')
+            span.set_attribute(
+                'transcription.request.audio_size_bytes', audio_size_bytes
+            )
+            span.set_attribute('transcription.request.model_id', model_id)
+    except Exception:
+        pass
+
+
+def _set_transcription_response_attributes(
+    response: Transcription | TranscriptionVerbose,
+    is_whisper: bool,
+) -> None:
+    """Metadata only — never the full segments/timestamps array."""
+    try:
+        span = trace.get_current_span()
+        if not span.is_recording():
+            return
+        span.set_attribute(
+            'transcription.response.text_length', len(response.text or '')
+        )
+        if is_whisper:
+            span.set_attribute(
+                'transcription.response.language', response.language or ''
+            )
+            span.set_attribute(
+                'transcription.response.duration_seconds', response.duration or 0
+            )
+            span.set_attribute(
+                'transcription.response.segment_count', len(response.segments or [])
+            )
+    except Exception:
+        pass
 
 
 class TranscriptionModelInvoker(ModelInvoker):
@@ -92,6 +139,13 @@ class TranscriptionModelInvoker(ModelInvoker):
         is_whisper = model_name.startswith(WHISPER_FAMILY_PREFIX)
         upstream_format = 'verbose_json' if is_whisper else 'json'
 
+        _set_transcription_request_attributes(
+            filename=filename,
+            content_type=content_type,
+            audio_size_bytes=len(audio_bytes),
+            model_id=model_id,
+        )
+
         create_kwargs: dict = {
             'model': model_name,
             'file': (filename, audio_bytes, content_type or 'application/octet-stream'),
@@ -122,6 +176,7 @@ class TranscriptionModelInvoker(ModelInvoker):
                 f'Transcription upstream call failed: {e}'
             ) from e
         latency_ms = (time.monotonic() - start_time) * 1000
+        _set_transcription_response_attributes(response, is_whisper)
 
         usage = response.usage
         if is_whisper:

--- a/gateway/tests/invoker/test_transcription_model_invoker.py
+++ b/gateway/tests/invoker/test_transcription_model_invoker.py
@@ -126,6 +126,90 @@ class TestTranscriptionModelInvoker(unittest.IsolatedAsyncioTestCase):
         assert result.usage.type == 'tokens'
         assert result.usage.input_token_details.audio_tokens == 82
 
+    async def test_transcribe_whisper_sets_span_attributes_without_audio_bytes(self):
+        invoker = self._build_invoker(WHISPER_MODEL)
+        mock_client = MockTranscriptionClient(response=WHISPER_VERBOSE_RESPONSE)
+        invoker.model_map['whisper'] = (WHISPER_MODEL, mock_client, [])
+
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+
+        with patch(
+            'radicalbit_ai_gateway.invocation.transcription_model_invoker.trace.get_current_span',
+            return_value=mock_span,
+        ):
+            await invoker.transcribe(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='whisper',
+            )
+
+        mock_span.set_attribute.assert_any_call(
+            'transcription.request.filename', 'test.wav'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.request.content_type', 'audio/wav'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.request.audio_size_bytes', len(b'fake-audio')
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.request.model_id', 'whisper'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.text_length', len('Ciao, questo è un test.')
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.language', 'italian'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.duration_seconds', 8.25
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.segment_count', 0
+        )
+        # AG-895: never the raw audio content, only its size.
+        for call in mock_span.set_attribute.call_args_list:
+            assert b'fake-audio' not in call.args
+
+    async def test_transcribe_gpt4o_sets_span_attributes_without_whisper_fields(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        mock_client = MockTranscriptionClient(response=GPT4O_JSON_RESPONSE)
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            mock_client,
+            [],
+        )
+
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+
+        with patch(
+            'radicalbit_ai_gateway.invocation.transcription_model_invoker.trace.get_current_span',
+            return_value=mock_span,
+        ):
+            await invoker.transcribe(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            )
+
+        mock_span.set_attribute.assert_any_call(
+            'transcription.request.model_id', 'gpt4o-transcribe'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.text_length', len('Ciao, questo è un test.')
+        )
+        # gpt-4o-transcribe's Transcription has no language/duration/segments.
+        set_attrs = {c.args[0] for c in mock_span.set_attribute.call_args_list}
+        assert 'transcription.response.language' not in set_attrs
+        assert 'transcription.response.duration_seconds' not in set_attrs
+        assert 'transcription.response.segment_count' not in set_attrs
+
     async def test_transcribe_unknown_model_id_raises_bad_request(self):
         invoker = self._build_invoker(WHISPER_MODEL)
 


### PR DESCRIPTION
# PR Summary: AG-895

Defines and implements the tracing/logging strategy for `/v1/audio/transcriptions`: adds explicit, lightweight span attributes for request and response metadata, instead of relying on an incidental (and fragile) side effect of Traceloop's default argument auto-capture that happened to keep the raw audio bytes out of traces today. This is a purely internal observability change — no DTO or endpoint changes are part of this PR.

---

## DTO Changes

None. `radicalbit_ai_gateway/models/` and `radicalbit_ai_gateway/routes/` are untouched by this PR.

---

## Affected Endpoints

None directly modified. `POST /v1/audio/transcriptions` gains richer OpenTelemetry span attributes on its underlying `llm_transcribe` trace span, but its request/response shape is unchanged.

---

## Other Changes

### Tracing instrumentation — `invocation/transcription_model_invoker.py`

Context: `TranscriptionModelInvoker.transcribe()` is decorated `@task(name='llm_transcribe')`, and Traceloop's decorator auto-captures the method's args/kwargs (including the raw `audio_bytes`) into a `traceloop.entity.input` span attribute by default. Investigation for this ticket found that Traceloop's JSON encoder can't serialize raw `bytes` and silently falls back to the literal string `"bytes"` — so the audio payload never actually leaked into traces, but only by accident of that fallback behavior, not by any deliberate exclusion.

- New `_set_transcription_request_attributes(filename, content_type, audio_size_bytes, model_id)` — called right before the upstream OpenAI call, sets `transcription.request.filename`, `.content_type`, `.audio_size_bytes`, `.model_id` directly on the current span. Never touches the raw audio bytes.
- New `_set_transcription_response_attributes(response, is_whisper)` — called right after the upstream response, sets `transcription.response.text_length` always, and (only for whisper-1, since only its `TranscriptionVerbose` response carries these) `transcription.response.language`, `.duration_seconds`, `.segment_count`. Deliberately **not** the full `segments`/timestamps array — no dedicated UI renderer exists to justify that storage cost (the trace detail view is a generic JSON viewer).
- Both functions follow the exact same `trace.get_current_span()` + `span.is_recording()` + `set_attribute(...)` pattern already used in `guardrails/guardrail_check.py`, wrapped in a broad `try/except` so tracing failures never affect the request path.
- Attribute keys use `transcription.request.*`/`transcription.response.*` dotted namespacing (span attributes are a flat string-keyed map, not nested objects) — mirrors the existing `guardrail.presidio.*`/`guardrail.judge.*`/`guardrail.triggered.*` sub-namespacing convention, so request- and response-time attributes visually group together in the generic trace attribute viewer.
- Cost/budget calculation (`_record_transcription_usage_cost` in this file, `_count_transcription_usage` in `ai_gateway.py`) and the new tracing calls are independent — both already read from the raw upstream `response`/`usage` object, not from the client-facing `body`, so neither needed any change for the other to work.

### Tests — `tests/invoker/test_transcription_model_invoker.py`

- `test_transcribe_whisper_sets_span_attributes_without_audio_bytes` — mocks `trace.get_current_span`, asserts all 4 request + 4 response attributes are set for a whisper-1 call, and explicitly asserts the raw audio bytes never appear in any `set_attribute` call.
- `test_transcribe_gpt4o_sets_span_attributes_without_whisper_fields` — same for gpt-4o-transcribe, asserting `language`/`duration_seconds`/`segment_count` are **not** set (that response type doesn't carry them).
