### PR TITLE
feat: add streaming support for transcribe models

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 import datetime
 import json
 import logging
@@ -11,6 +12,7 @@ from langchain_core.messages import (
 )
 import numpy as np
 from openai.types.audio.transcription import Transcription, UsageDuration, UsageTokens
+from openai.types.audio.transcription_stream_event import TranscriptionStreamEvent
 from openai.types.audio.transcription_verbose import TranscriptionVerbose
 from openai.types.chat import ChatCompletionToolChoiceOptionParam
 from openai.types.chat.chat_completion import ChatCompletion
@@ -729,6 +731,63 @@ class GatewayRoute:
         await self._count_transcription_usage(result.usage, model_selected)
 
         return result
+
+    async def invoke_transcription_stream(
+        self,
+        request_uuid: str,
+        api_key_uuid: str,
+        group_uuid: str,
+        api_key_name: str,
+        group_name: str,
+        route_name: str,
+        audio_bytes: bytes,
+        filename: str,
+        content_type: str | None,
+        language: str | None = None,
+        prompt: str | None = None,
+        temperature: float | None = None,
+    ) -> AsyncIterator[TranscriptionStreamEvent]:
+        if route_name != self.gateway_route_config.route_name:
+            raise GatewayBadRequest(f'{route_name} must be the route name')
+
+        if not self.transcription_invoker:
+            raise GatewayBadRequest(
+                f'Route {route_name} has no transcription models defined'
+            )
+
+        set_operation_category(OperationCategory.ROUTING)
+        model_selected = self._select_and_prepare_transcription_model()
+
+        if self.budget_limiter:
+            set_operation_category(OperationCategory.LIMITING)
+            await self.budget_limiter.check_budget()
+
+        set_operation_category(OperationCategory.INVOCATION)
+        final_event: TranscriptionStreamEvent | None = None
+        async for event in self.transcription_invoker.stream(
+            request_uuid=request_uuid,
+            api_key_uuid=api_key_uuid,
+            group_uuid=group_uuid,
+            api_key_name=api_key_name,
+            group_name=group_name,
+            route_name=route_name,
+            audio_bytes=audio_bytes,
+            filename=filename,
+            content_type=content_type,
+            model_id=model_selected.model_id,
+            language=language,
+            prompt=prompt,
+            temperature=temperature,
+            project_uuid=self.project_uuid,
+            project_name=self.project_name,
+        ):
+            final_event = event
+            yield event
+
+        if final_event is not None:
+            await self._count_transcription_usage(
+                getattr(final_event, 'usage', None), model_selected
+            )
 
     # ============================================================================
     # Pre Process Request

--- a/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
+++ b/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 from decimal import Decimal
 import logging
 import time
@@ -5,6 +6,7 @@ import time
 import openai
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai.types.audio.transcription import Transcription
+from openai.types.audio.transcription_stream_event import TranscriptionStreamEvent
 from openai.types.audio.transcription_verbose import TranscriptionVerbose
 from opentelemetry import trace
 from traceloop.sdk.decorators import task
@@ -113,67 +115,22 @@ class TranscriptionModelInvoker(ModelInvoker):
             http_client=self.httpx_client,
         )
 
-    @task(name='llm_transcribe')
-    async def transcribe(
-        self,
-        request_uuid: str,
-        api_key_uuid: str,
-        group_uuid: str,
-        api_key_name: str,
-        group_name: str,
-        route_name: str,
-        audio_bytes: bytes,
-        filename: str,
-        content_type: str | None,
-        model_id: str,
-        requested_response_format: str = 'json',
-        language: str | None = None,
-        prompt: str | None = None,
-        temperature: float | None = None,
-        project_uuid: str = '',
-        project_name: str = '',
-    ) -> Transcription | TranscriptionVerbose:
+    def _resolve_model(
+        self, model_id: str
+    ) -> tuple[Model, AsyncOpenAI | AsyncAzureOpenAI, bool, str]:
         if model_id not in self.model_map:
             raise ModelInvokerBadRequest(f'Transcription model {model_id} not defined')
