### PR TITLE
feat: expose verbose_json transcription output for whisper-1

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -11,6 +11,7 @@ from langchain_core.messages import (
 )
 import numpy as np
 from openai.types.audio.transcription import Transcription, UsageDuration, UsageTokens
+from openai.types.audio.transcription_verbose import TranscriptionVerbose
 from openai.types.chat import ChatCompletionToolChoiceOptionParam
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_tool_param import ChatCompletionToolParam
@@ -685,10 +686,11 @@ class GatewayRoute:
         audio_bytes: bytes,
         filename: str,
         content_type: str | None,
+        requested_response_format: str = 'json',
         language: str | None = None,
         prompt: str | None = None,
         temperature: float | None = None,
-    ) -> Transcription:
+    ) -> Transcription | TranscriptionVerbose:
         if route_name != self.gateway_route_config.route_name:
             raise GatewayBadRequest(f'{route_name} must be the route name')
 
@@ -716,6 +718,7 @@ class GatewayRoute:
             filename=filename,
             content_type=content_type,
             model_id=model_selected.model_id,
+            requested_response_format=requested_response_format,
             language=language,
             prompt=prompt,
             temperature=temperature,

--- a/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
+++ b/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
@@ -26,6 +26,7 @@ app_config = get_app_config()
 logger = logging.getLogger(app_config.log_config.logger_name)
 
 WHISPER_FAMILY_PREFIX = 'whisper'
+SUPPORTED_RESPONSE_FORMATS = {'json', 'verbose_json'}
 
 
 def _set_transcription_request_attributes(
@@ -125,18 +126,28 @@ class TranscriptionModelInvoker(ModelInvoker):
         filename: str,
         content_type: str | None,
         model_id: str,
+        requested_response_format: str = 'json',
         language: str | None = None,
         prompt: str | None = None,
         temperature: float | None = None,
         project_uuid: str = '',
         project_name: str = '',
-    ) -> Transcription:
+    ) -> Transcription | TranscriptionVerbose:
         if model_id not in self.model_map:
             raise ModelInvokerBadRequest(f'Transcription model {model_id} not defined')
+        if requested_response_format not in SUPPORTED_RESPONSE_FORMATS:
+            raise ModelInvokerBadRequest(
+                f'Unsupported response_format {requested_response_format!r}. '
+                f'Supported formats: {sorted(SUPPORTED_RESPONSE_FORMATS)}.'
+            )
 
         model, client, _fallbacks = self.model_map[model_id]
         _, model_name = parse_provider_and_model(model.model)
         is_whisper = model_name.startswith(WHISPER_FAMILY_PREFIX)
