### PR TITLE
feat: add dto for mcp on routes

### DIFF
--- a/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config_out.py
@@ -15,6 +15,7 @@ from radicalbit_ai_gateway.models.guardrails import (
     RedactParameter,
 )
 from radicalbit_ai_gateway.models.limiting import Limiting, RateLimiting, TokenLimiting
+from radicalbit_ai_gateway.models.mcp_server import McpHttpServer, McpStdioServer
 from radicalbit_ai_gateway.models.model import Model
 from radicalbit_ai_gateway.models.routing import (
     BudgetConditions,
@@ -194,6 +195,28 @@ AnyRoutingConfigOut = Annotated[
 ]
 
 
+class McpHttpServerOut(McpHttpServer):
+    headers: dict[str, SecretStr] | None = None
+
+    model_config = ConfigDict(
+        populate_by_name=True, alias_generator=to_camel, protected_namespaces=()
+    )
+
+
+class McpStdioServerOut(McpStdioServer):
+    env: dict[str, SecretStr] | None = None
+
+    model_config = ConfigDict(
+        populate_by_name=True, alias_generator=to_camel, protected_namespaces=()
+    )
+
+
+AnyMcpServerOut = Annotated[
+    Union[McpHttpServerOut, McpStdioServerOut],
+    Field(discriminator='transport'),
+]
+
+
 class GatewayRouteConfigOut(GatewayRouteConfig):
     chat_models: list[ModelOut] | None
     embedding_models: list[ModelOut] | None
@@ -204,6 +227,7 @@ class GatewayRouteConfigOut(GatewayRouteConfig):
     guardrails: list[GuardrailOut] | None
     caching: AnyCachingOut | None
     routing: AnyRoutingConfigOut | None
+    mcp_servers: list[AnyMcpServerOut] | None
 
     model_config = ConfigDict(
         populate_by_name=True, alias_generator=to_camel, protected_namespaces=()

--- a/gateway/radicalbit_ai_gateway/services/event_service.py
+++ b/gateway/radicalbit_ai_gateway/services/event_service.py
@@ -531,6 +531,15 @@ class EventService:
         else:
             route_dict['routing'] = None
 
+        mcp_aliases: list[str] | None = route_dict.get('mcp_servers')
+        if mcp_aliases is None:
+            route_dict['mcp_servers'] = None
+        else:
+            route_dict['mcp_servers'] = [
+                server.model_dump()
+                for server in config.get_route_mcp_servers(route_config.route_name)
+            ]
+
         return GatewayRouteConfigOut(**route_dict)
 
     def get_costs_chart_data(

--- a/gateway/tests/routes/test_dashboard_route.py
+++ b/gateway/tests/routes/test_dashboard_route.py
@@ -1263,6 +1263,62 @@ class TestDashboardRoute(unittest.TestCase):
         out = EventService._build_route_config_out(route_config, self.gateway_config)
         assert out.routing is None
 
+    def test_build_route_config_out_resolves_mcp_servers(self):
+        """mcp_servers aliases are resolved to full server objects, secrets masked."""
+        raw = {
+            'chat_models': [
+                {
+                    'model_id': 'default_model',
+                    'model': 'openai/gpt-4o',
+                    'credentials': {'api_key': 'sk-dummy'},
+                },
+            ],
+            'mcp_servers': [
+                {
+                    'alias': 'github',
+                    'transport': 'streamable_http',
+                    'url': 'https://api.githubcopilot.com/mcp/',
+                    'headers': {'authorization': 'Bearer sk-super-secret'},
+                },
+                {
+                    'alias': 'local-tools',
+                    'transport': 'stdio',
+                    'command': 'python',
+                    'args': ['-m', 'tools'],
+                    'env': {'API_KEY': 'sk-another-secret'},
+                },
+            ],
+            'routes': {
+                'mcp_route': {
+                    'chat_models': ['default_model'],
+                    'mcp_servers': ['github', 'local-tools'],
+                },
+                'plain_route': {'chat_models': ['default_model']},
+            },
+        }
+        config = GatewayConfig.model_validate(raw)
+
+        out = EventService._build_route_config_out(
+            config.routes['mcp_route'], config
+        )
+        assert len(out.mcp_servers) == 2
+        http_server, stdio_server = out.mcp_servers
+        assert http_server.alias == 'github'
+        assert http_server.url == 'https://api.githubcopilot.com/mcp/'
+        assert str(http_server.headers['authorization']) == '**********'
+        assert (
+            http_server.headers['authorization'].get_secret_value()
+            == 'Bearer sk-super-secret'
+        )
+        assert stdio_server.alias == 'local-tools'
+        assert stdio_server.command == 'python'
+        assert str(stdio_server.env['API_KEY']) == '**********'
+
+        out_no_mcp = EventService._build_route_config_out(
+            config.routes['plain_route'], config
+        )
+        assert out_no_mcp.mcp_servers is None
+
     def test_get_cost_breakdown_by_model(self):
         model_id = 'gpt-4'
         timestamp = 1736208000

--- a/gateway/tests/routes/test_dashboard_route.py
+++ b/gateway/tests/routes/test_dashboard_route.py
@@ -1298,9 +1298,7 @@ class TestDashboardRoute(unittest.TestCase):
         }
         config = GatewayConfig.model_validate(raw)
 
-        out = EventService._build_route_config_out(
-            config.routes['mcp_route'], config
-        )
+        out = EventService._build_route_config_out(config.routes['mcp_route'], config)
         assert len(out.mcp_servers) == 2
         http_server, stdio_server = out.mcp_servers
         assert http_server.alias == 'github'


### PR DESCRIPTION
## Summary

The routes endpoint previously returned MCP server references as bare alias strings (e.g. `"mcpServers": ["github"]`) instead of resolving them, unlike every other route-scoped reference (`chatModels`, `guardrails`, `routing`, ...). This PR resolves a route's `mcp_servers` aliases into their full server definitions in the `GET /projects/{project_uuid}/routes` (and single-route) response, masking any secret-bearing `headers`/`env` values in the process.

---

## DTO Changes

### `GatewayRouteConfigOut` (MODIFIED)

**Changes:**
```diff
+ mcpServers: McpServerOut[] | null  (added — was previously inherited as string[] | null from the base config, now resolved to full objects)
```

| Field | Type | Description |
|-------|------|-------------|
| `routeName` | string | Unique route name |
| `chatModels` | object[] \| null | Resolved chat model objects |
| `embeddingModels` | object[] \| null | Resolved embedding model objects |
| `transcriptionModels` | object[] \| null | Resolved transcription model objects |
| `rateLimiting` | object \| null | Rate limiting configuration |
| `tokenLimiting` | object \| null | Token limiting configuration |
| `fallback` | object[] \| null | Fallback configuration |
| `guardrails` | object[] \| null | Resolved guardrail objects |
| `caching` | object \| null | Caching configuration |
| `budgetLimiting` | object \| null | Budget limiting configuration |
| `routing` | object \| null | Resolved routing configuration |
| `plugins` | object \| null | Plugins configuration |
| `mcpServers` **NEW** | object[] \| null | Resolved MCP server objects exposed on this route (see below). `null` if the route has no `mcp_servers` |

### `McpHttpServerOut` (NEW)

Returned for MCP servers configured with `transport: streamable_http`.

| Field | Type | Description |
|-------|------|-------------|
| `alias` | string | Unique alias for the MCP server |
| `timeout` | float \| null | Per-operation timeout override in seconds |
| `transport` | string | Always `"streamable_http"` |
| `url` | string | Upstream Streamable HTTP endpoint |
| `headers` **masked** | object \| null | Static headers sent upstream. Values are always rendered as `"**********"` — never returned in plaintext, even when resolved from a `!secret` reference |
| `forwardHeaders` | string[] \| null | Allowlist of client-supplied headers forwarded upstream |

### `McpStdioServerOut` (NEW)

Returned for MCP servers configured with `transport: stdio`.

| Field | Type | Description |
|-------|------|-------------|
| `alias` | string | Unique alias for the MCP server |
| `timeout` | float \| null | Per-operation timeout override in seconds |
| `transport` | string | Always `"stdio"` |
| `command` | string | Executable used to spawn the subprocess |
| `args` | string[] | Arguments passed to the command |
| `env` **masked** | object \| null | Subprocess environment variables. Values are always rendered as `"**********"` — never returned in plaintext, even when resolved from a `!secret` reference |
| `cwd` | string \| null | Working directory for the subprocess |

**Example response** (`GET /projects/{project_uuid}/routes`, truncated to the relevant fields):
```json
[
  {
    "routeName": "support_route",
    "configuration": {
      "routeName": "support_route",
      "chatModels": [
        { "modelId": "gpt-4o", "model": "openai/gpt-4o" }
      ],
      "mcpServers": [
        {
          "alias": "github",
          "timeout": null,
          "transport": "streamable_http",
          "url": "https://api.githubcopilot.com/mcp/",
          "headers": { "authorization": "**********" },
          "forwardHeaders": null
        },
        {
          "alias": "local-tools",
          "timeout": null,
          "transport": "stdio",
          "command": "python",
          "args": ["-m", "tools"],
          "env": { "API_KEY": "**********" },
          "cwd": null
        }
      ]
    },
    "metrics": { "totalInputTokenProcessed": 1200 },
    "groups": null
  },
  {
    "routeName": "plain_route",
    "configuration": {
      "routeName": "plain_route",
      "chatModels": [{ "modelId": "gpt-4o", "model": "openai/gpt-4o" }]
    },
    "metrics": { "totalInputTokenProcessed": 300 },
    "groups": null
  }
]
```

Note `plain_route` above omits `mcpServers` entirely — the field is `null` and dropped by the endpoint's existing `response_model_exclude_none=True`.

**Used by:**
`GET /projects/{project_uuid}/routes`
`GET /projects/{project_uuid}/routes/{route_name}`

---

## Affected Endpoints

No request shape changes. Both endpoints below now include the new `configuration.mcpServers` field in their existing response body — no new query params, no breaking changes to existing fields.

### `GET /projects/{project_uuid}/routes` (MODIFIED — response body only)

```
GET /projects/33333333-3333-3333-3333-333333333333/routes?include_groups=false
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `_from` | integer | no | Start Unix timestamp for metrics window |
| `_to` | integer | no | End Unix timestamp for metrics window |
| `include_groups` | boolean | no | Include the route's associated groups (default `false`) |

### `GET /projects/{project_uuid}/routes/{route_name}` (MODIFIED — response body only)

```
GET /projects/33333333-3333-3333-3333-333333333333/routes/support_route
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `project_uuid` | string | yes | Project UUID (path) |
| `route_name` | string | yes | Route name (path) |
| `_from` | integer | no | Start Unix timestamp for metrics window |
| `_to` | integer | no | End Unix timestamp for metrics window |
| `include_groups` | boolean | no | Include the route's associated groups (default `false`) |

---

## Other Changes

- `models/gateway_config_out.py` — added `McpHttpServerOut`, `McpStdioServerOut`, `AnyMcpServerOut`, and the `mcp_servers` field override on `GatewayRouteConfigOut`. `headers`/`env` are typed as `dict[str, SecretStr]` so Pydantic automatically masks values in the JSON response, mirroring the existing `CredentialsOut.api_key: SecretStr` pattern (MCP server headers/env can carry raw secret values resolved at runtime from `!secret` YAML references, with no wrapper type upstream).
- `services/event_service.py` — `EventService._build_route_config_out` now resolves a route's `mcp_servers` alias list into full server objects via the existing `GatewayConfig.get_route_mcp_servers` helper, following the same resolution pattern already used for `chat_models`/`guardrails`/`routing`.
- `tests/routes/test_dashboard_route.py` — added `test_build_route_config_out_resolves_mcp_servers`, covering both HTTP and stdio server resolution, secret masking, and the no-MCP-servers (`None`) case.

**Verification:** `uv run pytest` → 1516 tests + 123 MCP-specific tests, all passing. `ruff check` clean.

## Linked Issue
Closes [AG-910](https://radicalbit.atlassian.net/browse/AG-910)

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
