### PR TITLE
feat: add mcp telemetry

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/request_event_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/request_event_dao.py
@@ -28,14 +28,6 @@ class RequestEventDAO:
         self.T = RequestEvent.__table__
 
     def _base_columns(self):
-        # Classified by REQUEST_STATUS, not HTTP_STATUS_CODE, so every reader in
-        # this DAO shares one definition of failure (get_error_breakdown and
-        # get_most_route_with_error already used it). The status code is not a
-        # reliable proxy: MCP returns JSON-RPC failures as an `error` body over
-        # HTTP 200, which the old `== 200` / `>= 400` pair counted as a success
-        # while the error breakdown in the same response counted it as an error.
-        # It also closes a gap for any 2xx that is not exactly 200, which
-        # previously counted as neither success nor error.
         T = self.T
         return [
             F.countIf(T.c['REQUEST_STATUS'] == RequestStatus.SUCCESS).label(

--- a/gateway/radicalbit_ai_gateway/db/dao/request_event_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/request_event_dao.py
@@ -28,10 +28,22 @@ class RequestEventDAO:
         self.T = RequestEvent.__table__
 
     def _base_columns(self):
+        # Classified by REQUEST_STATUS, not HTTP_STATUS_CODE, so every reader in
+        # this DAO shares one definition of failure (get_error_breakdown and
+        # get_most_route_with_error already used it). The status code is not a
+        # reliable proxy: MCP returns JSON-RPC failures as an `error` body over
+        # HTTP 200, which the old `== 200` / `>= 400` pair counted as a success
+        # while the error breakdown in the same response counted it as an error.
+        # It also closes a gap for any 2xx that is not exactly 200, which
+        # previously counted as neither success nor error.
         T = self.T
         return [
-            F.countIf(T.c['HTTP_STATUS_CODE'] == 200).label('successful_requests'),
-            F.countIf(T.c['HTTP_STATUS_CODE'] >= 400).label('error_requests'),
+            F.countIf(T.c['REQUEST_STATUS'] == RequestStatus.SUCCESS).label(
+                'successful_requests'
+            ),
+            F.countIf(T.c['REQUEST_STATUS'] != RequestStatus.SUCCESS).label(
+                'error_requests'
+            ),
             F.count().label('total_requests'),
             # nullIf converts epoch (returned by MAX on empty result sets) to NULL
             F.nullIf(F.max(T.c['TIMESTAMP']), text('toDateTime(0)')).label(

--- a/gateway/radicalbit_ai_gateway/mcp_proxy/upstream_client.py
+++ b/gateway/radicalbit_ai_gateway/mcp_proxy/upstream_client.py
@@ -72,6 +72,7 @@ class McpUpstreamClient:
             server, lambda session: session.call_tool(name, arguments), client_headers
         )
 
+    @task(name='mcp_upstream_list_prompts')
     async def list_prompts(
         self,
         server: AnyMcpServer,
@@ -83,6 +84,7 @@ class McpUpstreamClient:
             server, lambda session: session.list_prompts(cursor), client_headers
         )
 
+    @task(name='mcp_upstream_get_prompt')
     async def get_prompt(
         self,
         server: AnyMcpServer,
@@ -95,6 +97,7 @@ class McpUpstreamClient:
             server, lambda session: session.get_prompt(name, arguments), client_headers
         )
 
+    @task(name='mcp_upstream_list_resources')
     async def list_resources(
         self,
         server: AnyMcpServer,
@@ -106,6 +109,7 @@ class McpUpstreamClient:
             server, lambda session: session.list_resources(cursor), client_headers
         )
 
+    @task(name='mcp_upstream_read_resource')
     async def read_resource(
         self,
         server: AnyMcpServer,

--- a/gateway/radicalbit_ai_gateway/mcp_proxy/upstream_client.py
+++ b/gateway/radicalbit_ai_gateway/mcp_proxy/upstream_client.py
@@ -13,6 +13,7 @@ from mcp.client.stdio import (
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.exceptions import McpError as SdkMcpError
 from pydantic import AnyUrl
+from traceloop.sdk.decorators import task
 
 from radicalbit_ai_gateway.mcp_proxy.errors import McpUpstreamError
 from radicalbit_ai_gateway.mcp_proxy.headers import build_upstream_headers
@@ -46,6 +47,7 @@ class McpUpstreamClient:
         self._default_timeout = default_timeout
         self._httpx_client_factory = httpx_client_factory
 
+    @task(name='mcp_upstream_list_tools')
     async def list_tools(
         self,
         server: AnyMcpServer,
@@ -57,6 +59,7 @@ class McpUpstreamClient:
             server, lambda session: session.list_tools(cursor), client_headers
         )
 
+    @task(name='mcp_upstream_call_tool')
     async def call_tool(
         self,
         server: AnyMcpServer,

--- a/gateway/radicalbit_ai_gateway/middleware/request_event_middleware.py
+++ b/gateway/radicalbit_ai_gateway/middleware/request_event_middleware.py
@@ -54,8 +54,9 @@ class RequestEventMiddleware:
         segments = [segment for segment in scope.get('path', '').split('/') if segment]
         return len(segments) == 3 and segments[2] == 'mcp'
 
-    def is_tracked(self, scope: Scope) -> bool:
-        return scope.get('path', '') in self.TRACKED_PATHS or self.is_mcp_request(scope)
+    @classmethod
+    def is_tracked(cls, scope: Scope) -> bool:
+        return scope.get('path', '') in cls.TRACKED_PATHS or cls.is_mcp_request(scope)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope['type'] != 'http':
@@ -164,7 +165,7 @@ class RequestEventMiddleware:
     def _determine_status(
         http_code: int,
         ctx: RequestEventContext,
-        request_type: RequestType | None = None,
+        request_type: RequestType,
     ) -> RequestStatus:
         # MCP returns JSON-RPC failures as an `error` body over HTTP 200, so the
         # status code alone would report every failed tools/call as a success.

--- a/gateway/radicalbit_ai_gateway/middleware/request_event_middleware.py
+++ b/gateway/radicalbit_ai_gateway/middleware/request_event_middleware.py
@@ -1,4 +1,4 @@
-"""Middleware that emits REQUEST events for chat completions and embeddings."""
+"""Middleware that emits REQUEST events for the gateway's proxy endpoints."""
 
 from __future__ import annotations
 
@@ -21,10 +21,13 @@ logger = logging.getLogger(app_config.log_config.logger_name)
 
 
 class RequestEventMiddleware:
-    """Emits REQUEST event for chat completions and embeddings.
+    """Stamps ``request_uuid`` and emits a REQUEST event per proxied request.
 
     Pure ASGI middleware that properly handles exceptions by emitting events
     after exception handlers have processed the error.
+
+    ``request_uuid`` is generated here, and only here, so traces and events
+    share one correlation id.
     """
 
     TRACKED_PATHS = {
@@ -37,13 +40,29 @@ class RequestEventMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
+    @staticmethod
+    def is_mcp_request(scope: Scope) -> bool:
+        """Match ``POST /{project_name}/{route_name}/mcp``.
+
+        The inbound MCP proxy is mounted at the root with a dynamic path, so it
+        cannot be a literal in :attr:`TRACKED_PATHS`. Matching on an exact
+        segment count and the POST method keeps the SPA catch-all and the
+        ``/public/api/v1/...`` routes from colliding with it.
+        """
+        if scope.get('method') != 'POST':
+            return False
+        segments = [segment for segment in scope.get('path', '').split('/') if segment]
+        return len(segments) == 3 and segments[2] == 'mcp'
+
+    def is_tracked(self, scope: Scope) -> bool:
+        return scope.get('path', '') in self.TRACKED_PATHS or self.is_mcp_request(scope)
+
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope['type'] != 'http':
             await self.app(scope, receive, send)
             return
 
-        path = scope.get('path', '')
-        if path not in self.TRACKED_PATHS:
+        if not self.is_tracked(scope):
             await self.app(scope, receive, send)
             return
 
@@ -102,13 +121,21 @@ class RequestEventMiddleware:
                 )
                 return
 
-            status = self._determine_status(status_code, ctx)
-            if '/audio/transcriptions' in request.url.path:
+            if self.is_mcp_request(request.scope):
+                request_type = RequestType.MCP
+                if status_code == 202:
+                    # 202 is only ever a JSON-RPC notification (no id, no
+                    # response body). Emitting would fill request_event with
+                    # no-op handshake traffic.
+                    return
+            elif '/audio/transcriptions' in request.url.path:
                 request_type = RequestType.TRANSCRIPTIONS
             elif '/embeddings' in request.url.path:
                 request_type = RequestType.EMBEDDINGS
             else:
                 request_type = RequestType.CHAT_COMPLETIONS
+
+            status = self._determine_status(status_code, ctx, request_type)
 
             emit_request_event(
                 RequestEventPayload(
@@ -134,7 +161,17 @@ class RequestEventMiddleware:
             logger.exception('Failed to emit REQUEST event')
 
     @staticmethod
-    def _determine_status(http_code: int, ctx: RequestEventContext) -> RequestStatus:
+    def _determine_status(
+        http_code: int,
+        ctx: RequestEventContext,
+        request_type: RequestType | None = None,
+    ) -> RequestStatus:
+        # MCP returns JSON-RPC failures as an `error` body over HTTP 200, so the
+        # status code alone would report every failed tools/call as a success.
+        # Scoped to MCP: on the /v1/* endpoints an error always carries a 4xx/5xx,
+        # and widening this would reclassify anything that recovered to a 2xx.
+        if request_type is RequestType.MCP and http_code < 400 and ctx.error_type:
+            return RequestStatus.HANDLED_ERROR
         if http_code < 400:
             return RequestStatus.SUCCESS
         if ctx.is_unhandled_error:

--- a/gateway/radicalbit_ai_gateway/models/event_payload.py
+++ b/gateway/radicalbit_ai_gateway/models/event_payload.py
@@ -98,6 +98,7 @@ class RequestEventPayload(BaseModel):
         RequestType.CHAT_COMPLETIONS,
         RequestType.EMBEDDINGS,
         RequestType.TRANSCRIPTIONS,
+        RequestType.MCP,
     ]
     is_streaming: bool = False
     status: Literal[

--- a/gateway/radicalbit_ai_gateway/models/request_event_type.py
+++ b/gateway/radicalbit_ai_gateway/models/request_event_type.py
@@ -5,6 +5,7 @@ class RequestType(str, Enum):
     CHAT_COMPLETIONS = 'chat_completions'
     EMBEDDINGS = 'embeddings'
     TRANSCRIPTIONS = 'transcriptions'
+    MCP = 'mcp'
 
 
 class RequestStatus(str, Enum):

--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -3,9 +3,10 @@ from collections.abc import Mapping
 from importlib.metadata import PackageNotFoundError, version as _package_version
 import logging
 from urllib.parse import quote, unquote
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import Request
+from opentelemetry.trace import Status, StatusCode, get_current_span
 from traceloop.sdk.decorators import task, workflow
 
 from radicalbit_ai_gateway.auth.request_auth import authenticate_bearer_request
@@ -96,6 +97,29 @@ def decode_resource_uri(uri: str) -> tuple[str, str] | None:
     return unquote(alias_enc), unquote(uri_enc)
 
 
+def target_attributes(method: str, params: dict) -> dict:
+    """Best-effort ``alias``/``target`` for the methods addressing one object.
+
+    Resolved here rather than inside each handler because a ``@task`` detaches
+    its context on exit: attributes set inside one reach that task's span only,
+    never the enclosing ``mcp_request`` workflow span the traces list queries.
+    Called from the workflow scope, these land on the root span and are
+    inherited by the child task span.
+
+    An unresolvable name is still reported, since knowing what the client asked
+    for is what makes the failure diagnosable.
+    """
+    if method in ('tools/call', 'prompts/get'):
+        name = params.get('name')
+        split = split_alias_name(name) if isinstance(name, str) else None
+    elif method == 'resources/read':
+        uri = params.get('uri')
+        split = decode_resource_uri(uri) if isinstance(uri, str) else None
+    else:
+        return {}
+    return {'alias': split[0], 'target': split[1]} if split else {}
+
+
 class _McpMethodError(Exception):
     """Protocol-level failure inside a dispatched method → JSON-RPC error."""
 
@@ -128,12 +152,22 @@ class McpService:
         self, request: Request, project_name: str, route_name: str
     ) -> McpDispatchResult:
         """Authenticate and authorize the POST, then dispatch its JSON-RPC message."""
+        # Stamped before origin/auth checks so rejected requests stay
+        # correlatable. Unlike the /v1/* endpoints, whose request_uuid comes from
+        # RequestEventMiddleware, MCP is not a tracked path there — so reuse an
+        # existing id if one was set, else mint our own.
+        request_uuid = getattr(request.state, 'request_uuid', None) or str(uuid4())
+        request.state.request_uuid = request_uuid
+
         self._validate_origin(request)
 
         entry: ProjectEntry | None = request.app.state.project_configs.get(project_name)
         project_uuid = str(entry.uuid) if entry else ''
         set_trace_attributes(
-            project_uuid=project_uuid, project_name=project_name, route_name=route_name
+            request_uuid=request_uuid,
+            project_uuid=project_uuid,
+            project_name=project_name,
+            route_name=route_name,
         )
 
         set_operation_category(OperationCategory.AUTH)
@@ -161,14 +195,52 @@ class McpService:
         try:
             body = await request.json()
         except Exception:
-            return McpDispatchResult(
-                status_code=400,
-                payload=jsonrpc.error_message(None, jsonrpc.PARSE_ERROR, 'Parse error'),
+            return self._record_error_outcome(
+                McpDispatchResult(
+                    status_code=400,
+                    payload=jsonrpc.error_message(
+                        None, jsonrpc.PARSE_ERROR, 'Parse error'
+                    ),
+                )
             )
 
         servers = entry.config.get_route_mcp_servers(route_name)
         set_operation_category(OperationCategory.INVOCATION)
-        return await self._dispatch(body, servers, request.headers)
+        return self._record_error_outcome(
+            await self._dispatch(body, servers, request.headers)
+        )
+
+    @staticmethod
+    def _record_error_outcome(result: McpDispatchResult) -> McpDispatchResult:
+        """Mark the workflow span when the response carries a JSON-RPC error.
+
+        ``_dispatch`` returns protocol and upstream failures as ``error``
+        bodies over HTTP 200, so without this a failed ``tools/call`` is
+        indistinguishable from a success in the traces UI. Returns ``result``
+        so it can wrap a return statement.
+        """
+        error = (result.payload or {}).get('error')
+        if not error:
+            return result
+        set_mcp_attributes(error_code=error.get('code'))
+        span = get_current_span()
+        if span and span.is_recording():
+            span.set_status(Status(StatusCode.ERROR, error.get('message', '')))
+        return result
+
+    @staticmethod
+    def _record_fanout(total: int, failed: list[str], count: int) -> None:
+        """Record the outcome of a list method's fan-out on its own span.
+
+        Partial upstream failures are otherwise log-only, so a short list
+        can't be told from a degraded one. Always set, so ``mcp.result.count``
+        is present and ``mcp.upstream.failed`` is empty rather than absent.
+        """
+        span = get_current_span()
+        if span and span.is_recording():
+            span.set_attribute('mcp.upstream.total', total)
+            span.set_attribute('mcp.upstream.failed', ','.join(failed))
+            span.set_attribute('mcp.result.count', count)
 
     async def _dispatch(
         self,
@@ -192,6 +264,9 @@ class McpService:
                 ),
             )
         method = body['method']
+        # Recorded before the notification early-return so every dispatched
+        # message is attributable by method, not just the ones that reply.
+        set_mcp_attributes(method=method)
 
         if 'id' not in body:
             # Notifications (e.g. notifications/initialized) get no response.
@@ -217,6 +292,8 @@ class McpService:
                     request_id, jsonrpc.INVALID_PARAMS, 'params must be an object'
                 ),
             )
+
+        set_mcp_attributes(**target_attributes(method, params or {}))
 
         try:
             if method == 'initialize':
@@ -310,6 +387,7 @@ class McpService:
                 data = tool.model_dump(mode='json', by_alias=True, exclude_none=True)
                 data['name'] = f'{server.alias}{ALIAS_TOOL_SEPARATOR}{tool.name}'
                 tools.append(data)
+        self._record_fanout(len(servers), failed, len(tools))
         if failed:
             if len(failed) == len(servers):
                 raise _McpMethodError(
@@ -350,12 +428,12 @@ class McpService:
         )
         if split is None or server is None:
             raise _McpMethodError(jsonrpc.INVALID_PARAMS, f'Unknown tool: {name}')
-        set_mcp_attributes(method='tools/call', alias=split[0], tool_name=split[1])
         result = await self._upstream_client.call_tool(
             server, split[1], arguments, client_headers=client_headers
         )
         return result.model_dump(mode='json', by_alias=True, exclude_none=True)
 
+    @task(name='mcp_prompts_list')
     async def _prompts_list(
         self,
         servers: list[AnyMcpServer],
@@ -386,6 +464,7 @@ class McpService:
                 data = prompt.model_dump(mode='json', by_alias=True, exclude_none=True)
                 data['name'] = f'{server.alias}{ALIAS_TOOL_SEPARATOR}{prompt.name}'
                 prompts.append(data)
+        self._record_fanout(len(servers), failed, len(prompts))
         if failed:
             if len(failed) == len(servers):
                 raise _McpMethodError(
@@ -397,6 +476,7 @@ class McpService:
             )
         return {'prompts': prompts}
 
+    @task(name='mcp_prompts_get')
     async def _prompts_get(
         self,
         params: dict,
@@ -428,6 +508,7 @@ class McpService:
         )
         return result.model_dump(mode='json', by_alias=True, exclude_none=True)
 
+    @task(name='mcp_resources_list')
     async def _resources_list(
         self,
         servers: list[AnyMcpServer],
@@ -460,6 +541,7 @@ class McpService:
                 )
                 data['uri'] = encode_resource_uri(server.alias, data['uri'])
                 resources.append(data)
+        self._record_fanout(len(servers), failed, len(resources))
         if failed:
             if len(failed) == len(servers):
                 raise _McpMethodError(
@@ -471,6 +553,7 @@ class McpService:
             )
         return {'resources': resources}
 
+    @task(name='mcp_resources_read')
     async def _resources_read(
         self,
         params: dict,

--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from importlib.metadata import PackageNotFoundError, version as _package_version
 import logging
 from urllib.parse import quote, unquote
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from fastapi import Request
 from opentelemetry.trace import Status, StatusCode, get_current_span
@@ -16,6 +16,7 @@ from radicalbit_ai_gateway.mcp_proxy.errors import (
     McpUpstreamError,
 )
 from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
+from radicalbit_ai_gateway.middleware.request_event_context import RequestEventContext
 from radicalbit_ai_gateway.models.mcp_dispatch_result import McpDispatchResult
 from radicalbit_ai_gateway.models.mcp_server import ALIAS_TOOL_SEPARATOR, AnyMcpServer
 from radicalbit_ai_gateway.models.project_entry import ProjectEntry
@@ -152,12 +153,11 @@ class McpService:
         self, request: Request, project_name: str, route_name: str
     ) -> McpDispatchResult:
         """Authenticate and authorize the POST, then dispatch its JSON-RPC message."""
-        # Stamped before origin/auth checks so rejected requests stay
-        # correlatable. Unlike the /v1/* endpoints, whose request_uuid comes from
-        # RequestEventMiddleware, MCP is not a tracked path there — so reuse an
-        # existing id if one was set, else mint our own.
-        request_uuid = getattr(request.state, 'request_uuid', None) or str(uuid4())
-        request.state.request_uuid = request_uuid
+        # Stamped by RequestEventMiddleware before this handler runs, so it is
+        # present even when origin or auth checks reject the request. Absent
+        # only when McpService is driven without the middleware (unit tests),
+        # where set_trace_attributes drops the None.
+        request_uuid = getattr(request.state, 'request_uuid', None)
 
         self._validate_origin(request)
 
@@ -169,6 +169,13 @@ class McpService:
             project_name=project_name,
             route_name=route_name,
         )
+
+        # Populated before auth so the REQUEST event still identifies the route
+        # and project when the key is missing, invalid, or unbound.
+        ctx = RequestEventContext.get_or_create(request)
+        ctx.route_name = route_name
+        ctx.project_uuid = project_uuid
+        ctx.project_name = project_name
 
         set_operation_category(OperationCategory.AUTH)
         key_details = await authenticate_bearer_request(
@@ -196,36 +203,46 @@ class McpService:
             body = await request.json()
         except Exception:
             return self._record_error_outcome(
+                request,
                 McpDispatchResult(
                     status_code=400,
                     payload=jsonrpc.error_message(
                         None, jsonrpc.PARSE_ERROR, 'Parse error'
                     ),
-                )
+                ),
             )
 
         servers = entry.config.get_route_mcp_servers(route_name)
         set_operation_category(OperationCategory.INVOCATION)
         return self._record_error_outcome(
-            await self._dispatch(body, servers, request.headers)
+            request, await self._dispatch(body, servers, request.headers)
         )
 
     @staticmethod
-    def _record_error_outcome(result: McpDispatchResult) -> McpDispatchResult:
-        """Mark the workflow span when the response carries a JSON-RPC error.
+    def _record_error_outcome(
+        request: Request, result: McpDispatchResult
+    ) -> McpDispatchResult:
+        """Report a JSON-RPC error body to both telemetry pipelines.
 
-        ``_dispatch`` returns protocol and upstream failures as ``error``
-        bodies over HTTP 200, so without this a failed ``tools/call`` is
-        indistinguishable from a success in the traces UI. Returns ``result``
-        so it can wrap a return statement.
+        ``_dispatch`` returns protocol and upstream failures as ``error`` bodies
+        over HTTP 200, so without this a failed ``tools/call`` is
+        indistinguishable from a success in the traces UI and lands in
+        ``request_event`` as ``success``. Returns ``result`` so it can wrap a
+        return statement.
         """
         error = (result.payload or {}).get('error')
         if not error:
             return result
-        set_mcp_attributes(error_code=error.get('code'))
+        code = error.get('code')
+        set_mcp_attributes(error_code=code)
         span = get_current_span()
         if span and span.is_recording():
             span.set_status(Status(StatusCode.ERROR, error.get('message', '')))
+        ctx = RequestEventContext.get(request)
+        if ctx:
+            # Read back by _determine_status to downgrade the 200 to an error.
+            ctx.error_type = 'mcp_jsonrpc_error'
+            ctx.error_code = str(code)
         return result
 
     @staticmethod

--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -1,8 +1,9 @@
 import asyncio
 from collections.abc import Mapping
+from contextvars import ContextVar
 from importlib.metadata import PackageNotFoundError, version as _package_version
 import logging
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
 from uuid import UUID
 
 from fastapi import Request
@@ -45,6 +46,16 @@ MCP_SERVER_NAME = 'radicalbit-ai-gateway-mcp'
 # authority, like 'mailto:' or 'urn:') with both parts percent-encoded, so the
 # encoding never depends on either's character set.
 RESOURCE_URI_SCHEME = 'mcp-resource'
+
+# Written inside a ``@task``, read back from the enclosing workflow scope. A
+# task detaches its OTel context on exit, so nothing set inside one can reach
+# the root span — but a ContextVar mutated by an awaited coroutine belongs to
+# the enclosing request's context and outlives the task's return. Each request
+# runs in its own asyncio task, whose context is a copy, so this never bleeds
+# between requests.
+_fanout_failed: ContextVar[tuple[str, ...]] = ContextVar(
+    'mcp_fanout_failed', default=()
+)
 
 
 def gateway_version() -> str:
@@ -98,8 +109,32 @@ def decode_resource_uri(uri: str) -> tuple[str, str] | None:
     return unquote(alias_enc), unquote(uri_enc)
 
 
-def target_attributes(method: str, params: dict) -> dict:
-    """Best-effort ``alias``/``target`` for the methods addressing one object.
+def strip_uri_credentials(uri: str) -> str:
+    """Reduce a resource URI to the part that identifies the resource.
+
+    Scheme, host and path are what make the attribute useful; the query and the
+    ``user:pass@`` userinfo are where signed-URL tokens and basic-auth
+    credentials live. Spans reach every configured OTLP endpoint, third-party
+    ones included, so those parts must not travel with them.
+
+    Malformed input is returned unchanged rather than raising — an attribute is
+    never worth failing a request over, and an unparseable URI cannot resolve to
+    a configured alias in the first place.
+    """
+    try:
+        split = urlsplit(uri)
+        authority = split.hostname or ''
+        if authority and split.port:
+            authority = f'{authority}:{split.port}'
+        if not split.query and not split.fragment and authority == split.netloc:
+            return uri
+        return urlunsplit((split.scheme, authority, split.path, '', ''))
+    except ValueError:
+        return uri
+
+
+def target_attributes(method: str, params: dict, servers: list[AnyMcpServer]) -> dict:
+    """``alias``/``target`` for the methods addressing one object.
 
     Resolved here rather than inside each handler because a ``@task`` detaches
     its context on exit: attributes set inside one reach that task's span only,
@@ -107,8 +142,14 @@ def target_attributes(method: str, params: dict) -> dict:
     Called from the workflow scope, these land on the root span and are
     inherited by the child task span.
 
-    An unresolvable name is still reported, since knowing what the client asked
-    for is what makes the failure diagnosable.
+    Only a name resolving to a server configured on the route is recorded.
+    ``params`` is client-controlled and these become span attributes — indexed
+    dimensions — so echoing back an unresolvable name would let any caller mint
+    unlimited distinct values in the trace backend. Diagnosability is kept
+    without that: the rejected name still reaches the trace as the span status
+    description (``Unknown tool: {name}``, set from the JSON-RPC error message
+    by :meth:`McpService._record_error_outcome`), which is a free-text field
+    rather than a dimension.
     """
     if method in ('tools/call', 'prompts/get'):
         name = params.get('name')
@@ -118,7 +159,15 @@ def target_attributes(method: str, params: dict) -> dict:
         split = decode_resource_uri(uri) if isinstance(uri, str) else None
     else:
         return {}
-    return {'alias': split[0], 'target': split[1]} if split else {}
+    if split is None or not any(server.alias == split[0] for server in servers):
+        return {}
+    alias, target = split
+    return {
+        'alias': alias,
+        'target': strip_uri_credentials(target)
+        if method == 'resources/read'
+        else target,
+    }
 
 
 class _McpMethodError(Exception):
@@ -159,23 +208,24 @@ class McpService:
         # where set_trace_attributes drops the None.
         request_uuid = getattr(request.state, 'request_uuid', None)
 
-        self._validate_origin(request)
-
         entry: ProjectEntry | None = request.app.state.project_configs.get(project_name)
         project_uuid = str(entry.uuid) if entry else ''
+
+        # Populated before the first check that can reject, so every outcome —
+        # a rejected Origin, a missing, invalid or unbound key — still names the
+        # route and project it targeted in both the span and the REQUEST event.
         set_trace_attributes(
             request_uuid=request_uuid,
             project_uuid=project_uuid,
             project_name=project_name,
             route_name=route_name,
         )
-
-        # Populated before auth so the REQUEST event still identifies the route
-        # and project when the key is missing, invalid, or unbound.
         ctx = RequestEventContext.get_or_create(request)
         ctx.route_name = route_name
         ctx.project_uuid = project_uuid
         ctx.project_name = project_name
+
+        self._validate_origin(request)
 
         set_operation_category(OperationCategory.AUTH)
         key_details = await authenticate_bearer_request(
@@ -214,9 +264,9 @@ class McpService:
 
         servers = entry.config.get_route_mcp_servers(route_name)
         set_operation_category(OperationCategory.INVOCATION)
-        return self._record_error_outcome(
-            request, await self._dispatch(body, servers, request.headers)
-        )
+        result = await self._dispatch(body, servers, request.headers)
+        self._record_degradation()
+        return self._record_error_outcome(request, result)
 
     @staticmethod
     def _record_error_outcome(
@@ -242,22 +292,38 @@ class McpService:
         if ctx:
             # Read back by _determine_status to downgrade the 200 to an error.
             ctx.error_type = 'mcp_jsonrpc_error'
-            ctx.error_code = str(code)
+            ctx.error_code = str(code) if code is not None else None
         return result
 
     @staticmethod
     def _record_fanout(total: int, failed: list[str], count: int) -> None:
         """Record the outcome of a list method's fan-out on its own span.
 
-        Partial upstream failures are otherwise log-only, so a short list
-        can't be told from a degraded one. Always set, so ``mcp.result.count``
-        is present and ``mcp.upstream.failed`` is empty rather than absent.
+        Partial upstream failures are otherwise log-only, so a short list can't
+        be told from a degraded one. Always set, so
+        ``rb.gateway.mcp_result_count`` is present and
+        ``rb.gateway.mcp_upstream_failed`` is empty rather than absent.
         """
+        _fanout_failed.set(tuple(failed))
         span = get_current_span()
         if span and span.is_recording():
-            span.set_attribute('mcp.upstream.total', total)
-            span.set_attribute('mcp.upstream.failed', ','.join(failed))
-            span.set_attribute('mcp.result.count', count)
+            span.set_attribute('rb.gateway.mcp_upstream_total', total)
+            span.set_attribute('rb.gateway.mcp_upstream_failed', ','.join(failed))
+            span.set_attribute('rb.gateway.mcp_result_count', count)
+
+    @staticmethod
+    def _record_degradation() -> None:
+        """Hoist a fan-out's failed upstreams onto the root span.
+
+        :meth:`_record_fanout` can only reach the task's own span, which the
+        root-span query behind the traces list never reads — so "which requests
+        were served from a degraded fan-out?" would be unanswerable there. Only
+        the failures are hoisted: the counts stay per-task detail, while this is
+        the signal worth filtering a trace list on.
+        """
+        failed = _fanout_failed.get()
+        if failed:
+            set_mcp_attributes(upstream_failed=','.join(failed))
 
     async def _dispatch(
         self,
@@ -287,6 +353,9 @@ class McpService:
 
         if 'id' not in body:
             # Notifications (e.g. notifications/initialized) get no response.
+            # The 202 is load-bearing beyond HTTP semantics: it is the only
+            # signal RequestEventMiddleware._emit_event has for "notification,
+            # emit no REQUEST event". Keep the two in step.
             logger.debug('MCP notification accepted: %s', method)
             return McpDispatchResult(status_code=202)
 
@@ -310,7 +379,7 @@ class McpService:
                 ),
             )
 
-        set_mcp_attributes(**target_attributes(method, params or {}))
+        set_mcp_attributes(**target_attributes(method, params or {}, servers))
 
         try:
             if method == 'initialize':

--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -5,6 +5,7 @@ import logging
 from uuid import UUID
 
 from fastapi import Request
+from traceloop.sdk.decorators import task, workflow
 
 from radicalbit_ai_gateway.auth.request_auth import authenticate_bearer_request
 from radicalbit_ai_gateway.mcp_proxy import jsonrpc
@@ -19,6 +20,13 @@ from radicalbit_ai_gateway.models.project_entry import ProjectEntry
 from radicalbit_ai_gateway.services.group_service import GroupService
 from radicalbit_ai_gateway.utils.app_config import get_app_config
 from radicalbit_ai_gateway.utils.exceptions import McpTransportError
+from radicalbit_ai_gateway.utils.trace_attributes import (
+    OperationCategory,
+    ensure_endpoint_category,
+    set_mcp_attributes,
+    set_operation_category,
+    set_trace_attributes,
+)
 
 logger = logging.getLogger(get_app_config().log_config.logger_name)
 
@@ -84,6 +92,8 @@ class McpService:
             else get_app_config().cors_config.cors_allow_origins
         )
 
+    @workflow(name='mcp_request')
+    @ensure_endpoint_category
     async def handle_post(
         self, request: Request, project_name: str, route_name: str
     ) -> McpDispatchResult:
@@ -92,6 +102,11 @@ class McpService:
 
         entry: ProjectEntry | None = request.app.state.project_configs.get(project_name)
         project_uuid = str(entry.uuid) if entry else ''
+        set_trace_attributes(
+            project_uuid=project_uuid, project_name=project_name, route_name=route_name
+        )
+
+        set_operation_category(OperationCategory.AUTH)
         key_details = await authenticate_bearer_request(
             request, project_uuid, project_name
         )
@@ -122,6 +137,7 @@ class McpService:
             )
 
         servers = entry.config.get_route_mcp_servers(route_name)
+        set_operation_category(OperationCategory.INVOCATION)
         return await self._dispatch(body, servers, request.headers)
 
     async def _dispatch(
@@ -212,6 +228,7 @@ class McpService:
             status_code=200, payload=jsonrpc.result_message(request_id, result)
         )
 
+    @task(name='mcp_initialize')
     def _initialize(self, params: dict) -> dict:
         return {
             'protocolVersion': negotiate_protocol_version(
@@ -221,6 +238,7 @@ class McpService:
             'serverInfo': {'name': MCP_SERVER_NAME, 'version': gateway_version()},
         }
 
+    @task(name='mcp_tools_list')
     async def _tools_list(
         self,
         servers: list[AnyMcpServer],
@@ -263,6 +281,7 @@ class McpService:
             )
         return {'tools': tools}
 
+    @task(name='mcp_tools_call')
     async def _tools_call(
         self,
         params: dict,
@@ -291,6 +310,7 @@ class McpService:
         )
         if split is None or server is None:
             raise _McpMethodError(jsonrpc.INVALID_PARAMS, f'Unknown tool: {name}')
+        set_mcp_attributes(method='tools/call', alias=split[0], tool_name=split[1])
         result = await self._upstream_client.call_tool(
             server, split[1], arguments, client_headers=client_headers
         )

--- a/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
+++ b/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
@@ -67,6 +67,7 @@ def set_mcp_attributes(
     alias: str | None = None,
     target: str | None = None,
     error_code: int | None = None,
+    upstream_failed: str | None = None,
 ) -> None:
     """Record MCP-specific attributes on the current trace.
 
@@ -74,6 +75,9 @@ def set_mcp_attributes(
     prompt name for ``prompts/get``, or the upstream URI for
     ``resources/read``. ``method`` disambiguates which, so one attribute
     serves all three instead of one per kind.
+
+    ``upstream_failed`` is the comma-joined aliases a list method's fan-out
+    could not reach, set only when a fan-out was actually degraded.
     """
     properties = {
         'rb.gateway.mcp_method': method,
@@ -82,6 +86,7 @@ def set_mcp_attributes(
         'rb.gateway.mcp_error_code': str(error_code)
         if error_code is not None
         else None,
+        'rb.gateway.mcp_upstream_failed': upstream_failed,
     }
     properties = {k: v for k, v in properties.items() if v is not None}
     if properties:

--- a/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
+++ b/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
@@ -65,12 +65,23 @@ def set_trace_attributes(
 def set_mcp_attributes(
     method: str | None = None,
     alias: str | None = None,
-    tool_name: str | None = None,
+    target: str | None = None,
+    error_code: int | None = None,
 ) -> None:
+    """Record MCP-specific attributes on the current trace.
+
+    ``target`` is the method's subject: a tool name for ``tools/call``, a
+    prompt name for ``prompts/get``, or the upstream URI for
+    ``resources/read``. ``method`` disambiguates which, so one attribute
+    serves all three instead of one per kind.
+    """
     properties = {
         'rb.gateway.mcp_method': method,
         'rb.gateway.mcp_alias': alias,
-        'rb.gateway.mcp_tool_name': tool_name,
+        'rb.gateway.mcp_target': target,
+        'rb.gateway.mcp_error_code': str(error_code)
+        if error_code is not None
+        else None,
     }
     properties = {k: v for k, v in properties.items() if v is not None}
     if properties:

--- a/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
+++ b/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
@@ -62,6 +62,21 @@ def set_trace_attributes(
         _merge_association_properties(properties)
 
 
+def set_mcp_attributes(
+    method: str | None = None,
+    alias: str | None = None,
+    tool_name: str | None = None,
+) -> None:
+    properties = {
+        'rb.gateway.mcp_method': method,
+        'rb.gateway.mcp_alias': alias,
+        'rb.gateway.mcp_tool_name': tool_name,
+    }
+    properties = {k: v for k, v in properties.items() if v is not None}
+    if properties:
+        _merge_association_properties(properties)
+
+
 def ensure_endpoint_category(func):
     """Ensure the workflow span always ends with ENDPOINT category.
 

--- a/gateway/tests/dao/request_event_dao_test.py
+++ b/gateway/tests/dao/request_event_dao_test.py
@@ -6,7 +6,7 @@ from tests.common import db_mock
 from tests.common.db_integration_ch import DatabaseIntegrationClickhouse
 
 from radicalbit_ai_gateway.db.dao.request_event_dao import RequestEventDAO
-from radicalbit_ai_gateway.models.request_event_type import RequestStatus
+from radicalbit_ai_gateway.models.request_event_type import RequestStatus, RequestType
 
 
 class RequestEventDAOTest(DatabaseIntegrationClickhouse):
@@ -234,6 +234,7 @@ class RequestEventDAOTest(DatabaseIntegrationClickhouse):
             db_mock.get_sample_request_event(
                 timestamp=base_time + datetime.timedelta(minutes=20),
                 route_name='route-a',
+                request_status=RequestStatus.UNHANDLED_ERROR,
                 http_status_code=500,
             ),
         ]
@@ -246,6 +247,43 @@ class RequestEventDAOTest(DatabaseIntegrationClickhouse):
         assert res.error_requests == 1
         assert res.total_requests == 3
         assert res.last_request_timestamp is not None
+
+    def test_get_request_stats_counts_an_mcp_error_over_http_200_as_an_error(self):
+        """MCP returns JSON-RPC failures as an `error` body over HTTP 200.
+
+        Classifying on HTTP_STATUS_CODE counted these as successes here while
+        get_error_breakdown, which reads REQUEST_STATUS, counted them as errors —
+        two contradictory numbers in one dashboard response.
+        """
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        test_events = [
+            db_mock.get_sample_request_event(
+                timestamp=base_time,
+                route_name='route-a',
+                request_type=RequestType.MCP,
+                request_status=RequestStatus.SUCCESS,
+                http_status_code=200,
+            ),
+            db_mock.get_sample_request_event(
+                timestamp=base_time + datetime.timedelta(minutes=10),
+                route_name='route-a',
+                request_type=RequestType.MCP,
+                request_status=RequestStatus.HANDLED_ERROR,
+                http_status_code=200,
+                error_type='mcp_jsonrpc_error',
+                error_code='-32602',
+            ),
+        ]
+        self.insert(test_events)
+
+        res = self.request_event_dao.get_request_stats_global(
+            None, _from=base_time, _to=base_time + datetime.timedelta(hours=1)
+        )
+        assert res.successful_requests == 1
+        assert res.error_requests == 1
+        assert res.total_requests == 2
 
     def test_get_request_stats_global_filters_by_time_range(self):
         base_time = datetime.datetime(

--- a/gateway/tests/mcp/test_instrumentation.py
+++ b/gateway/tests/mcp/test_instrumentation.py
@@ -38,8 +38,11 @@ def _span_name(func) -> str | None:
     """Recover a Traceloop entity name from the decorator's closure.
 
     Traceloop exposes no public accessor for it, so this reads the closed-over
-    name. If a future SDK version changes that, this returns None and only the
-    name assertions loosen — the ``__wrapped__`` check below still holds.
+    name. ``traceloop-sdk`` is an open version range, so a future release
+    closing over a second string would make this ambiguous; it returns None
+    there, and callers must treat None as "can't tell" rather than as a
+    mismatch — otherwise an SDK bump reads as a missing decorator, which the
+    ``__wrapped__`` assertions check independently anyway.
     """
     names = [
         cell.cell_contents
@@ -49,23 +52,30 @@ def _span_name(func) -> str | None:
     return names[0] if len(names) == 1 else None
 
 
+def _assert_span_name(func, expected: str) -> None:
+    actual = _span_name(func)
+    assert actual in (expected, None), (
+        f'expected span name {expected!r}, found {actual!r}'
+    )
+
+
 @pytest.mark.parametrize(('method', 'span'), sorted(SERVICE_SPANS.items()))
 def test_service_handlers_are_instrumented(method, span):
     func = getattr(McpService, method)
     assert hasattr(func, '__wrapped__'), f'{method} is missing its @task decorator'
-    assert _span_name(func) == span
+    _assert_span_name(func, span)
 
 
 @pytest.mark.parametrize(('method', 'span'), sorted(UPSTREAM_SPANS.items()))
 def test_upstream_calls_are_instrumented(method, span):
     func = getattr(McpUpstreamClient, method)
     assert hasattr(func, '__wrapped__'), f'{method} is missing its @task decorator'
-    assert _span_name(func) == span
+    _assert_span_name(func, span)
 
 
 def test_handle_post_is_the_root_workflow():
     assert hasattr(McpService.handle_post, '__wrapped__')
-    assert _span_name(McpService.handle_post) == 'mcp_request'
+    _assert_span_name(McpService.handle_post, 'mcp_request')
 
 
 def test_every_public_upstream_operation_is_covered():

--- a/gateway/tests/mcp/test_instrumentation.py
+++ b/gateway/tests/mcp/test_instrumentation.py
@@ -1,0 +1,78 @@
+"""Guards that every MCP handler carries a Traceloop span.
+
+This is the regression that already happened once: ``prompts/*`` and
+``resources/*`` shipped after the first telemetry pass and went uninstrumented,
+so half the dispatch table was invisible in traces. These tests fail when a new
+handler is added without a decorator.
+"""
+
+import pytest
+
+from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
+from radicalbit_ai_gateway.services.mcp_service import McpService
+
+# Every dispatch branch in McpService._dispatch that has its own handler
+# method. 'ping' is intentionally absent: it returns {} inline, and the
+# mcp_request workflow span plus rb.gateway.mcp_method covers it.
+SERVICE_SPANS = {
+    '_initialize': 'mcp_initialize',
+    '_tools_list': 'mcp_tools_list',
+    '_tools_call': 'mcp_tools_call',
+    '_prompts_list': 'mcp_prompts_list',
+    '_prompts_get': 'mcp_prompts_get',
+    '_resources_list': 'mcp_resources_list',
+    '_resources_read': 'mcp_resources_read',
+}
+
+UPSTREAM_SPANS = {
+    'list_tools': 'mcp_upstream_list_tools',
+    'call_tool': 'mcp_upstream_call_tool',
+    'list_prompts': 'mcp_upstream_list_prompts',
+    'get_prompt': 'mcp_upstream_get_prompt',
+    'list_resources': 'mcp_upstream_list_resources',
+    'read_resource': 'mcp_upstream_read_resource',
+}
+
+
+def _span_name(func) -> str | None:
+    """Recover a Traceloop entity name from the decorator's closure.
+
+    Traceloop exposes no public accessor for it, so this reads the closed-over
+    name. If a future SDK version changes that, this returns None and only the
+    name assertions loosen — the ``__wrapped__`` check below still holds.
+    """
+    names = [
+        cell.cell_contents
+        for cell in (func.__closure__ or ())
+        if isinstance(cell.cell_contents, str)
+    ]
+    return names[0] if len(names) == 1 else None
+
+
+@pytest.mark.parametrize(('method', 'span'), sorted(SERVICE_SPANS.items()))
+def test_service_handlers_are_instrumented(method, span):
+    func = getattr(McpService, method)
+    assert hasattr(func, '__wrapped__'), f'{method} is missing its @task decorator'
+    assert _span_name(func) == span
+
+
+@pytest.mark.parametrize(('method', 'span'), sorted(UPSTREAM_SPANS.items()))
+def test_upstream_calls_are_instrumented(method, span):
+    func = getattr(McpUpstreamClient, method)
+    assert hasattr(func, '__wrapped__'), f'{method} is missing its @task decorator'
+    assert _span_name(func) == span
+
+
+def test_handle_post_is_the_root_workflow():
+    assert hasattr(McpService.handle_post, '__wrapped__')
+    assert _span_name(McpService.handle_post) == 'mcp_request'
+
+
+def test_every_public_upstream_operation_is_covered():
+    """A new upstream operation must be added to UPSTREAM_SPANS above."""
+    operations = {
+        name
+        for name in vars(McpUpstreamClient)
+        if not name.startswith('_') and callable(getattr(McpUpstreamClient, name))
+    }
+    assert operations == set(UPSTREAM_SPANS)

--- a/gateway/tests/mcp/test_mcp_service.py
+++ b/gateway/tests/mcp/test_mcp_service.py
@@ -14,6 +14,7 @@ from radicalbit_ai_gateway.services.mcp_service import (
     encode_resource_uri,
     negotiate_protocol_version,
     split_alias_name,
+    strip_uri_credentials,
 )
 
 GITHUB = McpHttpServer(alias='github', url='https://github.example.com/mcp/')
@@ -92,6 +93,29 @@ def test_resource_uri_round_trips_reserved_characters():
 )
 def test_decode_resource_uri_rejects_foreign_or_malformed(uri):
     assert decode_resource_uri(uri) is None
+
+
+@pytest.mark.parametrize(
+    ('uri', 'expected'),
+    [
+        # the identifying part survives untouched
+        ('https://h.example/readme', 'https://h.example/readme'),
+        ('https://h.example:8443/readme', 'https://h.example:8443/readme'),
+        ('urn:isbn:123', 'urn:isbn:123'),
+        ('file:///etc/hosts', 'file:///etc/hosts'),
+        # signed-URL tokens and basic-auth credentials do not
+        ('https://h.example/r?token=s3cret', 'https://h.example/r'),
+        ('https://h.example/r#frag', 'https://h.example/r'),
+        ('https://user:pass@h.example/r', 'https://h.example/r'),
+        ('file:///etc/hosts?x=1', 'file:///etc/hosts'),
+        # unparseable input is passed through rather than raising
+        ('https://h.example:99999/r', 'https://h.example:99999/r'),
+        ('not a uri at all', 'not a uri at all'),
+        ('', ''),
+    ],
+)
+def test_strip_uri_credentials(uri, expected):
+    assert strip_uri_credentials(uri) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -783,8 +807,12 @@ async def test_resources_read_records_alias_and_the_upstream_uri():
     mock_set_attrs.assert_any_call(alias='github', target=upstream_uri)
 
 
-async def test_a_target_naming_no_known_upstream_is_still_recorded():
-    """What the client asked for is what makes the -32602 diagnosable."""
+async def test_a_target_naming_no_known_upstream_records_nothing():
+    """params.name is client-controlled: echoing it back is unbounded cardinality.
+
+    The name is still diagnosable from the span status description, which
+    _record_error_outcome sets from the JSON-RPC error message.
+    """
     client = MagicMock(spec_set=McpUpstreamClient)
     client.call_tool = AsyncMock()
 
@@ -794,7 +822,32 @@ async def test_a_target_naming_no_known_upstream_is_still_recorded():
         )
 
     assert result.payload['error']['code'] == -32602
-    mock_set_attrs.assert_any_call(alias='unknown', target='tool')
+    assert 'unknown__tool' in result.payload['error']['message']
+    assert all(c.kwargs.get('alias') is None for c in mock_set_attrs.call_args_list)
+    assert all(c.kwargs.get('target') is None for c in mock_set_attrs.call_args_list)
+
+
+async def test_a_resource_uris_credentials_are_stripped_before_reaching_a_span():
+    """Signed-URL tokens live in the query; the path is the resource identity."""
+    upstream_uri = 'https://user:pw@github.example.com/readme?token=s3cret#frag'
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.read_resource = AsyncMock(return_value=types.ReadResourceResult(contents=[]))
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service(client)._dispatch(
+            _request(
+                'resources/read',
+                params={'uri': encode_resource_uri('github', upstream_uri)},
+            ),
+            SERVERS,
+            None,
+        )
+
+    mock_set_attrs.assert_any_call(
+        alias='github', target='https://github.example.com/readme'
+    )
+    # only the span attribute is redacted; the upstream still gets the URI whole
+    assert client.read_resource.await_args.args[1] == upstream_uri
 
 
 @pytest.mark.parametrize(
@@ -861,9 +914,9 @@ async def test_tools_list_records_fanout_on_a_partial_failure():
         await _service(client)._dispatch(_request('tools/list'), SERVERS, None)
 
     assert _span_attrs(span) == {
-        'mcp.upstream.total': 2,
-        'mcp.upstream.failed': 'github',
-        'mcp.result.count': 1,
+        'rb.gateway.mcp_upstream_total': 2,
+        'rb.gateway.mcp_upstream_failed': 'github',
+        'rb.gateway.mcp_result_count': 1,
     }
 
 
@@ -882,9 +935,9 @@ async def test_list_records_fanout_on_full_success():
         await _service(client)._dispatch(_request('prompts/list'), SERVERS, None)
 
     assert _span_attrs(span) == {
-        'mcp.upstream.total': 2,
-        'mcp.upstream.failed': '',
-        'mcp.result.count': 3,
+        'rb.gateway.mcp_upstream_total': 2,
+        'rb.gateway.mcp_upstream_failed': '',
+        'rb.gateway.mcp_result_count': 3,
     }
 
 
@@ -901,7 +954,7 @@ async def test_resources_list_records_fanout():
     with patch(f'{MCP_SERVICE}.get_current_span', return_value=span):
         await _service(client)._dispatch(_request('resources/list'), SERVERS, None)
 
-    assert _span_attrs(span)['mcp.upstream.failed'] == 'jira'
+    assert _span_attrs(span)['rb.gateway.mcp_upstream_failed'] == 'jira'
 
 
 async def test_fanout_is_not_recorded_on_a_non_recording_span():

--- a/gateway/tests/mcp/test_mcp_service.py
+++ b/gateway/tests/mcp/test_mcp_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from mcp import types
 import pytest
@@ -675,3 +675,242 @@ async def test_resources_read_upstream_error_maps_to_jsonrpc_error():
     assert result.status_code == 200
     assert result.payload['error']['code'] == -32000
     assert 'timed out' in result.payload['error']['message']
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+MCP_SERVICE = 'radicalbit_ai_gateway.services.mcp_service'
+
+
+def _recorded_methods(mock_set_attrs) -> list[str]:
+    return [
+        c.kwargs['method']
+        for c in mock_set_attrs.call_args_list
+        if c.kwargs.get('method') is not None
+    ]
+
+
+@pytest.mark.parametrize(
+    'method',
+    [
+        'initialize',
+        'ping',
+        'tools/list',
+        'tools/call',
+        'prompts/list',
+        'prompts/get',
+        'resources/list',
+        'resources/read',
+        'completion/complete',  # unsupported, still attributed
+    ],
+)
+async def test_dispatch_records_the_method_for_every_request(method):
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+    client.list_prompts = AsyncMock(return_value=types.ListPromptsResult(prompts=[]))
+    client.list_resources = AsyncMock(
+        return_value=types.ListResourcesResult(resources=[])
+    )
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service(client)._dispatch(_request(method), SERVERS, None)
+
+    assert _recorded_methods(mock_set_attrs) == [method]
+
+
+async def test_dispatch_records_the_method_for_notifications():
+    """Notifications return 202 with no body, but still belong in traces."""
+    body = {'jsonrpc': '2.0', 'method': 'notifications/initialized'}
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        result = await _service()._dispatch(body, SERVERS, None)
+
+    assert result.status_code == 202
+    assert _recorded_methods(mock_set_attrs) == ['notifications/initialized']
+
+
+async def test_dispatch_records_no_method_for_a_malformed_envelope():
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service()._dispatch({'jsonrpc': '1.0'}, SERVERS, None)
+
+    assert _recorded_methods(mock_set_attrs) == []
+
+
+async def test_tools_call_records_alias_and_target():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.call_tool = AsyncMock(return_value=types.CallToolResult(content=[]))
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service(client)._dispatch(
+            _request('tools/call', params={'name': 'github__get_issue'}),
+            SERVERS,
+            None,
+        )
+
+    mock_set_attrs.assert_any_call(alias='github', target='get_issue')
+
+
+async def test_prompts_get_records_alias_and_target():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.get_prompt = AsyncMock(return_value=types.GetPromptResult(messages=[]))
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service(client)._dispatch(
+            _request('prompts/get', params={'name': 'github__review'}), SERVERS, None
+        )
+
+    mock_set_attrs.assert_any_call(alias='github', target='review')
+
+
+async def test_resources_read_records_alias_and_the_upstream_uri():
+    upstream_uri = 'https://github.example.com/readme'
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.read_resource = AsyncMock(return_value=types.ReadResourceResult(contents=[]))
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service(client)._dispatch(
+            _request(
+                'resources/read',
+                params={'uri': encode_resource_uri('github', upstream_uri)},
+            ),
+            SERVERS,
+            None,
+        )
+
+    # the decoded upstream URI, not the wrapped mcp-resource: form
+    mock_set_attrs.assert_any_call(alias='github', target=upstream_uri)
+
+
+async def test_a_target_naming_no_known_upstream_is_still_recorded():
+    """What the client asked for is what makes the -32602 diagnosable."""
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.call_tool = AsyncMock()
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        result = await _service(client)._dispatch(
+            _request('tools/call', params={'name': 'unknown__tool'}), SERVERS, None
+        )
+
+    assert result.payload['error']['code'] == -32602
+    mock_set_attrs.assert_any_call(alias='unknown', target='tool')
+
+
+@pytest.mark.parametrize(
+    'params',
+    [
+        {'name': 'no_separator'},  # unsplittable
+        {'name': 7},  # not a string
+        {},  # absent
+    ],
+)
+async def test_an_unsplittable_target_records_nothing(params):
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.call_tool = AsyncMock()
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service(client)._dispatch(
+            _request('tools/call', params=params), SERVERS, None
+        )
+
+    assert all(c.kwargs.get('alias') is None for c in mock_set_attrs.call_args_list)
+
+
+@pytest.mark.parametrize(
+    'method', ['initialize', 'ping', 'tools/list', 'prompts/list', 'resources/list']
+)
+async def test_methods_without_a_single_target_record_none(method):
+    """target_attributes only applies to the object-addressing methods."""
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+    client.list_prompts = AsyncMock(return_value=types.ListPromptsResult(prompts=[]))
+    client.list_resources = AsyncMock(
+        return_value=types.ListResourcesResult(resources=[])
+    )
+
+    with patch(f'{MCP_SERVICE}.set_mcp_attributes') as mock_set_attrs:
+        await _service(client)._dispatch(
+            _request(method, params={'name': 'github__x'}), SERVERS, None
+        )
+
+    assert all(c.kwargs.get('target') is None for c in mock_set_attrs.call_args_list)
+
+
+def _recording_span() -> MagicMock:
+    span = MagicMock()
+    span.is_recording.return_value = True
+    return span
+
+
+def _span_attrs(span: MagicMock) -> dict:
+    return {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list}
+
+
+async def test_tools_list_records_fanout_on_a_partial_failure():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(
+        side_effect=[
+            McpUpstreamError('github', 'boom'),
+            types.ListToolsResult(tools=[_tool('search')]),
+        ]
+    )
+    span = _recording_span()
+
+    with patch(f'{MCP_SERVICE}.get_current_span', return_value=span):
+        await _service(client)._dispatch(_request('tools/list'), SERVERS, None)
+
+    assert _span_attrs(span) == {
+        'mcp.upstream.total': 2,
+        'mcp.upstream.failed': 'github',
+        'mcp.result.count': 1,
+    }
+
+
+async def test_list_records_fanout_on_full_success():
+    """Always recorded, so a healthy fan-out is distinguishable from an absent one."""
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_prompts = AsyncMock(
+        side_effect=[
+            types.ListPromptsResult(prompts=[_prompt('a'), _prompt('b')]),
+            types.ListPromptsResult(prompts=[_prompt('c')]),
+        ]
+    )
+    span = _recording_span()
+
+    with patch(f'{MCP_SERVICE}.get_current_span', return_value=span):
+        await _service(client)._dispatch(_request('prompts/list'), SERVERS, None)
+
+    assert _span_attrs(span) == {
+        'mcp.upstream.total': 2,
+        'mcp.upstream.failed': '',
+        'mcp.result.count': 3,
+    }
+
+
+async def test_resources_list_records_fanout():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_resources = AsyncMock(
+        side_effect=[
+            types.ListResourcesResult(resources=[_resource('https://a.example/1')]),
+            McpUpstreamError('jira', 'boom'),
+        ]
+    )
+    span = _recording_span()
+
+    with patch(f'{MCP_SERVICE}.get_current_span', return_value=span):
+        await _service(client)._dispatch(_request('resources/list'), SERVERS, None)
+
+    assert _span_attrs(span)['mcp.upstream.failed'] == 'jira'
+
+
+async def test_fanout_is_not_recorded_on_a_non_recording_span():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+    span = MagicMock()
+    span.is_recording.return_value = False
+
+    with patch(f'{MCP_SERVICE}.get_current_span', return_value=span):
+        await _service(client)._dispatch(_request('tools/list'), SERVERS, None)
+
+    span.set_attribute.assert_not_called()

--- a/gateway/tests/mcp/test_span_attributes.py
+++ b/gateway/tests/mcp/test_span_attributes.py
@@ -1,0 +1,259 @@
+"""End-to-end span assertions for the MCP path, against a real OTel pipeline.
+
+The mock-based tests in ``test_mcp_service.py`` verify that the helpers are
+*called*; they cannot verify where the attributes actually land. That
+distinction matters: Traceloop's ``@task`` detaches its context token on exit,
+so anything set inside a task reaches that task's span only and never the
+enclosing ``mcp_request`` workflow span — which is the span
+``OtelTracesDAO.get_root_traces_paginated`` queries. These tests boot Traceloop
+against an in-memory exporter and assert on the emitted spans.
+
+Note: ``Traceloop.init`` installs a global tracer provider for the rest of the
+session. That only means other tests emit spans nobody collects.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import uuid
+
+from fastapi import FastAPI
+from mcp import types
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+import pytest
+from starlette.testclient import TestClient
+from traceloop.sdk import Traceloop
+
+from radicalbit_ai_gateway.mcp_proxy.errors import McpUpstreamError
+from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
+from radicalbit_ai_gateway.models.auth_dto import KeyDetails
+from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
+from radicalbit_ai_gateway.models.project_entry import ProjectEntry
+from radicalbit_ai_gateway.routes.mcp_route import McpRoute
+from radicalbit_ai_gateway.services.mcp_service import McpService, encode_resource_uri
+from radicalbit_ai_gateway.utils.exceptions import (
+    ApiKeyError,
+    McpTransportError,
+    api_key_exception_handler,
+    mcp_transport_exception_handler,
+)
+
+PATH = '/proj/my-route/mcp'
+AUTH = {'Authorization': 'Bearer sk-rb-abc'}
+ASSOC = 'traceloop.association.properties.'
+ROOT_SPAN = 'mcp_request.workflow'
+
+
+@pytest.fixture(scope='module')
+def exporter() -> InMemorySpanExporter:
+    exp = InMemorySpanExporter()
+    Traceloop.init(
+        app_name='test-gateway',
+        telemetry_enabled=False,
+        disable_batch=True,
+        processor=SimpleSpanProcessor(exp),
+    )
+    return exp
+
+
+@pytest.fixture
+def upstream() -> MagicMock:
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.call_tool = AsyncMock(return_value=types.CallToolResult(content=[]))
+    client.get_prompt = AsyncMock(return_value=types.GetPromptResult(messages=[]))
+    client.read_resource = AsyncMock(return_value=types.ReadResourceResult(contents=[]))
+    return client
+
+
+@pytest.fixture
+def client(exporter, upstream) -> TestClient:
+    exporter.clear()
+    config = GatewayConfig.model_validate(
+        {
+            'chat_models': [{'model_id': 'm1', 'model': 'openai/gpt-4o'}],
+            'routes': {
+                'my-route': {'chat_models': ['m1'], 'mcp_servers': ['github', 'jira']}
+            },
+            'mcp_servers': [
+                {
+                    'alias': 'github',
+                    'transport': 'streamable_http',
+                    'url': 'https://gh.example/mcp/',
+                },
+                {
+                    'alias': 'jira',
+                    'transport': 'streamable_http',
+                    'url': 'https://jira.example/mcp/',
+                },
+            ],
+        }
+    )
+    group_service = MagicMock()
+    group_service.check_key_uuid_for_route.return_value = True
+
+    app = FastAPI()
+    app.include_router(
+        McpRoute.get_mcp_router(
+            McpService(
+                upstream_client=upstream,
+                group_service=group_service,
+                allowed_origins=['*'],
+            )
+        )
+    )
+    app.add_exception_handler(McpTransportError, mcp_transport_exception_handler)
+    app.add_exception_handler(ApiKeyError, api_key_exception_handler)
+    app.state.project_configs = {'proj': ProjectEntry(uuid=uuid.uuid4(), config=config)}
+    app.state.token_validator = SimpleNamespace(
+        validate_token=AsyncMock(
+            return_value=KeyDetails(
+                api_key_uuid=str(uuid.uuid4()),
+                api_key_name='my-key',
+                group_uuid=str(uuid.uuid4()),
+                group_name='team-a',
+                hashed_api_key='h',
+            )
+        )
+    )
+    return TestClient(app)
+
+
+def _post(client: TestClient, method: str, params: dict | None = None):
+    body = {'jsonrpc': '2.0', 'id': 1, 'method': method}
+    if params is not None:
+        body['params'] = params
+    return client.post(PATH, json=body, headers=AUTH)
+
+
+def _span(exporter, name: str):
+    matches = [s for s in exporter.get_finished_spans() if s.name == name]
+    assert matches, (
+        f'no {name} span emitted, got {[s.name for s in exporter.get_finished_spans()]}'
+    )
+    return matches[-1]
+
+
+def _mcp_attrs(span) -> dict:
+    return {
+        k.replace(f'{ASSOC}rb.gateway.mcp_', ''): v
+        for k, v in (span.attributes or {}).items()
+        if 'rb.gateway.mcp_' in k
+    }
+
+
+def test_root_span_carries_the_request_uuid(client, exporter):
+    assert _post(client, 'ping').status_code == 200
+
+    recorded = _span(exporter, ROOT_SPAN).attributes[f'{ASSOC}request_uuid']
+    assert uuid.UUID(recorded).version == 4
+
+
+def test_root_span_carries_the_auth_identity(client, exporter):
+    """Supplied by authenticate_bearer_request, and must survive the MCP merge."""
+    assert _post(client, 'ping').status_code == 200
+
+    attrs = _span(exporter, ROOT_SPAN).attributes
+    assert attrs[f'{ASSOC}api_key_name'] == 'my-key'
+    assert attrs[f'{ASSOC}group_name'] == 'team-a'
+    assert attrs[f'{ASSOC}project_name'] == 'proj'
+    assert attrs[f'{ASSOC}route_name'] == 'my-route'
+
+
+@pytest.mark.parametrize(
+    ('method', 'params', 'expected_target'),
+    [
+        ('tools/call', {'name': 'github__get_issue'}, 'get_issue'),
+        ('prompts/get', {'name': 'github__review'}, 'review'),
+        (
+            'resources/read',
+            {'uri': encode_resource_uri('github', 'https://gh.example/readme')},
+            'https://gh.example/readme',
+        ),
+    ],
+)
+def test_root_span_carries_method_alias_and_target(
+    client, exporter, method, params, expected_target
+):
+    """The regression guard: these must reach the ROOT span, not just the task."""
+    assert _post(client, method, params).status_code == 200
+
+    assert _mcp_attrs(_span(exporter, ROOT_SPAN)) == {
+        'method': method,
+        'alias': 'github',
+        'target': expected_target,
+    }
+
+
+def test_a_jsonrpc_error_marks_the_root_span(client, exporter):
+    """HTTP is 200, so the span status is the only failure signal."""
+    response = _post(client, 'tools/call', {'name': 'nope__missing'})
+
+    assert response.status_code == 200
+    root = _span(exporter, ROOT_SPAN)
+    assert root.status.status_code is StatusCode.ERROR
+    # what was attempted, so the failure is diagnosable
+    assert _mcp_attrs(root) == {
+        'method': 'tools/call',
+        'alias': 'nope',
+        'target': 'missing',
+        'error_code': '-32602',
+    }
+
+
+def test_a_successful_call_leaves_the_root_span_unset(client, exporter):
+    assert _post(client, 'tools/call', {'name': 'github__get_issue'}).status_code == 200
+
+    assert _span(exporter, ROOT_SPAN).status.status_code is not StatusCode.ERROR
+
+
+def test_a_partial_fanout_failure_is_recorded_on_the_task_span(
+    client, exporter, upstream
+):
+    upstream.list_tools = AsyncMock(
+        side_effect=[
+            types.ListToolsResult(tools=[types.Tool(name='t', inputSchema={})]),
+            McpUpstreamError('jira', 'boom'),
+        ]
+    )
+
+    assert _post(client, 'tools/list').status_code == 200
+
+    attrs = _span(exporter, 'mcp_tools_list.task').attributes
+    assert attrs['mcp.upstream.total'] == 2
+    assert attrs['mcp.upstream.failed'] == 'jira'
+    assert attrs['mcp.result.count'] == 1
+
+
+def test_upstream_calls_get_their_own_child_span(client, exporter, upstream):
+    """Real upstream latency is only visible if the outbound call is its own span."""
+    assert _post(client, 'tools/call', {'name': 'github__get_issue'}).status_code == 200
+
+    names = {s.name for s in exporter.get_finished_spans()}
+    assert {'mcp_request.workflow', 'mcp_tools_call.task'} <= names
+
+
+def test_a_parse_error_marks_the_root_span(client, exporter):
+    """The 400 path returns before _dispatch, so it needs its own guard."""
+    response = client.post(
+        PATH, content=b'{not json', headers={**AUTH, 'Content-Type': 'application/json'}
+    )
+
+    assert response.status_code == 400
+    assert response.json()['error']['code'] == -32700
+    root = _span(exporter, ROOT_SPAN)
+    assert root.status.status_code is StatusCode.ERROR
+    assert _mcp_attrs(root) == {'error_code': '-32700'}
+
+
+def test_a_notification_leaves_the_root_span_unset(client, exporter):
+    response = client.post(
+        PATH,
+        json={'jsonrpc': '2.0', 'method': 'notifications/initialized'},
+        headers=AUTH,
+    )
+
+    assert response.status_code == 202
+    root = _span(exporter, ROOT_SPAN)
+    assert root.status.status_code is not StatusCode.ERROR
+    assert _mcp_attrs(root) == {'method': 'notifications/initialized'}

--- a/gateway/tests/mcp/test_span_attributes.py
+++ b/gateway/tests/mcp/test_span_attributes.py
@@ -1,4 +1,4 @@
-"""End-to-end span assertions for the MCP path, against a real OTel pipeline.
+"""End-to-end telemetry assertions for the MCP path, with production wiring.
 
 The mock-based tests in ``test_mcp_service.py`` verify that the helpers are
 *called*; they cannot verify where the attributes actually land. That
@@ -6,14 +6,18 @@ distinction matters: Traceloop's ``@task`` detaches its context token on exit,
 so anything set inside a task reaches that task's span only and never the
 enclosing ``mcp_request`` workflow span — which is the span
 ``OtelTracesDAO.get_root_traces_paginated`` queries. These tests boot Traceloop
-against an in-memory exporter and assert on the emitted spans.
+against an in-memory exporter and assert on the emitted spans, plus on the
+REQUEST event payloads the same request produces.
 
-Note: ``Traceloop.init`` installs a global tracer provider for the rest of the
-session. That only means other tests emit spans nobody collects.
+Note: ``Traceloop.init`` installs a global tracer provider that cannot be
+uninstalled, so the ``exporter`` fixture disables the wrapper on teardown. Without
+that, every later test in the session keeps feeding this exporter and the run is
+OOM-killed.
 """
 
+from collections.abc import Iterator
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 from fastapi import FastAPI
@@ -24,16 +28,22 @@ from opentelemetry.trace import StatusCode
 import pytest
 from starlette.testclient import TestClient
 from traceloop.sdk import Traceloop
+from traceloop.sdk.tracing.tracing import TracerWrapper
 
 from radicalbit_ai_gateway.mcp_proxy.errors import McpUpstreamError
 from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
+from radicalbit_ai_gateway.middleware.request_event_middleware import (
+    RequestEventMiddleware,
+)
 from radicalbit_ai_gateway.models.auth_dto import KeyDetails
 from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 from radicalbit_ai_gateway.models.project_entry import ProjectEntry
+from radicalbit_ai_gateway.models.request_event_type import RequestStatus, RequestType
 from radicalbit_ai_gateway.routes.mcp_route import McpRoute
 from radicalbit_ai_gateway.services.mcp_service import McpService, encode_resource_uri
 from radicalbit_ai_gateway.utils.exceptions import (
     ApiKeyError,
+    InvalidApiKey,
     McpTransportError,
     api_key_exception_handler,
     mcp_transport_exception_handler,
@@ -46,7 +56,7 @@ ROOT_SPAN = 'mcp_request.workflow'
 
 
 @pytest.fixture(scope='module')
-def exporter() -> InMemorySpanExporter:
+def exporter() -> Iterator[InMemorySpanExporter]:
     exp = InMemorySpanExporter()
     Traceloop.init(
         app_name='test-gateway',
@@ -54,7 +64,16 @@ def exporter() -> InMemorySpanExporter:
         disable_batch=True,
         processor=SimpleSpanProcessor(exp),
     )
-    return exp
+    TracerWrapper.set_disabled(False)
+    yield exp
+    # Traceloop installs a global tracer provider that cannot be uninstalled, so
+    # without this every later test in the session would keep emitting spans into
+    # this exporter — unbounded growth that OOM-kills the full run. Disabling the
+    # wrapper makes the decorators no-op again, restoring the behaviour the rest
+    # of the suite has always had (Traceloop is never initialized in production
+    # tests).
+    TracerWrapper.set_disabled(True)
+    exp.clear()
 
 
 @pytest.fixture
@@ -93,6 +112,9 @@ def client(exporter, upstream) -> TestClient:
     group_service.check_key_uuid_for_route.return_value = True
 
     app = FastAPI()
+    # request_uuid is stamped here in production, so the test app must have it
+    # too — otherwise the root span's request_uuid assertion proves nothing.
+    app.add_middleware(RequestEventMiddleware)
     app.include_router(
         McpRoute.get_mcp_router(
             McpService(
@@ -257,3 +279,76 @@ def test_a_notification_leaves_the_root_span_unset(client, exporter):
     root = _span(exporter, ROOT_SPAN)
     assert root.status.status_code is not StatusCode.ERROR
     assert _mcp_attrs(root) == {'method': 'notifications/initialized'}
+
+
+# ---------------------------------------------------------------------------
+# REQUEST events (same wiring, other pipeline)
+# ---------------------------------------------------------------------------
+
+EMIT = 'radicalbit_ai_gateway.middleware.request_event_middleware.emit_request_event'
+
+
+def test_the_request_event_carries_route_project_and_key_identity(client):
+    """Empty identity columns would make the rows useless to the dashboard."""
+    with patch(EMIT) as emit:
+        assert (
+            _post(client, 'tools/call', {'name': 'github__get_issue'}).status_code
+            == 200
+        )
+
+    payload = emit.call_args.args[0]
+    assert payload.request_type is RequestType.MCP
+    assert payload.route_name == 'my-route'
+    assert payload.project_name == 'proj'
+    assert payload.project_uuid
+    assert payload.api_key_name == 'my-key'
+    assert payload.group_name == 'team-a'
+    assert payload.status is RequestStatus.SUCCESS
+    assert payload.duration_ms > 0
+
+
+def test_the_request_event_shares_the_request_uuid_with_the_span(client, exporter):
+    """Pin the join that the traces and events pipelines rely on."""
+    with patch(EMIT) as emit:
+        assert _post(client, 'ping').status_code == 200
+
+    span_uuid = _span(exporter, ROOT_SPAN).attributes[f'{ASSOC}request_uuid']
+    assert emit.call_args.args[0].request_uuid == span_uuid
+
+
+def test_a_jsonrpc_error_is_a_handled_error_in_the_request_event(client):
+    with patch(EMIT) as emit:
+        assert _post(client, 'tools/call', {'name': 'nope__missing'}).status_code == 200
+
+    payload = emit.call_args.args[0]
+    assert payload.http_status_code == 200
+    assert payload.status is RequestStatus.HANDLED_ERROR
+    assert payload.error_type == 'mcp_jsonrpc_error'
+    assert payload.error_code == '-32602'
+
+
+def test_a_notification_emits_no_request_event(client):
+    with patch(EMIT) as emit:
+        response = client.post(
+            PATH,
+            json={'jsonrpc': '2.0', 'method': 'notifications/initialized'},
+            headers=AUTH,
+        )
+
+    assert response.status_code == 202
+    emit.assert_not_called()
+
+
+def test_an_auth_failure_still_reports_the_route_it_targeted(client):
+    """Context is populated before auth, so 401s stay attributable to a route."""
+    client.app.state.token_validator = SimpleNamespace(
+        validate_token=AsyncMock(side_effect=InvalidApiKey('nope'))
+    )
+
+    with patch(EMIT) as emit:
+        assert _post(client, 'ping').status_code == 401
+
+    payload = emit.call_args.args[0]
+    assert payload.route_name == 'my-route'
+    assert payload.project_name == 'proj'
+    assert payload.status is RequestStatus.HANDLED_ERROR

--- a/gateway/tests/mcp/test_span_attributes.py
+++ b/gateway/tests/mcp/test_span_attributes.py
@@ -63,6 +63,12 @@ def exporter() -> Iterator[InMemorySpanExporter]:
         telemetry_enabled=False,
         disable_batch=True,
         processor=SimpleSpanProcessor(exp),
+        # Omitting this enables every instrumentor Traceloop ships (openai,
+        # httpx, ...), which monkeypatch their libraries globally and are not
+        # undone by set_disabled below — they would stay installed for the rest
+        # of the session. The MCP path needs none of them, and production only
+        # enables LANGCHAIN.
+        instruments=set(),
     )
     TracerWrapper.set_disabled(False)
     yield exp
@@ -214,13 +220,11 @@ def test_a_jsonrpc_error_marks_the_root_span(client, exporter):
     assert response.status_code == 200
     root = _span(exporter, ROOT_SPAN)
     assert root.status.status_code is StatusCode.ERROR
-    # what was attempted, so the failure is diagnosable
-    assert _mcp_attrs(root) == {
-        'method': 'tools/call',
-        'alias': 'nope',
-        'target': 'missing',
-        'error_code': '-32602',
-    }
+    # 'nope' resolves to no configured upstream, so the client-supplied name is
+    # kept out of the attributes (unbounded cardinality) ...
+    assert _mcp_attrs(root) == {'method': 'tools/call', 'error_code': '-32602'}
+    # ... and stays diagnosable through the free-text status description
+    assert root.status.description == 'Unknown tool: nope__missing'
 
 
 def test_a_successful_call_leaves_the_root_span_unset(client, exporter):
@@ -242,9 +246,62 @@ def test_a_partial_fanout_failure_is_recorded_on_the_task_span(
     assert _post(client, 'tools/list').status_code == 200
 
     attrs = _span(exporter, 'mcp_tools_list.task').attributes
-    assert attrs['mcp.upstream.total'] == 2
-    assert attrs['mcp.upstream.failed'] == 'jira'
-    assert attrs['mcp.result.count'] == 1
+    assert attrs['rb.gateway.mcp_upstream_total'] == 2
+    assert attrs['rb.gateway.mcp_upstream_failed'] == 'jira'
+    assert attrs['rb.gateway.mcp_result_count'] == 1
+
+
+def test_a_partial_fanout_failure_also_reaches_the_root_span(
+    client, exporter, upstream
+):
+    """The task span is invisible to the root-span query behind the traces list."""
+    upstream.list_tools = AsyncMock(
+        side_effect=[
+            types.ListToolsResult(tools=[types.Tool(name='t', inputSchema={})]),
+            McpUpstreamError('jira', 'boom'),
+        ]
+    )
+
+    assert _post(client, 'tools/list').status_code == 200
+
+    root = _span(exporter, ROOT_SPAN)
+    assert _mcp_attrs(root) == {'method': 'tools/list', 'upstream_failed': 'jira'}
+    # a degraded fan-out is still a 200 with results — not a failed request
+    assert root.status.status_code is not StatusCode.ERROR
+
+
+def test_a_healthy_fanout_leaves_the_root_span_without_the_degraded_marker(
+    client, exporter, upstream
+):
+    upstream.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+
+    assert _post(client, 'tools/list').status_code == 200
+
+    assert _mcp_attrs(_span(exporter, ROOT_SPAN)) == {'method': 'tools/list'}
+
+
+def test_one_requests_degradation_does_not_leak_into_the_next(
+    client, exporter, upstream
+):
+    """The marker crosses a task boundary via a ContextVar, so prove the scope.
+
+    Each request is its own asyncio task with a copied context; a module-level
+    ContextVar would otherwise mark every later request as degraded.
+    """
+    upstream.list_tools = AsyncMock(
+        side_effect=[
+            types.ListToolsResult(tools=[]),
+            McpUpstreamError('jira', 'boom'),
+            types.ListToolsResult(tools=[]),
+            types.ListToolsResult(tools=[]),
+        ]
+    )
+
+    assert _post(client, 'tools/list').status_code == 200
+    assert _mcp_attrs(_span(exporter, ROOT_SPAN))['upstream_failed'] == 'jira'
+
+    assert _post(client, 'tools/list').status_code == 200
+    assert 'upstream_failed' not in _mcp_attrs(_span(exporter, ROOT_SPAN))
 
 
 def test_upstream_calls_get_their_own_child_span(client, exporter, upstream):

--- a/gateway/tests/middlewares/test_request_event_middleware.py
+++ b/gateway/tests/middlewares/test_request_event_middleware.py
@@ -1,0 +1,167 @@
+"""Path matching and REQUEST event classification in RequestEventMiddleware.
+
+The MCP proxy is mounted at the root with a dynamic path, so it cannot be a
+literal in ``TRACKED_PATHS`` — these tests pin the predicate that stands in for
+one against the routes it must not swallow. They also pin the two ways MCP
+differs from the ``/v1/*`` endpoints: a 202 notification is not an event, and a
+JSON-RPC error arrives over HTTP 200 rather than a 4xx.
+"""
+
+from unittest.mock import patch
+import uuid
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from radicalbit_ai_gateway.middleware.request_event_context import RequestEventContext
+from radicalbit_ai_gateway.middleware.request_event_middleware import (
+    RequestEventMiddleware,
+)
+from radicalbit_ai_gateway.models.request_event_type import RequestStatus, RequestType
+
+EMIT = 'radicalbit_ai_gateway.middleware.request_event_middleware.emit_request_event'
+
+
+def _scope(path: str, method: str = 'POST') -> dict:
+    return {'type': 'http', 'path': path, 'method': method}
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        '/proj/my-route/mcp',
+        '/a/b/mcp',
+        '/proj/route-with-dashes/mcp',
+    ],
+)
+def test_is_mcp_request_matches_the_proxy_path(path):
+    assert RequestEventMiddleware.is_mcp_request(_scope(path)) is True
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        '/public/api/v1/projects/mcp',  # 5 segments: management API
+        '/proj/my-route/mcp/extra',  # deeper than the route
+        '/mcp',  # 1 segment
+        '/proj/mcp',  # 2 segments
+        '/proj/my-route/mcpx',  # near miss
+        '/proj/my-route/tools',
+        '/v1/chat/completions',  # 3 segments, but not mcp
+        '',
+    ],
+)
+def test_is_mcp_request_rejects_everything_else(path):
+    assert RequestEventMiddleware.is_mcp_request(_scope(path)) is False
+
+
+@pytest.mark.parametrize('method', ['GET', 'DELETE', 'PUT', 'OPTIONS'])
+def test_is_mcp_request_is_post_only(method):
+    """The SPA catch-all serves GET on arbitrary paths."""
+    assert (
+        RequestEventMiddleware.is_mcp_request(_scope('/proj/my-route/mcp', method))
+        is False
+    )
+
+
+def _app(path: str, *, status_code: int = 200, error: str | None = None) -> TestClient:
+    """Build a one-route app behind the middleware.
+
+    ``error`` populates the request event context the way an exception handler
+    or ``McpService._record_error_outcome`` would, without a 4xx response.
+    """
+
+    async def endpoint(request):
+        if error is not None:
+            ctx = RequestEventContext.get_or_create(request)
+            ctx.error_type = error
+            ctx.error_code = '-32602'
+        # echo what the middleware stamped so the test can assert on it
+        return JSONResponse(
+            {'request_uuid': getattr(request.state, 'request_uuid', None)},
+            status_code=status_code,
+        )
+
+    app = Starlette(routes=[Route(path, endpoint, methods=['POST'])])
+    app.add_middleware(RequestEventMiddleware)
+    return TestClient(app)
+
+
+def test_mcp_requests_are_stamped_and_emit_an_mcp_event():
+    with patch(EMIT) as emit:
+        body = (
+            _app('/{project_name}/{route_name}/mcp').post('/proj/my-route/mcp').json()
+        )
+
+    assert uuid.UUID(body['request_uuid']).version == 4
+    payload = emit.call_args.args[0]
+    assert payload.request_type is RequestType.MCP
+    assert payload.request_uuid == body['request_uuid']
+
+
+def test_tracked_paths_are_stamped_and_emit_an_event():
+    with patch(EMIT) as emit:
+        body = _app('/v1/chat/completions').post('/v1/chat/completions').json()
+
+    assert uuid.UUID(body['request_uuid']).version == 4
+    assert emit.call_args.args[0].request_type is RequestType.CHAT_COMPLETIONS
+
+
+def test_an_mcp_notification_emits_no_event():
+    """202 means a JSON-RPC notification: no id, no body, nothing to bill."""
+    with patch(EMIT) as emit:
+        response = _app('/{project_name}/{route_name}/mcp', status_code=202).post(
+            '/proj/my-route/mcp'
+        )
+
+    assert response.status_code == 202
+    emit.assert_not_called()
+
+
+def test_an_mcp_jsonrpc_error_over_200_is_a_handled_error():
+    """The status code says success; only the error context says otherwise."""
+    with patch(EMIT) as emit:
+        _app('/{project_name}/{route_name}/mcp', error='mcp_jsonrpc_error').post(
+            '/proj/my-route/mcp'
+        )
+
+    payload = emit.call_args.args[0]
+    assert payload.http_status_code == 200
+    assert payload.status is RequestStatus.HANDLED_ERROR
+    assert payload.error_code == '-32602'
+
+
+def test_a_successful_mcp_call_is_a_success():
+    with patch(EMIT) as emit:
+        _app('/{project_name}/{route_name}/mcp').post('/proj/my-route/mcp')
+
+    assert emit.call_args.args[0].status is RequestStatus.SUCCESS
+
+
+def test_an_error_context_on_a_2xx_llm_call_stays_a_success():
+    """The MCP downgrade must not widen to the /v1/* endpoints."""
+    with patch(EMIT) as emit:
+        _app('/v1/chat/completions', error='SomeError').post('/v1/chat/completions')
+
+    assert emit.call_args.args[0].status is RequestStatus.SUCCESS
+
+
+def test_untracked_paths_are_left_alone():
+    with patch(EMIT) as emit:
+        body = _app('/public/api/v1/keys').post('/public/api/v1/keys').json()
+
+    assert body['request_uuid'] is None
+    emit.assert_not_called()
+
+
+def test_each_mcp_request_gets_its_own_request_uuid():
+    client = _app('/{project_name}/{route_name}/mcp')
+
+    with patch(EMIT):
+        first = client.post('/proj/my-route/mcp').json()['request_uuid']
+        second = client.post('/proj/my-route/mcp').json()['request_uuid']
+
+    assert first != second

--- a/gateway/tests/routes/test_mcp_route.py
+++ b/gateway/tests/routes/test_mcp_route.py
@@ -406,41 +406,30 @@ class _StampRequestUuid:
         await self.app(scope, receive, send)
 
 
-def test_request_uuid_is_stamped_on_the_trace():
+def test_the_service_reports_the_request_uuid_the_middleware_stamped():
+    """RequestEventMiddleware owns generation; the service only reads it."""
+    client, _ = _make_client()
+    stamped = str(uuid.uuid4())
+    client.app.add_middleware(_StampRequestUuid, value=stamped)
+
+    with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
+        assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 200
+
+    assert mock_set_attrs.call_args_list[0].kwargs['request_uuid'] == stamped
+
+
+def test_no_request_uuid_is_invented_without_the_middleware():
+    """None is dropped by set_trace_attributes rather than becoming a fake id."""
     client, _ = _make_client()
 
     with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
         assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 200
 
-    recorded = mock_set_attrs.call_args_list[0].kwargs['request_uuid']
-    # a real uuid4, not a placeholder
-    assert uuid.UUID(recorded).version == 4
-
-
-def test_request_uuid_is_reused_when_already_set():
-    """Keeps MCP correct if it is ever added to RequestEventMiddleware."""
-    client, _ = _make_client()
-    existing = str(uuid.uuid4())
-    client.app.add_middleware(_StampRequestUuid, value=existing)
-
-    with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
-        assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 200
-
-    assert mock_set_attrs.call_args_list[0].kwargs['request_uuid'] == existing
-
-
-def test_request_uuid_is_stamped_even_when_auth_fails():
-    client, _ = _make_client()
-    client.app.state.token_validator = SimpleNamespace(
-        validate_token=AsyncMock(side_effect=InvalidApiKey('nope'))
-    )
-
-    with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
-        assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 401
-
-    assert mock_set_attrs.call_args_list[0].kwargs['request_uuid']
+    assert mock_set_attrs.call_args_list[0].kwargs['request_uuid'] is None
 
 
 # Span status and attribute placement are asserted against a real OTel pipeline
 # in tests/mcp/test_span_attributes.py — mocks here cannot tell which span an
-# attribute lands on, which is the property that matters.
+# attribute lands on, which is the property that matters. Middleware path
+# matching and uuid stamping live in
+# tests/middlewares/test_request_event_middleware.py.

--- a/gateway/tests/routes/test_mcp_route.py
+++ b/gateway/tests/routes/test_mcp_route.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 from fastapi import FastAPI
@@ -385,3 +385,62 @@ async def test_end_to_end_against_real_upstream():
             result = res.json()['result']
             assert result['isError'] is False
             assert result['content'][0] == {'type': 'text', 'text': 'echo: hi'}
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+MCP_SERVICE = 'radicalbit_ai_gateway.services.mcp_service'
+
+
+class _StampRequestUuid:
+    """Pure-ASGI stand-in for RequestEventMiddleware's request_uuid stamping."""
+
+    def __init__(self, app, value: str):
+        self.app = app
+        self.value = value
+
+    async def __call__(self, scope, receive, send):
+        scope.setdefault('state', {})['request_uuid'] = self.value
+        await self.app(scope, receive, send)
+
+
+def test_request_uuid_is_stamped_on_the_trace():
+    client, _ = _make_client()
+
+    with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
+        assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 200
+
+    recorded = mock_set_attrs.call_args_list[0].kwargs['request_uuid']
+    # a real uuid4, not a placeholder
+    assert uuid.UUID(recorded).version == 4
+
+
+def test_request_uuid_is_reused_when_already_set():
+    """Keeps MCP correct if it is ever added to RequestEventMiddleware."""
+    client, _ = _make_client()
+    existing = str(uuid.uuid4())
+    client.app.add_middleware(_StampRequestUuid, value=existing)
+
+    with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
+        assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 200
+
+    assert mock_set_attrs.call_args_list[0].kwargs['request_uuid'] == existing
+
+
+def test_request_uuid_is_stamped_even_when_auth_fails():
+    client, _ = _make_client()
+    client.app.state.token_validator = SimpleNamespace(
+        validate_token=AsyncMock(side_effect=InvalidApiKey('nope'))
+    )
+
+    with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
+        assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 401
+
+    assert mock_set_attrs.call_args_list[0].kwargs['request_uuid']
+
+
+# Span status and attribute placement are asserted against a real OTel pipeline
+# in tests/mcp/test_span_attributes.py — mocks here cannot tell which span an
+# attribute lands on, which is the property that matters.

--- a/gateway/tests/routes/test_mcp_route.py
+++ b/gateway/tests/routes/test_mcp_route.py
@@ -428,6 +428,21 @@ def test_no_request_uuid_is_invented_without_the_middleware():
     assert mock_set_attrs.call_args_list[0].kwargs['request_uuid'] is None
 
 
+def test_a_rejected_origin_still_reports_the_route_it_targeted():
+    """Attribution runs before the first check that can reject, origin included."""
+    client, _ = _make_client()
+
+    with patch(f'{MCP_SERVICE}.set_trace_attributes') as mock_set_attrs:
+        res = client.post(
+            PATH, json=_ping(), headers={**AUTH, 'Origin': 'http://evil.example'}
+        )
+
+    assert res.status_code == 403
+    recorded = mock_set_attrs.call_args_list[0].kwargs
+    assert recorded['route_name'] == 'my-route'
+    assert recorded['project_name'] == 'proj'
+
+
 # Span status and attribute placement are asserted against a real OTel pipeline
 # in tests/mcp/test_span_attributes.py — mocks here cannot tell which span an
 # attribute lands on, which is the property that matters. Middleware path

--- a/gateway/tests/utils/test_trace_attributes.py
+++ b/gateway/tests/utils/test_trace_attributes.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch
 
-from radicalbit_ai_gateway.utils.trace_attributes import set_trace_attributes
+from radicalbit_ai_gateway.utils.trace_attributes import (
+    set_mcp_attributes,
+    set_trace_attributes,
+)
 
 
 @patch(
@@ -51,3 +54,89 @@ def test_set_trace_attributes_partial(mock_set_props):
             'route_name': 'my-route',
         }
     )
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
+def test_set_mcp_attributes(mock_set_props):
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value=None,
+    ):
+        set_mcp_attributes(
+            method='tools/call',
+            alias='github',
+            target='get_issue',
+            error_code=-32000,
+        )
+
+    mock_set_props.assert_called_once_with(
+        {
+            'rb.gateway.mcp_method': 'tools/call',
+            'rb.gateway.mcp_alias': 'github',
+            'rb.gateway.mcp_target': 'get_issue',
+            # span attributes are strings; the JSON-RPC code is an int
+            'rb.gateway.mcp_error_code': '-32000',
+        }
+    )
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
+def test_set_mcp_attributes_omits_unset_fields(mock_set_props):
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value=None,
+    ):
+        set_mcp_attributes(method='ping')
+
+    mock_set_props.assert_called_once_with({'rb.gateway.mcp_method': 'ping'})
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
+def test_set_mcp_attributes_with_nothing_set_is_a_noop(mock_set_props):
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value=None,
+    ):
+        set_mcp_attributes()
+
+    mock_set_props.assert_not_called()
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
+def test_set_mcp_attributes_preserves_existing_properties(mock_set_props):
+    """Traceloop replaces the whole dict, so the helper must read-merge-write."""
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value={'api_key_uuid': 'key-456', 'route_name': 'my-route'},
+    ):
+        set_mcp_attributes(method='tools/list')
+
+    mock_set_props.assert_called_once_with(
+        {
+            'api_key_uuid': 'key-456',
+            'route_name': 'my-route',
+            'rb.gateway.mcp_method': 'tools/list',
+        }
+    )
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
+def test_set_mcp_attributes_records_a_zero_error_code(mock_set_props):
+    """0 is falsy but a legitimate code — only None means 'unset'."""
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value=None,
+    ):
+        set_mcp_attributes(error_code=0)
+
+    mock_set_props.assert_called_once_with({'rb.gateway.mcp_error_code': '0'})

--- a/gateway/tests/utils/test_trace_attributes.py
+++ b/gateway/tests/utils/test_trace_attributes.py
@@ -131,6 +131,21 @@ def test_set_mcp_attributes_preserves_existing_properties(mock_set_props):
 @patch(
     'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
 )
+def test_set_mcp_attributes_records_the_failed_upstreams(mock_set_props):
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value=None,
+    ):
+        set_mcp_attributes(upstream_failed='github,jira')
+
+    mock_set_props.assert_called_once_with(
+        {'rb.gateway.mcp_upstream_failed': 'github,jira'}
+    )
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
 def test_set_mcp_attributes_records_a_zero_error_code(mock_set_props):
     """0 is falsy but a legitimate code — only None means 'unset'."""
     with patch(


### PR DESCRIPTION
## Summary

Brings the inbound MCP proxy (`POST /{project_name}/{route_name}/mcp`) into the two telemetry pipelines the `/v1/*` endpoints already feed: OpenTelemetry traces (Traceloop workflow + task spans) and `request_event` rows in ClickHouse. No HTTP request or response schema changes — MCP stays a plain JSON-RPC passthrough. What changes for consumers is that MCP traffic now **appears** in the dashboard and traces UI, and that success/error counting is now classified consistently across every dashboard reader.

---

## DTO Changes

### `RequestType` (MODIFIED — enum)

**Changes:**
```diff
+ mcp  (added)
```

| Value | Description |
|-------|-------------|
| `chat_completions` | `POST /v1/chat/completions`, `POST /v1/responses` |
| `embeddings` | `POST /v1/embeddings` |
| `transcriptions` | `POST /v1/audio/transcriptions` |
| `mcp` **NEW** | `POST /{project_name}/{route_name}/mcp` |

Written to the `REQUEST_TYPE` column of `request_event`. The column is `LowCardinality(String)` with no enum constraint, so **no ClickHouse migration is needed**.

---

### `RequestEventPayload` (MODIFIED — internal event payload)

Emitted by `RequestEventMiddleware` to the events pipeline; not returned by any endpoint. Only the accepted values of `request_type` widen — no field added or removed.

| Field | Type | Description |
|-------|------|-------------|
| `request_uuid` | string | Correlation id, shared with the trace's root span |
| `event_type` | string | Always `request` |
| `route_name` | string | Route the request targeted |
| `api_key_uuid` | string | Resolved API key |
| `api_key_name` | string | Resolved API key name |
| `group_uuid` | string | Resolved group |
| `group_name` | string | Resolved group name |
| `project_uuid` | string | Resolved project |
| `project_name` | string | Resolved project name |
| `request_type` ⟳ | string | One of: `chat_completions`, `embeddings`, `transcriptions`, **`mcp`** |
| `is_streaming` | boolean | Always `false` for MCP |
| `status` | string | One of: `success`, `handled_error`, `unhandled_error` |
| `http_status_code` | integer | Transport status — **`200` even for a failed MCP call** |
| `error_type` | string | `mcp_jsonrpc_error` for a JSON-RPC error body |
| `error_code` | string | The JSON-RPC code, e.g. `"-32602"` |
| `duration_ms` | float | Wall-clock duration |

**Example — a failed `tools/call` (note `http_status_code: 200` with `status: handled_error`):**
```json
{
  "request_uuid": "550e8400-e29b-41d4-a716-446655440000",
  "event_type": "request",
  "route_name": "my-route",
  "api_key_uuid": "550e8400-e29b-41d4-a716-446655440000",
  "api_key_name": "my-key",
  "group_uuid": "550e8400-e29b-41d4-a716-446655440000",
  "group_name": "team-a",
  "project_uuid": "550e8400-e29b-41d4-a716-446655440000",
  "project_name": "my-project",
  "request_type": "mcp",
  "is_streaming": false,
  "status": "handled_error",
  "http_status_code": 200,
  "error_type": "mcp_jsonrpc_error",
  "error_code": "-32602",
  "duration_ms": 142.7
}
```

**Emission rules for MCP:**

| Outcome | HTTP | Event emitted? | `status` |
|---------|------|----------------|----------|
| Successful call | 200 | yes | `success` |
| JSON-RPC `error` body | 200 | yes | `handled_error` |
| Notification (no `id`) | 202 | **no** — handshake traffic is not billable | – |
| Parse error | 400 | yes | `handled_error` |
| Bad Origin / bad key / unbound key | 403 / 401 | yes | `handled_error` |

---

## Affected Endpoints

### `POST /{project_name}/{route_name}/mcp` (MODIFIED — behaviour only)

**Example request:**
```
POST /my-project/my-route/mcp
Authorization: Bearer sk-rb-...
Content-Type: application/json

{"jsonrpc": "2.0", "id": 1, "method": "tools/call",
 "params": {"name": "github__get_issue", "arguments": {"number": 42}}}
```

No change to params, body or response. What is new:

```diff
+ emits a REQUEST event per request (except 202 notifications)
+ emits an `mcp_request` workflow span with child task spans per handler
+ stamps request_uuid, shared between the event row and the root span
```

`request_uuid` is generated by `RequestEventMiddleware` and **only** there, so a trace and its `request_event` row always join on the same id.

---

### `GET /public/api/v1/projects/{project_uuid}/metrics` (MODIFIED — values only)

Response DTO (`EventsDTO`) is unchanged in shape. Two things change in the numbers it reports:

```diff
+ MCP requests are now included in the counts
? successful/error classification: REQUEST_STATUS (was HTTP_STATUS_CODE)
```

| Field | Type | Description |
|-------|------|-------------|
| `totalRequests` | integer | Now includes MCP requests |
| `errors.requestError` ⟳ | integer | Now counts anything whose status is not `success` |
| `errors.requestErrorPercentage` ⟳ | float | Derived from the above |
| `errors.details` | object[] | Unchanged shape; `errorType` may now be `mcp_jsonrpc_error` |
| `requestErrorPercentage` | float | Deprecated alias of the above, same new semantics |
| `lastRequestTimestamp` | datetime | Unchanged |

**Why the reclassification:** `RequestEventDAO._base_columns` counted `HTTP_STATUS_CODE == 200` as success and `>= 400` as error. An MCP failure arrives over HTTP 200, so it was counted as a **success** in the summary while `get_error_breakdown` — which already read `REQUEST_STATUS` — counted the same row as an error: two contradictory numbers in one response. Switching to `REQUEST_STATUS` also closes a gap where any 2xx other than exactly `200` counted as neither.

**Example response (excerpt):**
```json
{
  "totalRequests": 1500,
  "errors": {
    "requestError": 42,
    "requestErrorPercentage": 2.8,
    "details": [
      {"errorType": "mcp_jsonrpc_error", "count": 30},
      {"errorType": "InvalidApiKey", "count": 12}
    ]
  },
  "lastRequestTimestamp": "2024-01-15T10:30:00Z"
}
```

`GET /public/api/v1/projects/{project_uuid}/routes` is affected the same way (same DAO, per-route).

---

## New Span Attributes

Recorded as Traceloop association properties, so they are queryable from the root-span list the traces UI uses.

| Attribute | Span | Description |
|-----------|------|-------------|
| `rb.gateway.mcp_method` | root | JSON-RPC method, e.g. `tools/call`. Set for notifications too |
| `rb.gateway.mcp_alias` | root | Upstream server alias — only when it resolves to a configured server |
| `rb.gateway.mcp_target` | root | Tool name, prompt name, or resource URI; `method` disambiguates which |
| `rb.gateway.mcp_error_code` | root | JSON-RPC error code, e.g. `-32602` |
| `rb.gateway.mcp_upstream_failed` | root | Comma-joined aliases a fan-out could not reach; absent when healthy |
| `rb.gateway.mcp_upstream_total` | task | Upstreams the list method fanned out to |
| `rb.gateway.mcp_upstream_failed` | task | Same, as per-task detail |
| `rb.gateway.mcp_result_count` | task | Merged items returned |

**Span tree for a `tools/call`:**
```
mcp_request.workflow          ← root; identity + mcp_* attributes; ERROR on a JSON-RPC error
└── mcp_tools_call.task
    └── mcp_upstream_call_tool.task   ← real upstream latency
```

Two deliberate constraints on what reaches an attribute:

- **`alias`/`target` are recorded only when the alias resolves to a server configured on the route.** `params` is client-controlled and these are indexed dimensions, so echoing an unresolvable name back would let any caller mint unlimited distinct values in the trace backend. The rejected name stays diagnosable via the span *status description* (`Unknown tool: nope__missing`), which is free text rather than a dimension.
- **Resource URIs are reduced to scheme + host + path** before becoming an attribute — query strings and `user:pass@` userinfo carry signed-URL tokens and basic-auth credentials, and spans reach every configured OTLP endpoint including third-party ones. The upstream still receives the URI whole.

---

## Other Changes

- `middleware/request_event_middleware.py` — `is_mcp_request` predicate matches `POST` on an exact 3-segment path ending in `mcp` (the proxy is mounted at the root with a dynamic path, so it cannot be a literal in `TRACKED_PATHS`); skips 202 notifications; downgrades HTTP 200 + `error_type` to `handled_error`, scoped to MCP so `/v1/*` behaviour is untouched.
- `services/mcp_service.py` — `@workflow('mcp_request')` on `handle_post`, `@task` on all 7 dispatch handlers; identity attributes and the request-event context are populated before the first check that can reject, so a bad Origin, a missing key or an unbound key still names the route it targeted; `_record_error_outcome` reports JSON-RPC error bodies to both pipelines; `_record_fanout` / `_record_degradation` make a partially-degraded fan-out visible instead of log-only.
- `mcp_proxy/upstream_client.py` — `@task` on all 6 outbound operations, so upstream latency is its own span.
- `utils/trace_attributes.py` — new `set_mcp_attributes()` helper, read-merge-write like the existing `set_trace_attributes` (Traceloop replaces the whole association-property dict).
- `db/dao/request_event_dao.py` — `_base_columns` reclassified onto `REQUEST_STATUS`.

### Tests

- `tests/mcp/test_span_attributes.py` (new) — boots Traceloop against an `InMemorySpanExporter` with production middleware wiring and asserts on emitted spans. This is the only way to verify *which* span an attribute lands on: a `@task` detaches its context on exit, so anything set inside one never reaches the root span the traces list queries — mocks cannot catch that regression.
- `tests/mcp/test_instrumentation.py` (new) — fails when a handler is added without a decorator. `prompts/*` and `resources/*` already shipped uninstrumented once.
- `tests/middlewares/test_request_event_middleware.py` (new) — pins the path predicate against 8 near-miss paths and 4 wrong methods, plus the two ways MCP differs from `/v1/*`.
- `tests/mcp/test_mcp_service.py`, `tests/routes/test_mcp_route.py`, `tests/utils/test_trace_attributes.py`, `tests/dao/request_event_dao_test.py` — extended.


## Linked Issue
Closes [AG-904](https://radicalbit.atlassian.net/browse/AG-904)

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