+        if requested_response_format == 'verbose_json' and not is_whisper:
+            raise ModelInvokerBadRequest(
+                'response_format=verbose_json is only supported for whisper-1 models.'
+            )
         upstream_format = 'verbose_json' if is_whisper else 'json'
 
         _set_transcription_request_attributes(
@@ -179,7 +190,10 @@ class TranscriptionModelInvoker(ModelInvoker):
         _set_transcription_response_attributes(response, is_whisper)
 
         usage = response.usage
-        if is_whisper:
+        if requested_response_format == 'verbose_json':
+            # Only reachable for whisper-1
+            body = response
+        elif is_whisper:
             body = Transcription(
                 text=response.text,
                 usage=usage.model_dump() if usage else None,

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -918,6 +918,7 @@ async def audio_transcriptions(
         audio_bytes=content,
         filename=file.filename or 'audio',
         content_type=file.content_type,
+        requested_response_format=transcription_params.response_format,
         language=transcription_params.language,
         prompt=transcription_params.prompt,
         temperature=transcription_params.temperature,

--- a/gateway/radicalbit_ai_gateway/utils/open_ai_types.py
+++ b/gateway/radicalbit_ai_gateway/utils/open_ai_types.py
@@ -568,8 +568,9 @@ class TranscriptionCreateParamsCustom(BaseModel):
     prompt: str | None = None
     """An optional text to guide the model's style or continue a previous audio segment."""
 
-    response_format: Literal['json'] = 'json'
-    """The format of the transcript output. verbose_json/text/srt/vtt aren't supported yet."""
+    response_format: Literal['json', 'verbose_json'] = 'json'
+    """The format of the transcript output. verbose_json is only supported for whisper-1;
+    text/srt/vtt aren't supported yet."""
 
     temperature: float | None = None
     """Sampling temperature, between 0 and 1."""

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -905,11 +905,56 @@ async def test_invoke_transcription_success():
         filename='test.wav',
         content_type='audio/wav',
         model_id='whisper-1',
+        requested_response_format='json',
         language=None,
         prompt=None,
         temperature=None,
         project_uuid='',
         project_name='',
+    )
+
+
+@pytest.mark.asyncio
+async def test_invoke_transcription_passes_through_requested_response_format():
+    cost_service = MagicMock(spec_set=CostService)
+    whisper_model = Model(
+        model_id='whisper-1',
+        model='openai/whisper-1',
+        credentials=Credentials(api_key='sk-test'),
+    )
+    route_cfg = _make_transcription_route_config()
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=[whisper_model],
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=None,
+        cost_service=cost_service,
+    )
+
+    fake_result = MagicMock(usage=MagicMock(type='duration', seconds=9))
+    ai_gateway.transcription_invoker.transcribe = AsyncMock(return_value=fake_result)
+
+    await ai_gateway.invoke_transcription(
+        request_uuid=str(REQUEST_UUID),
+        api_key_uuid=str(API_KEY_UUID),
+        group_uuid=str(GROUP_UUID),
+        api_key_name='rb-key',
+        group_name='test-group',
+        route_name='rb-gateway',
+        audio_bytes=b'fake-audio',
+        filename='test.wav',
+        content_type='audio/wav',
+        requested_response_format='verbose_json',
+    )
+
+    assert (
+        ai_gateway.transcription_invoker.transcribe.call_args.kwargs[
+            'requested_response_format'
+        ]
+        == 'verbose_json'
     )
 
 

--- a/gateway/tests/invoker/test_transcription_model_invoker.py
+++ b/gateway/tests/invoker/test_transcription_model_invoker.py
@@ -210,6 +210,63 @@ class TestTranscriptionModelInvoker(unittest.IsolatedAsyncioTestCase):
         assert 'transcription.response.duration_seconds' not in set_attrs
         assert 'transcription.response.segment_count' not in set_attrs
 
+    async def test_transcribe_whisper_verbose_json_passthrough(self):
+        invoker = self._build_invoker(WHISPER_MODEL)
+        mock_client = MockTranscriptionClient(response=WHISPER_VERBOSE_RESPONSE)
+        invoker.model_map['whisper'] = (WHISPER_MODEL, mock_client, [])
+
+        result = await invoker.transcribe(
+            **_COMMON_TRANSCRIBE_KWARGS,
+            audio_bytes=b'fake-audio',
+            filename='test.wav',
+            content_type='audio/wav',
+            model_id='whisper',
+            requested_response_format='verbose_json',
+        )
+
+        # verbose_json matches whisper's upstream call exactly: the raw
+        # TranscriptionVerbose is returned as-is, no conversion needed.
+        assert result is WHISPER_VERBOSE_RESPONSE
+        assert isinstance(result, TranscriptionVerbose)
+        assert result.segments == []
+        assert result.duration == 8.25
+
+    async def test_transcribe_gpt4o_rejects_verbose_json(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        mock_client = MockTranscriptionClient(response=GPT4O_JSON_RESPONSE)
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            mock_client,
+            [],
+        )
+
+        with pytest.raises(
+            ModelInvokerBadRequest, match='only supported for whisper-1'
+        ):
+            await invoker.transcribe(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+                requested_response_format='verbose_json',
+            )
+
+    async def test_transcribe_rejects_unsupported_response_format(self):
+        invoker = self._build_invoker(WHISPER_MODEL)
+        mock_client = MockTranscriptionClient(response=WHISPER_VERBOSE_RESPONSE)
+        invoker.model_map['whisper'] = (WHISPER_MODEL, mock_client, [])
+
+        with pytest.raises(ModelInvokerBadRequest, match='Unsupported response_format'):
+            await invoker.transcribe(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='whisper',
+                requested_response_format='text',
+            )
+
     async def test_transcribe_unknown_model_id_raises_bad_request(self):
         invoker = self._build_invoker(WHISPER_MODEL)
 

--- a/gateway/tests/test_server.py
+++ b/gateway/tests/test_server.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from langchain_core.messages import HumanMessage, SystemMessage
 from openai.types.audio.transcription import Transcription
+from openai.types.audio.transcription_verbose import TranscriptionVerbose
 from openai.types.create_embedding_response import CreateEmbeddingResponse, Usage
 from openai.types.embedding import Embedding
 import pook
@@ -488,15 +489,58 @@ class TestServer(unittest.TestCase):
             audio_bytes=b'fake-audio-bytes',
             filename='test.wav',
             content_type='audio/wav',
+            requested_response_format='json',
+            language=None,
+            prompt=None,
+            temperature=None,
+        )
+
+    def test_audio_transcriptions_success_verbose_json(self):
+        api_key = db_mock.get_sample_key_with_group(group_uuid=db_mock.GROUP_UUID)
+        key_service.get_key_by_hashed_key = MagicMock(return_value=api_key)
+        group_service.check_key_uuid_for_route = MagicMock(return_value=True)
+
+        mock_result = TranscriptionVerbose(
+            task='transcribe',
+            language='italian',
+            duration=8.25,
+            text='Ciao mondo',
+            segments=[],
+            usage={'type': 'duration', 'seconds': 9},
+        )
+        self.gateways_mock['rb-gateway'].invoke_transcription = AsyncMock(
+            return_value=mock_result
+        )
+
+        response = self.client.post(
+            '/v1/audio/transcriptions',
+            data={'model': 'rb-gateway', 'response_format': 'verbose_json'},
+            files={'file': ('test.wav', b'fake-audio-bytes', 'audio/wav')},
+            headers=self.headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == mock_result.model_dump()
+        self.gateways_mock['rb-gateway'].invoke_transcription.assert_awaited_once_with(
+            request_uuid=str(db_mock.REQUEST_UUID),
+            api_key_uuid=str(api_key.uuid),
+            api_key_name=api_key.name,
+            group_uuid=str(db_mock.GROUP_UUID),
+            group_name='group',
+            route_name='rb-gateway',
+            audio_bytes=b'fake-audio-bytes',
+            filename='test.wav',
+            content_type='audio/wav',
+            requested_response_format='verbose_json',
             language=None,
             prompt=None,
             temperature=None,
         )
 
     def test_audio_transcriptions_rejects_unsupported_response_format(self):
-        """response_format is pinned to `Literal['json']` at the request
-        schema — this is the only place that value is validated (the invoker
-        no longer re-checks it), so this is the one test covering rejection.
+        """response_format is pinned to `Literal['json', 'verbose_json']` at
+        the request schema — anything else is rejected before it even
+        reaches the invoker.
         """
         api_key = db_mock.get_sample_key_with_group(group_uuid=db_mock.GROUP_UUID)
         key_service.get_key_by_hashed_key = MagicMock(return_value=api_key)
@@ -504,7 +548,7 @@ class TestServer(unittest.TestCase):
 
         response = self.client.post(
             '/v1/audio/transcriptions',
-            data={'model': 'rb-gateway', 'response_format': 'verbose_json'},
+            data={'model': 'rb-gateway', 'response_format': 'text'},
             files={'file': ('test.wav', b'fake-audio-bytes', 'audio/wav')},
             headers=self.headers,
         )


### PR DESCRIPTION
# PR Summary: feature/expose-verbose-json

Lets clients request `verbose_json` on `POST /v1/audio/transcriptions` for whisper-1 models, returning the full OpenAI `TranscriptionVerbose` object (segments, timestamps, detected language, duration) instead of the previously-forced `json` (a stripped-down `Transcription`). gpt-4o-transcribe family models still only support `json`, since OpenAI doesn't produce segment/timestamp data for them.

---

## DTO Changes

No new or modified Pydantic models in `radicalbit_ai_gateway/models/`. The only schema change is a request field in `radicalbit_ai_gateway/utils/open_ai_types.py`:

### `TranscriptionCreateParamsCustom` (MODIFIED)

**Changes:**
```diff
- response_format: Literal['json'] = 'json'
+ response_format: Literal['json', 'verbose_json'] = 'json'
```

| Field | Type | Description |
|-------|------|--------------|
| `model` | string | Gateway route name used to select the backend model |
| `file` | file | The audio file to transcribe |
| `language` | string \| null | ISO-639-1 language code of the input audio |
| `prompt` | string \| null | Optional text to guide the model's style or continue a previous segment |
| `response_format` | string | One of: `json`, `verbose_json` **(verbose_json NEW)**. `verbose_json` is only accepted for whisper-1 models — rejected for gpt-4o-transcribe family with a 400. |
| `temperature` | float \| null | Sampling temperature, between 0 and 1 |

The actual **response body** is a genuine OpenAI SDK type, not a gateway-defined DTO — either `openai.types.audio.transcription.Transcription` (format=`json`) or `openai.types.audio.transcription_verbose.TranscriptionVerbose` (format=`verbose_json`, whisper-1 only). Both are passed straight through from the upstream OpenAI response, jsonable-encoded as-is.

---

## Affected Endpoints

### `POST /v1/audio/transcriptions` (MODIFIED — request + response body)

**Example request (whisper-1, verbose_json):**
```
POST /v1/audio/transcriptions
Content-Type: multipart/form-data

model=my-whisper-route
response_format=verbose_json
file=@sample.wav
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `model` | string | yes | Gateway route name (form field) |
| `file` | file | yes | Audio file to transcribe (form field) |
| `language` | string | no | ISO-639-1 language code |
| `prompt` | string | no | Style/continuation hint |
| `response_format` | string | no | `json` (default) or `verbose_json` **(NEW option)** — whisper-1 only |
| `temperature` | float | no | Sampling temperature |

**Example response** (`response_format=json`, unchanged from before):
```json
{
  "text": "Ciao, questo è un test.",
  "usage": { "type": "duration", "seconds": 9 }
}
```

**Example response** (`response_format=verbose_json`, whisper-1 only — **NEW**):
```json
{
  "task": "transcribe",
  "language": "italian",
  "duration": 8.25,
  "text": "Ciao, questo è un test.",
  "segments": [
    {
      "id": 0,
      "start": 0.0,
      "end": 8.25,
      "text": "Ciao, questo è un test.",
      "tokens": [50364, 2153, 1200],
      "temperature": 0.0,
      "avg_logprob": -0.21,
      "compression_ratio": 1.1,
      "no_speech_prob": 0.01
    }
  ],
  "usage": { "type": "duration", "seconds": 9 }
}
```

**Error response** (gpt-4o-transcribe family + `verbose_json`, 400):
```json
{
  "detail": "response_format=verbose_json is only supported for whisper-1 models."
}
```

---

## Other Changes

- `radicalbit_ai_gateway/invocation/transcription_model_invoker.py` — `transcribe()` regains a `requested_response_format` parameter (previously removed when the endpoint was json-only) and its return type widens to `Transcription | TranscriptionVerbose`. When `verbose_json` is requested (whisper-1 only, validated up front), the raw upstream `TranscriptionVerbose` is returned as-is — no conversion. `json` behavior is unchanged (whisper-1's verbose response is still stripped down to a plain `Transcription`; gpt-4o-transcribe's response passes through as-is either way, since its upstream call already uses `json`).
- `radicalbit_ai_gateway/ai_gateway.py` — `invoke_transcription` regains `requested_response_format`, threads it through to the invoker, and its return type widens the same way.
- `radicalbit_ai_gateway/server.py` — passes `transcription_params.response_format` through to `invoke_transcription` (previously dropped).
- Cost calculation, budget counting, and the tracing span attributes added in AG-895 are all unaffected — they already read from the raw upstream `response`/`usage` object, not from the client-facing response body.
- Tests updated/added across `tests/invoker/test_transcription_model_invoker.py`, `tests/ai_gateway_test.py`, and `tests/test_server.py` to cover: whisper-1 verbose_json passthrough, gpt-4o-transcribe rejecting verbose_json, and unsupported-format rejection.