-        if requested_response_format not in SUPPORTED_RESPONSE_FORMATS:
-            raise ModelInvokerBadRequest(
-                f'Unsupported response_format {requested_response_format!r}. '
-                f'Supported formats: {sorted(SUPPORTED_RESPONSE_FORMATS)}.'
-            )
-
         model, client, _fallbacks = self.model_map[model_id]
         _, model_name = parse_provider_and_model(model.model)
         is_whisper = model_name.startswith(WHISPER_FAMILY_PREFIX)
-        if requested_response_format == 'verbose_json' and not is_whisper:
-            raise ModelInvokerBadRequest(
-                'response_format=verbose_json is only supported for whisper-1 models.'
-            )
-        upstream_format = 'verbose_json' if is_whisper else 'json'
+        return model, client, is_whisper, model_name
 
-        _set_transcription_request_attributes(
-            filename=filename,
-            content_type=content_type,
-            audio_size_bytes=len(audio_bytes),
-            model_id=model_id,
-        )
-
-        create_kwargs: dict = {
-            'model': model_name,
-            'file': (filename, audio_bytes, content_type or 'application/octet-stream'),
-            'response_format': upstream_format,
-        }
-        if language:
-            create_kwargs['language'] = language
-        if prompt:
-            create_kwargs['prompt'] = prompt
-        if temperature is not None:
-            create_kwargs['temperature'] = temperature
-
-        start_time = time.monotonic()
+    @staticmethod
+    async def _create_upstream(
+        client: AsyncOpenAI | AsyncAzureOpenAI, create_kwargs: dict
+    ):
         try:
-            response: (
-                Transcription | TranscriptionVerbose
-            ) = await client.audio.transcriptions.create(**create_kwargs)
+            return await client.audio.transcriptions.create(**create_kwargs)
         except openai.APIStatusError as e:
             if 400 <= e.status_code < 500:
                 raise ModelInvokerBadRequest(
@@ -186,21 +143,23 @@ class TranscriptionModelInvoker(ModelInvoker):
             raise ModelInvokerInternalError(
                 f'Transcription upstream call failed: {e}'
             ) from e
-        latency_ms = (time.monotonic() - start_time) * 1000
-        _set_transcription_response_attributes(response, is_whisper)
 
-        usage = response.usage
-        if requested_response_format == 'verbose_json':
-            # Only reachable for whisper-1
-            body = response
-        elif is_whisper:
-            body = Transcription(
-                text=response.text,
-                usage=usage.model_dump() if usage else None,
-            )
-        else:
-            body = response
-
+    def _finalize_transcription(
+        self,
+        *,
+        request_uuid: str,
+        api_key_uuid: str,
+        group_uuid: str,
+        api_key_name: str,
+        group_name: str,
+        route_name: str,
+        model_id: str,
+        model: Model,
+        latency_ms: float,
+        usage,
+        project_uuid: str = '',
+        project_name: str = '',
+    ) -> None:
         self._record_metrics(
             request_uuid=request_uuid,
             api_key_uuid=api_key_uuid,
@@ -228,7 +187,175 @@ class TranscriptionModelInvoker(ModelInvoker):
             project_name=project_name,
         )
 
+    @task(name='llm_transcribe')
+    async def transcribe(
+        self,
+        request_uuid: str,
+        api_key_uuid: str,
+        group_uuid: str,
+        api_key_name: str,
+        group_name: str,
+        route_name: str,
+        audio_bytes: bytes,
+        filename: str,
+        content_type: str | None,
+        model_id: str,
+        requested_response_format: str = 'json',
+        language: str | None = None,
+        prompt: str | None = None,
+        temperature: float | None = None,
+        project_uuid: str = '',
+        project_name: str = '',
+    ) -> Transcription | TranscriptionVerbose:
+        model, client, is_whisper, model_name = self._resolve_model(model_id)
+        if requested_response_format not in SUPPORTED_RESPONSE_FORMATS:
+            raise ModelInvokerBadRequest(
+                f'Unsupported response_format {requested_response_format!r}. '
+                f'Supported formats: {sorted(SUPPORTED_RESPONSE_FORMATS)}.'
+            )
+        if requested_response_format == 'verbose_json' and not is_whisper:
+            raise ModelInvokerBadRequest(
+                'response_format=verbose_json is only supported for whisper-1 models.'
+            )
+        upstream_format = 'verbose_json' if is_whisper else 'json'
+
+        _set_transcription_request_attributes(
+            filename=filename,
+            content_type=content_type,
+            audio_size_bytes=len(audio_bytes),
+            model_id=model_id,
+        )
+
+        create_kwargs: dict = {
+            'model': model_name,
+            'file': (filename, audio_bytes, content_type or 'application/octet-stream'),
+            'response_format': upstream_format,
+        }
+        if language:
+            create_kwargs['language'] = language
+        if prompt:
+            create_kwargs['prompt'] = prompt
+        if temperature is not None:
+            create_kwargs['temperature'] = temperature
+
+        start_time = time.monotonic()
+        response: Transcription | TranscriptionVerbose = await self._create_upstream(
+            client, create_kwargs
+        )
+        latency_ms = (time.monotonic() - start_time) * 1000
+        _set_transcription_response_attributes(response, is_whisper)
+
+        usage = response.usage
+        if requested_response_format == 'verbose_json':
+            # Only reachable for whisper-1
+            body = response
+        elif is_whisper:
+            body = Transcription(
+                text=response.text,
+                usage=usage.model_dump() if usage else None,
+            )
+        else:
+            body = response
+
+        self._finalize_transcription(
+            request_uuid=request_uuid,
+            api_key_uuid=api_key_uuid,
+            group_uuid=group_uuid,
+            api_key_name=api_key_name,
+            group_name=group_name,
+            route_name=route_name,
+            model_id=model_id,
+            model=model,
+            latency_ms=latency_ms,
+            usage=usage,
+            project_uuid=project_uuid,
+            project_name=project_name,
+        )
+
         return body
+
+    @task(name='llm_transcribe_stream')
+    async def stream(
+        self,
+        request_uuid: str,
+        api_key_uuid: str,
+        group_uuid: str,
+        api_key_name: str,
+        group_name: str,
+        route_name: str,
+        audio_bytes: bytes,
+        filename: str,
+        content_type: str | None,
+        model_id: str,
+        language: str | None = None,
+        prompt: str | None = None,
+        temperature: float | None = None,
+        project_uuid: str = '',
+        project_name: str = '',
+    ) -> AsyncIterator[TranscriptionStreamEvent]:
+        model, client, is_whisper, model_name = self._resolve_model(model_id)
+        if is_whisper:
+            raise ModelInvokerBadRequest(
+                'stream=true is only supported for the gpt-4o-transcribe family; '
+                'whisper-1 does not support streaming.'
+            )
+
+        _set_transcription_request_attributes(
+            filename=filename,
+            content_type=content_type,
+            audio_size_bytes=len(audio_bytes),
+            model_id=model_id,
+        )
+
+        create_kwargs: dict = {
+            'model': model_name,
+            'file': (filename, audio_bytes, content_type or 'application/octet-stream'),
+            'response_format': 'json',
+            'stream': True,
+        }
+        if language:
+            create_kwargs['language'] = language
+        if prompt:
+            create_kwargs['prompt'] = prompt
+        if temperature is not None:
+            create_kwargs['temperature'] = temperature
+
+        start_time = time.monotonic()
+        upstream_stream = await self._create_upstream(client, create_kwargs)
+
+        final_usage = None
+        text_parts: list[str] = []
+        async for event in upstream_stream:
+            if event.type == 'transcript.text.delta':
+                text_parts.append(event.delta)
+            elif event.type == 'transcript.text.done':
+                final_usage = event.usage
+            yield event
+        latency_ms = (time.monotonic() - start_time) * 1000
+
+        try:
+            span = trace.get_current_span()
+            if span.is_recording():
+                span.set_attribute(
+                    'transcription.response.text_length', len(''.join(text_parts))
+                )
+        except Exception:
+            pass
+
+        self._finalize_transcription(
+            request_uuid=request_uuid,
+            api_key_uuid=api_key_uuid,
+            group_uuid=group_uuid,
+            api_key_name=api_key_name,
+            group_name=group_name,
+            route_name=route_name,
+            model_id=model_id,
+            model=model,
+            latency_ms=latency_ms,
+            usage=final_usage,
+            project_uuid=project_uuid,
+            project_name=project_name,
+        )
 
     def _record_transcription_usage_cost(
         self,

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -865,7 +865,7 @@ async def audio_transcriptions(
     # Populate request event context first (before auth, so route_name is always captured)
     ctx = RequestEventContext.get_or_create(request)
     ctx.route_name = route_name
-    ctx.is_streaming = False
+    ctx.is_streaming = transcription_params.stream
 
     # Validate API key after context is populated
     set_operation_category(OperationCategory.AUTH)
@@ -908,6 +908,60 @@ async def audio_transcriptions(
     content = await file.read()
 
     set_operation_category(OperationCategory.ENDPOINT)
+
+    if transcription_params.stream:
+
+        async def event_generator():
+            try:
+                async for event in route.invoke_transcription_stream(
+                    request_uuid=request_uuid,
+                    api_key_uuid=key_details.api_key_uuid,
+                    api_key_name=key_details.api_key_name,
+                    group_uuid=key_details.group_uuid,
+                    group_name=key_details.group_name,
+                    route_name=route_name,
+                    audio_bytes=content,
+                    filename=file.filename or 'audio',
+                    content_type=file.content_type,
+                    language=transcription_params.language,
+                    prompt=transcription_params.prompt,
+                    temperature=transcription_params.temperature,
+                ):
+                    event_json = event.model_dump_json(exclude_none=True)
+                    logger.debug('Streaming transcription event: %s', event_json)
+                    yield f'data: {event_json}\n\n'
+                logger.debug('Streaming finished: [DONE]')
+                yield 'data: [DONE]\n\n'
+            except AppError as exc:
+                error_body = json.dumps(
+                    {
+                        'error': {
+                            'message': exc.client_message,
+                            'type': 'model_invoker_error',
+                            'param': None,
+                            'code': exc.status_code,
+                        }
+                    }
+                )
+                yield error_body, exc.status_code
+            except Exception:
+                logger.exception('Unhandled error during transcription streaming')
+                error_body = json.dumps(
+                    {
+                        'error': {
+                            'message': 'Unhandled error during streaming',
+                            'type': 'internal_error',
+                            'param': None,
+                            'code': 500,
+                        }
+                    }
+                )
+                yield error_body, 500
+
+        return StreamingResponseWithStatusCode(
+            event_generator(), media_type='text/event-stream'
+        )
+
     result = await route.invoke_transcription(
         request_uuid=request_uuid,
         api_key_uuid=key_details.api_key_uuid,

--- a/gateway/radicalbit_ai_gateway/utils/open_ai_types.py
+++ b/gateway/radicalbit_ai_gateway/utils/open_ai_types.py
@@ -572,5 +572,9 @@ class TranscriptionCreateParamsCustom(BaseModel):
     """The format of the transcript output. verbose_json is only supported for whisper-1;
     text/srt/vtt aren't supported yet."""
 
+    stream: bool = False
+    """Stream the transcript as it's generated via SSE. Only supported for the
+    gpt-4o-transcribe family; whisper-1 does not support streaming."""
+
     temperature: float | None = None
     """Sampling temperature, between 0 and 1."""

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -1114,6 +1114,115 @@ async def test_invoke_transcription_no_models_configured_raises():
         )
 
 
+@pytest.mark.asyncio
+async def test_invoke_transcription_stream_relays_events_and_counts_usage_once():
+    cost_service = MagicMock(spec_set=CostService)
+    gpt4o_model = Model(
+        model_id='gpt4o-transcribe',
+        model='openai/gpt-4o-transcribe',
+        credentials=Credentials(api_key='sk-test'),
+        input_cost_per_million_tokens=Decimal('2.5'),
+        output_cost_per_million_tokens=Decimal('10.0'),
+        input_cost_per_audio_token=Decimal('0.000006'),
+    )
+    route_cfg = _make_transcription_route_config(
+        model_id='gpt4o-transcribe', max_budget=10.0, window_size=3600
+    )
+    budget_limiter = route_cfg.get_budget_limiter()
+    budget_limiter.check_budget = AsyncMock()
+    budget_limiter.count_input = AsyncMock()
+    budget_limiter.count_output = AsyncMock()
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=[gpt4o_model],
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=None,
+        cost_service=cost_service,
+        budget_limiter=budget_limiter,
+    )
+
+    delta_event = MagicMock(usage=None)
+    done_event = MagicMock(
+        usage=MagicMock(
+            type='tokens',
+            input_tokens=87,
+            output_tokens=38,
+            input_token_details=MagicMock(audio_tokens=82, text_tokens=5),
+        )
+    )
+
+    async def fake_stream(**kwargs):
+        yield delta_event
+        yield done_event
+
+    ai_gateway.transcription_invoker.stream = fake_stream
+
+    events = [
+        event
+        async for event in ai_gateway.invoke_transcription_stream(
+            request_uuid=str(REQUEST_UUID),
+            api_key_uuid=str(API_KEY_UUID),
+            group_uuid=str(GROUP_UUID),
+            api_key_name='rb-key',
+            group_name='test-group',
+            route_name='rb-gateway',
+            audio_bytes=b'fake-audio',
+            filename='test.wav',
+            content_type='audio/wav',
+        )
+    ]
+
+    assert events == [delta_event, done_event]
+    budget_limiter.check_budget.assert_awaited_once()
+    # Usage is only available on the final event — budget counting must use
+    # that one, not the (usage=None) delta in between.
+    count_input_calls = budget_limiter.count_input.call_args_list
+    assert len(count_input_calls) == 2
+    assert {
+        (c.kwargs['token_count'], c.kwargs['input_cost_per_token'])
+        for c in count_input_calls
+    } == {
+        (82, gpt4o_model.input_cost_per_audio_token),
+        (5, gpt4o_model.input_cost_per_token),
+    }
+    budget_limiter.count_output.assert_awaited_once_with(
+        token_count=38, output_cost_per_token=gpt4o_model.output_cost_per_token
+    )
+
+
+@pytest.mark.asyncio
+async def test_invoke_transcription_stream_no_models_configured_raises():
+    cost_service = MagicMock(spec_set=CostService)
+    route_cfg = GatewayRouteConfig(route_name='rb-gateway', chat_models=[])
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=None,
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=None,
+        cost_service=cost_service,
+    )
+
+    with pytest.raises(GatewayBadRequest, match='no transcription models defined'):
+        async for _ in ai_gateway.invoke_transcription_stream(
+            request_uuid=str(REQUEST_UUID),
+            api_key_uuid=str(API_KEY_UUID),
+            group_uuid=str(GROUP_UUID),
+            api_key_name='rb-key',
+            group_name='test-group',
+            route_name='rb-gateway',
+            audio_bytes=b'fake-audio',
+            filename='test.wav',
+            content_type='audio/wav',
+        ):
+            pass
+
+
 @patch('radicalbit_ai_gateway.ai_gateway.emit_event', autospec=True)
 @patch('radicalbit_ai_gateway.invocation.model_invoker.emit_event', autospec=True)
 @pook.activate

--- a/gateway/tests/common/mocked_transcription_client.py
+++ b/gateway/tests/common/mocked_transcription_client.py
@@ -1,14 +1,37 @@
+class _MockTranscriptionStream:
+    """Mimics `AsyncStream[TranscriptionStreamEvent]` for a fixed list of events."""
+
+    def __init__(self, events):
+        self._events = events
+
+    def __aiter__(self):
+        return self._agen()
+
+    async def _agen(self):
+        for event in self._events:
+            yield event
+
+
 class _MockTranscriptions:
-    def __init__(self, response=None, exception=None, captured_kwargs=None):
+    def __init__(
+        self,
+        response=None,
+        exception=None,
+        captured_kwargs=None,
+        stream_events=None,
+    ):
         self._response = response
         self._exception = exception
         self._captured_kwargs = captured_kwargs
+        self._stream_events = stream_events
 
     async def create(self, **kwargs):
         if self._captured_kwargs is not None:
             self._captured_kwargs.update(kwargs)
         if self._exception is not None:
             raise self._exception
+        if kwargs.get('stream'):
+            return _MockTranscriptionStream(self._stream_events or [])
         return self._response
 
 
@@ -23,11 +46,15 @@ class MockTranscriptionClient:
 
     `captured_kwargs` is populated with the kwargs passed to
     `audio.transcriptions.create(...)`, so tests can assert on the upstream
-    `response_format` policy.
+    `response_format` policy. `stream_events`, if provided, is what a
+    `stream=True` call returns (an async-iterable of stream events); a
+    `response`/`exception` still control the non-streaming call.
     """
 
-    def __init__(self, response=None, exception=None):
+    def __init__(self, response=None, exception=None, stream_events=None):
         self.captured_kwargs: dict = {}
         self.audio = _MockAudio(
-            _MockTranscriptions(response, exception, self.captured_kwargs)
+            _MockTranscriptions(
+                response, exception, self.captured_kwargs, stream_events
+            )
         )

--- a/gateway/tests/invoker/test_transcription_model_invoker.py
+++ b/gateway/tests/invoker/test_transcription_model_invoker.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock, patch
 import httpx
 from openai import APIConnectionError, APIStatusError
 from openai.types.audio.transcription import Transcription
+from openai.types.audio.transcription_text_delta_event import (
+    TranscriptionTextDeltaEvent,
+)
+from openai.types.audio.transcription_text_done_event import TranscriptionTextDoneEvent
 from openai.types.audio.transcription_verbose import TranscriptionVerbose
 import pytest
 
@@ -334,6 +338,99 @@ class TestTranscriptionModelInvoker(unittest.IsolatedAsyncioTestCase):
                 content_type='audio/wav',
                 model_id='whisper',
             )
+
+    async def test_stream_whisper_rejects_before_any_upstream_call(self):
+        invoker = self._build_invoker(WHISPER_MODEL)
+        mock_client = MockTranscriptionClient(response=WHISPER_VERBOSE_RESPONSE)
+        invoker.model_map['whisper'] = (WHISPER_MODEL, mock_client, [])
+
+        with pytest.raises(ModelInvokerBadRequest, match='does not support streaming'):
+            async for _ in invoker.stream(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='whisper',
+            ):
+                pass
+
+        assert mock_client.captured_kwargs == {}
+
+    async def test_stream_gpt4o_relays_events_and_records_usage_once(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        invoker.cost_service.compute_cost.return_value = Decimal('0.000492')
+        delta_1 = TranscriptionTextDeltaEvent(
+            type='transcript.text.delta', delta='Ciao, '
+        )
+        delta_2 = TranscriptionTextDeltaEvent(
+            type='transcript.text.delta', delta='questo è un test.'
+        )
+        done = TranscriptionTextDoneEvent(
+            type='transcript.text.done',
+            text='Ciao, questo è un test.',
+            usage={
+                'type': 'tokens',
+                'input_tokens': 82,
+                'output_tokens': 0,
+                'total_tokens': 82,
+                'input_token_details': {'audio_tokens': 82, 'text_tokens': 0},
+            },
+        )
+        mock_client = MockTranscriptionClient(stream_events=[delta_1, delta_2, done])
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            mock_client,
+            [],
+        )
+
+        events = [
+            event
+            async for event in invoker.stream(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            )
+        ]
+
+        assert events == [delta_1, delta_2, done]
+        assert mock_client.captured_kwargs['stream'] is True
+        assert mock_client.captured_kwargs['response_format'] == 'json'
+        # One MODEL_INVOCATION event (_record_metrics) + one cost event
+        # (only the audio-token component is non-zero) — both emitted once,
+        # after the stream ends, not per-chunk.
+        assert self.mock_emit_event.call_count == 2
+        invoker.cost_service.compute_cost.assert_called_once_with(
+            model_id='gpt4o-transcribe', token_processed=82, where='audio'
+        )
+        cost_payload = self.mock_emit_event.call_args_list[1].args[0]
+        assert cost_payload.cache_type == 'audio'
+        assert cost_payload.value == 82
+
+    async def test_stream_gpt4o_upstream_5xx_raises_internal_error(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        request = httpx.Request(
+            'POST', 'https://api.openai.com/v1/audio/transcriptions'
+        )
+        response = httpx.Response(status_code=503, request=request)
+        exception = APIStatusError('Service unavailable', response=response, body=None)
+        mock_client = MockTranscriptionClient(exception=exception)
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            mock_client,
+            [],
+        )
+
+        with pytest.raises(ModelInvokerInternalError):
+            async for _ in invoker.stream(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            ):
+                pass
 
     def test_model_map_initialization(self):
         invoker = self._build_invoker(WHISPER_MODEL)

--- a/gateway/tests/test_server.py
+++ b/gateway/tests/test_server.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -7,6 +8,10 @@ from fastapi.testclient import TestClient
 from freezegun import freeze_time
 from langchain_core.messages import HumanMessage, SystemMessage
 from openai.types.audio.transcription import Transcription
+from openai.types.audio.transcription_text_delta_event import (
+    TranscriptionTextDeltaEvent,
+)
+from openai.types.audio.transcription_text_done_event import TranscriptionTextDoneEvent
 from openai.types.audio.transcription_verbose import TranscriptionVerbose
 from openai.types.create_embedding_response import CreateEmbeddingResponse, Usage
 from openai.types.embedding import Embedding
@@ -619,6 +624,93 @@ class TestServer(unittest.TestCase):
         )
         assert response.status_code == 200
         self.gateways_mock['rb-gateway'].invoke_transcription.assert_awaited_once()
+
+    def test_audio_transcriptions_streaming(self):
+        key_service.get_key_by_hashed_key = MagicMock(
+            return_value=db_mock.get_sample_key_with_group(
+                group_uuid=db_mock.GROUP_UUID
+            )
+        )
+        group_service.check_key_uuid_for_route = MagicMock(return_value=True)
+
+        async def mock_invoke_transcription_stream(*args, **kwargs):
+            yield TranscriptionTextDeltaEvent(
+                type='transcript.text.delta', delta='Ciao, '
+            )
+            yield TranscriptionTextDeltaEvent(
+                type='transcript.text.delta', delta='mondo.'
+            )
+            yield TranscriptionTextDoneEvent(
+                type='transcript.text.done',
+                text='Ciao, mondo.',
+                usage={
+                    'type': 'tokens',
+                    'input_tokens': 1,
+                    'output_tokens': 1,
+                    'total_tokens': 2,
+                },
+            )
+
+        self.gateways_mock[
+            'rb-gateway'
+        ].invoke_transcription_stream = mock_invoke_transcription_stream
+
+        response = self.client.post(
+            '/v1/audio/transcriptions',
+            data={'model': 'rb-gateway', 'stream': 'true'},
+            files={'file': ('test.wav', b'fake-audio-bytes', 'audio/wav')},
+            headers=self.headers,
+        )
+
+        assert response.status_code == 200
+        assert response.headers['content-type'] == 'text/event-stream; charset=utf-8'
+
+        lines = response.text.strip().split('\n\n')
+        assert len(lines) == 4
+        assert lines[0].startswith('data: ')
+        assert lines[1].startswith('data: ')
+        assert lines[2].startswith('data: ')
+        assert lines[3] == 'data: [DONE]'
+
+        chunk1 = json.loads(lines[0][6:])
+        assert chunk1['delta'] == 'Ciao, '
+        chunk3 = json.loads(lines[2][6:])
+        assert chunk3['text'] == 'Ciao, mondo.'
+
+    def test_audio_transcriptions_streaming_whisper_rejected_returns_error_status(self):
+        """When invoke_transcription_stream fails before yielding anything
+        (e.g. stream=true against a whisper-1 route), the response should be
+        a proper HTTP error, not a 200 with an error hidden in the SSE body.
+        """
+        key_service.get_key_by_hashed_key = MagicMock(
+            return_value=db_mock.get_sample_key_with_group(
+                group_uuid=db_mock.GROUP_UUID
+            )
+        )
+        group_service.check_key_uuid_for_route = MagicMock(return_value=True)
+
+        async def mock_invoke_transcription_stream_error(*args, **kwargs):
+            raise ModelInvokerBadRequest(
+                'stream=true is only supported for the gpt-4o-transcribe family; '
+                'whisper-1 does not support streaming.'
+            )
+            yield  # noqa: RUF027 — makes this an async generator
+
+        self.gateways_mock[
+            'rb-gateway'
+        ].invoke_transcription_stream = mock_invoke_transcription_stream_error
+
+        response = self.client.post(
+            '/v1/audio/transcriptions',
+            data={'model': 'rb-gateway', 'stream': 'true'},
+            files={'file': ('test.wav', b'fake-audio-bytes', 'audio/wav')},
+            headers=self.headers,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert 'error' in body
+        assert 'whisper-1 does not support streaming' in body['error']['message']
 
     @patch('radicalbit_ai_gateway.ai_gateway.emit_event', autospec=True)
     @patch('radicalbit_ai_gateway.invocation.model_invoker.emit_event', autospec=True)


### PR DESCRIPTION
# PR Summary: AG-899

Adds SSE streaming support to `/v1/audio/transcriptions` for the
`gpt-4o-transcribe` family. `whisper-1` does not support streaming upstream,
so `stream=true` against a whisper-1 route is rejected with an explicit 400
instead of silently falling back to a non-streaming response.

---

## DTO Changes

### `TranscriptionCreateParamsCustom` (MODIFIED)

**Changes:**
```diff
+ stream: boolean (added, default false)
```

| Field | Type | Description |
|-------|------|--------------|
| `file` | file | Audio file to transcribe |
| `model` | string | Route name to invoke |
| `language` | string | Optional. ISO-639-1 language hint |
| `prompt` | string | Optional. Guiding prompt |
| `response_format` | string | `json` or `verbose_json` (verbose_json is whisper-1 only) |
| `stream` **NEW** | boolean | Stream the transcript as it's generated via SSE. Only supported for the gpt-4o-transcribe family; whisper-1 does not support streaming. Default: `false` |
| `temperature` | float | Sampling temperature, between 0 and 1 |

**Used by:** `POST /v1/audio/transcriptions`

---

## Affected Endpoints

### `POST /v1/audio/transcriptions` (MODIFIED)

**Changes:**
```diff
+ stream: boolean (added, optional, default false)
```

When `stream=true`, the response switches from a single JSON body to a
`text/event-stream` response relaying the upstream OpenAI stream events
1:1 (real `openai` SDK types, no custom shape):

**Example request:**
```
POST /v1/audio/transcriptions
Content-Type: multipart/form-data

model=default/gpt4o-transcribe-route
file=<audio.wav>
stream=true
```

**Example response (SSE):**
```
data: {"delta":"Hello, ","type":"transcript.text.delta"}

data: {"delta":"world.","type":"transcript.text.delta"}

data: {"text":"Hello, world.","type":"transcript.text.done","usage":{"type":"tokens","input_tokens":82,"output_tokens":12,"total_tokens":94,"input_token_details":{"audio_tokens":82,"text_tokens":0}}}

data: [DONE]
```

- Only `transcript.text.delta` and `transcript.text.done` events are emitted
  (matches OpenAI's own SSE contract for this endpoint).
- Usage/cost is recorded once, after the stream completes, using the
  `usage` field on the final `transcript.text.done` event (audio tokens,
  text tokens, and output tokens billed separately, same as the
  non-streaming token-billed path).
- `stream=true` against a `whisper-1`-backed route fails fast with **400**
  (`whisper-1 does not support streaming`) — before any upstream call,
  budget check, or tracing side-effect. No 200-with-error-in-the-SSE-body.
- Any other upstream error (4xx/5xx) during streaming is mapped to the same
  `ModelInvokerBadRequest`/`ModelInvokerInternalError` → HTTP status as the
  non-streaming path, returned as a normal HTTP error status (not hidden
  inside the SSE body), since the error can only surface before the first
  chunk is written (the upstream call happens before iteration starts).

---

## Other Changes

- `ai_gateway.py` — new `GatewayRoute.invoke_transcription_stream()`,
  mirroring `invoke_transcription()`: resolves the route's transcription
  model, checks budget, relays `transcription_invoker.stream()`'s events,
  and counts usage once from the final event after the stream ends.
- `invocation/transcription_model_invoker.py`:
  - New `TranscriptionModelInvoker.stream()`, the streaming counterpart to
    `transcribe()`: rejects `whisper-1` immediately, otherwise calls
    upstream with `stream=True` and relays `TranscriptionStreamEvent`s as
    they arrive.
  - Refactored the 3 blocks duplicated between `transcribe()` and
    `stream()` into shared helpers: `_resolve_model()` (model lookup +
    whisper-family detection), `_create_upstream()` (upstream call +
    4xx/5xx → `ModelInvokerBadRequest`/`ModelInvokerInternalError` mapping),
    and `_finalize_transcription()` (`_record_metrics` +
    `_record_transcription_usage_cost` pairing). Pure refactor, no
    behavior change — covered by the existing non-streaming test suite.
- `tests/common/mocked_transcription_client.py` — `MockTranscriptionClient`
  now also accepts `stream_events` (an iterable of events returned when
  `stream=True` is passed to `create()`), alongside the existing
  `response`/`exception` for non-streaming calls.
- Test coverage added across all 3 layers (invoker, `ai_gateway.py`,
  `server.py`) for: event relay + single usage-count on stream end, the
  whisper-1 fail-fast rejection, and upstream 5xx mapping during streaming.
