### PR TITLE
feat(ui): UI refinements — icon buttons, segmented group-by, explicit chart loading state

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@radicalbit/formbit": "2.1.0",
-    "@radicalbit/radicalbit-design-system": "2.19.1",
+    "@radicalbit/radicalbit-design-system": "2.19.5",
     "@reduxjs/toolkit": "^2.8.2",
     "@vitejs/plugin-react": "^4.2.1",
     "ace-builds": "^1.33.2",

--- a/ui/src/components/logo/index.jsx
+++ b/ui/src/components/logo/index.jsx
@@ -29,13 +29,13 @@ export default function Logo({ className = '', onClick, title }) {
   const svg = logos[shape][color];
 
   return (
-    <a
-      className={`${className} p-4`}
+    <div
+      className={`${className} p-4 cursor-pointer`}
       onClick={onClick}
       role="presentation"
       title={title}
     >
       {svg}
-    </a>
+    </div>
   );
 }

--- a/ui/src/components/lucide/_styles.less
+++ b/ui/src/components/lucide/_styles.less
@@ -1,0 +1,12 @@
+.c-lucide {
+    &--disabled,
+	&[aria-disabled="true"] {
+		opacity: .3;
+		pointer-events: none;
+		cursor: default;
+	}
+
+    &--type-error {
+        color: var(--coo-error)
+    }
+}

--- a/ui/src/components/lucide/index.jsx
+++ b/ui/src/components/lucide/index.jsx
@@ -1,11 +1,33 @@
+import classNames from 'classnames';
+import './_styles.less';
+
 const SIZE_CLASSNAMES = {
   md: 'w-5 h-5',
 };
 
-function Lucide({ icon: Icon, size = 'md', className = '', ...rest }) {
+function Lucide({
+  icon: Icon,
+  size = 'md',
+  className = '',
+  disabled,
+  type = 'default',
+  ...rest
+}) {
+  const css = classNames(
+    {
+      [`c-lucide--type-${type}`]: type,
+      'c-lucide--disabled': disabled,
+    },
+    'c-lucide',
+  );
   const sizeClassName = SIZE_CLASSNAMES[size] ?? SIZE_CLASSNAMES.md;
 
-  return <Icon className={`inline-block align-middle ${sizeClassName} ${className}`} {...rest} />;
+  return (
+    <Icon
+      className={`inline-block align-middle ${sizeClassName} ${className} ${css}`}
+      {...rest}
+    />
+  );
 }
 
 export default Lucide;

--- a/ui/src/components/modals/add-group-to-key/header.jsx
+++ b/ui/src/components/modals/add-group-to-key/header.jsx
@@ -42,7 +42,6 @@ function Header() {
         </div>
       )}
       title="Associate group"
-      titleColor="primary"
     />
   );
 }

--- a/ui/src/components/modals/add-groups-to-route/header.jsx
+++ b/ui/src/components/modals/add-groups-to-route/header.jsx
@@ -27,7 +27,6 @@ function Header() {
         </div>
       )}
       title="Associate groups"
-      titleColor="primary"
     />
   );
 }

--- a/ui/src/components/modals/add-groups-to-route/useHandleOnSubmit.jsx
+++ b/ui/src/components/modals/add-groups-to-route/useHandleOnSubmit.jsx
@@ -14,9 +14,10 @@ export default () => {
   const [searchParams] = useSearchParams();
   const projectUuid = searchParams.get('projectUuid');
 
-  const { isFormInvalid, isDirty, submitForm } = useFormbitContext();
+  const { form, isFormInvalid, isDirty, submitForm } = useFormbitContext();
   const [trigger, args] = useAddGroupsToRouteMutation({ fixedCacheKey: `add-groups-to-route-${name}` });
-  const isSubmitDisabled = !isDirty || isFormInvalid();
+  const hasNoSelectedGroups = !form?.groups?.length;
+  const isSubmitDisabled = !isDirty || isFormInvalid() || hasNoSelectedGroups;
 
   const handleOnSubmit = useCallback(() => {
     if (isSubmitDisabled || args.isLoading) {

--- a/ui/src/components/modals/add-keys-to-group/header.jsx
+++ b/ui/src/components/modals/add-keys-to-group/header.jsx
@@ -42,7 +42,6 @@ function Header() {
         </div>
       )}
       title="Associate credentials"
-      titleColor="primary"
     />
   );
 }

--- a/ui/src/components/modals/add-keys-to-group/useHandleOnSubmit.jsx
+++ b/ui/src/components/modals/add-keys-to-group/useHandleOnSubmit.jsx
@@ -12,10 +12,11 @@ export default () => {
   const { data } = useGetGroupQuery(uuid);
   const name = data?.name;
 
-  const { isFormInvalid, isDirty, submitForm } = useFormbitContext();
+  const { form, isFormInvalid, isDirty, submitForm } = useFormbitContext();
 
   const [trigger, args] = useAddKeysToGroupMutation({ fixedCacheKey: `add-keys-to-groups-${uuid}` });
-  const isSubmitDisabled = !isDirty || isFormInvalid();
+  const hasNoSelectedKeys = !form?.keys?.length;
+  const isSubmitDisabled = !isDirty || isFormInvalid() || hasNoSelectedKeys;
 
   const handleOnSubmit = useCallback(() => {
     if (isSubmitDisabled || args.isLoading) {

--- a/ui/src/components/modals/add-routes-to-group/header.jsx
+++ b/ui/src/components/modals/add-routes-to-group/header.jsx
@@ -42,7 +42,6 @@ function Header() {
         </div>
       )}
       title="Associate routes"
-      titleColor="primary"
     />
   );
 }

--- a/ui/src/components/modals/add-routes-to-group/useHandleOnSubmit.jsx
+++ b/ui/src/components/modals/add-routes-to-group/useHandleOnSubmit.jsx
@@ -12,10 +12,11 @@ export default () => {
   const { data } = useGetGroupQuery(uuid);
   const name = data?.name;
 
-  const { isFormInvalid, isDirty, submitForm } = useFormbitContext();
+  const { form, isFormInvalid, isDirty, submitForm } = useFormbitContext();
 
   const [trigger, args] = useAddRoutesToGroupMutation({ fixedCacheKey: `add-routes-to-groups-${uuid}` });
-  const isSubmitDisabled = !isDirty || isFormInvalid();
+  const hasNoSelectedRoutes = !form?.routes?.length;
+  const isSubmitDisabled = !isDirty || isFormInvalid() || hasNoSelectedRoutes;
 
   const handleOnSubmit = useCallback(() => {
     if (isSubmitDisabled || args.isLoading) {

--- a/ui/src/components/modals/create-alert-rule/index.jsx
+++ b/ui/src/components/modals/create-alert-rule/index.jsx
@@ -48,7 +48,6 @@ function CreateAlertRuleInner() {
         <SectionTitle
           subtitle={subtitle}
           title="Create Alert"
-          titleColor="primary"
         />
       )}
       onCancel={hideModal}

--- a/ui/src/components/modals/create-group/index.jsx
+++ b/ui/src/components/modals/create-group/index.jsx
@@ -29,7 +29,6 @@ function CreateGroupInner() {
         <SectionTitle
           subtitle="Each group can be associated with routes and credentials"
           title="Create group"
-          titleColor="primary"
         />
       )}
       onCancel={hideModal}

--- a/ui/src/components/modals/create-key/create-modal.jsx
+++ b/ui/src/components/modals/create-key/create-modal.jsx
@@ -26,7 +26,6 @@ function CreateModal() {
             </>
           )}
           title="Create credential"
-          titleColor="primary"
         />
       )}
       onCancel={hideModal}

--- a/ui/src/components/modals/create-key/success-modal.jsx
+++ b/ui/src/components/modals/create-key/success-modal.jsx
@@ -20,7 +20,6 @@ function SuccessModal() {
         <SectionTitle
           subtitle="Please note that we do not display your credentials again after you generate them."
           title="Credential"
-          titleColor="primary"
         />
       )}
       maskClosable={false}

--- a/ui/src/components/modals/create-project/index.jsx
+++ b/ui/src/components/modals/create-project/index.jsx
@@ -30,7 +30,6 @@ function CreateProjectInner() {
         <SectionTitle
           subtitle="Create a new project to organize your resources"
           title="Create project"
-          titleColor="primary"
         />
       )}
       onCancel={hideModal}

--- a/ui/src/components/modals/edit-group/index.jsx
+++ b/ui/src/components/modals/edit-group/index.jsx
@@ -33,7 +33,6 @@ function EditGroupOuter() {
         <SectionTitle
           align="center"
           title="Edit Group"
-          titleColor="primary"
         />
       )}
       onCancel={hideModal}

--- a/ui/src/components/modals/edit-key/index.jsx
+++ b/ui/src/components/modals/edit-key/index.jsx
@@ -33,7 +33,6 @@ function EditKeyOuter() {
         <SectionTitle
           align="center"
           title="Edit credential"
-          titleColor="primary"
         />
       )}
       onCancel={hideModal}

--- a/ui/src/components/modals/edit-project-config/chatbot/chatbot-draft/index.jsx
+++ b/ui/src/components/modals/edit-project-config/chatbot/chatbot-draft/index.jsx
@@ -15,7 +15,7 @@ function ChatbotDraft({ config, projectUuid }) {
   const [isGenerated, setIsGenerated] = useState(false);
 
   return (
-    <div className="flex flex-col min-h-0">
+    <div className="flex flex-col min-h-0 gap-4">
       <NewHeader title={(
         <SectionTitle
           subtitle="AI can make mistakes, please check the answer"
@@ -28,6 +28,7 @@ function ChatbotDraft({ config, projectUuid }) {
       <ErrorAlert error={error} />
 
       <Board
+        backgroundLevel={0}
         className="min-h-0"
         main={(
           <div className="flex flex-col h-full min-h-0">

--- a/ui/src/components/modals/edit-project-config/chatbot/chatbot-draft/prompt-input.jsx
+++ b/ui/src/components/modals/edit-project-config/chatbot/chatbot-draft/prompt-input.jsx
@@ -55,6 +55,7 @@ function PromptInput({
 
   return (
     <Board
+      backgroundLevel={0}
       borderType="none"
       footer={(
         <NewHeader

--- a/ui/src/components/modals/edit-project-config/chatbot/chatbot-ready-to-serve.jsx
+++ b/ui/src/components/modals/edit-project-config/chatbot/chatbot-ready-to-serve.jsx
@@ -22,6 +22,7 @@ function ChatbotReadyToServe() {
         />
 
         <Board
+          backgroundLevel={0}
           borderType="none"
           footer={(
             <NewHeader

--- a/ui/src/components/modals/edit-project-config/chatbot/chatbot-served.jsx
+++ b/ui/src/components/modals/edit-project-config/chatbot/chatbot-served.jsx
@@ -22,6 +22,7 @@ function ChatbotServed() {
         />
 
         <Board
+          backgroundLevel={0}
           borderType="none"
           footer={(
             <NewHeader

--- a/ui/src/components/modals/edit-project-config/code-editor/header.jsx
+++ b/ui/src/components/modals/edit-project-config/code-editor/header.jsx
@@ -12,7 +12,7 @@ function Header({ activeConfigUuid, configs, onSelectConfig }) {
             size="small"
             title={`Slot ${config.slot}`}
           />
-      )}
+        )}
       />
     ),
   }));

--- a/ui/src/components/modals/edit-project-config/code-editor/index.jsx
+++ b/ui/src/components/modals/edit-project-config/code-editor/index.jsx
@@ -13,7 +13,7 @@ function CodeEditor() {
   }
 
   return (
-    <div className="flex flex-col min-h-0 gap-2 h-full">
+    <div className="flex flex-col min-h-0 gap-4 h-full">
 
       <Feedbacks config={activeConfig} />
 

--- a/ui/src/components/modals/edit-project-config/index.jsx
+++ b/ui/src/components/modals/edit-project-config/index.jsx
@@ -52,6 +52,7 @@ function EditProjectConfigOuter() {
 
   return (
     <RbitModal
+      backgroundLevel={0}
       closable={false}
       defaultMaximize
       header={<Header />}

--- a/ui/src/components/modals/route-analytics/requests-graph/option.js
+++ b/ui/src/components/modals/route-analytics/requests-graph/option.js
@@ -28,7 +28,7 @@ export default ({ xAxisData, series = [], granularity, total }) => ({
     axisLine: {
       show: true,
       lineStyle: {
-        color: '#dedede',
+        color: '#e4e4dd',
         width: 1,
       },
     },

--- a/ui/src/components/modals/route-analytics/tokens-graph/option.js
+++ b/ui/src/components/modals/route-analytics/tokens-graph/option.js
@@ -28,7 +28,7 @@ export default ({ xAxisData, series = [], granularity, total }) => ({
     axisLine: {
       show: true,
       lineStyle: {
-        color: '#dedede',
+        color: '#e4e4dd',
         width: 1,
       },
     },

--- a/ui/src/components/time-filter/index.jsx
+++ b/ui/src/components/time-filter/index.jsx
@@ -40,11 +40,11 @@ function TimeFilterTag() {
   const to = searchParams.get('to');
 
   if (!from && !to) {
-    return <Tag animated="default" rounded size="large" type="full">REAL TIME</Tag>;
+    return <Tag rounded size="large" type="full">REAL TIME</Tag>;
   }
 
   if (from && !to) {
-    return <Tag animated="default" rounded size="large" type="full">REAL TIME</Tag>;
+    return <Tag rounded size="large" type="full">REAL TIME</Tag>;
   }
 
   return false;

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -76,7 +76,8 @@ const numberFormatterFloat = (number, options = {}) => {
 
 const echartNumberFormatter = (options = defaultNumberFormatter) => new Intl.NumberFormat('en-US', options);
 
-const CHART_COLORS = ['#3E75D8', '#4C95A4', '#F1B143', '#EF9337', '#84929E', '#70A268', '#467EA8', '#1D15B1', '#9242A5'];
+// Categorical palette for echarts series — design-system "Visualization Colors"
+const CHART_COLORS = ['#00E6C7', '#B61CD4', '#00A35C', '#D16900', '#006FFA', '#F33D23', '#ED32B9', '#FF8C00'];
 
 const DATE_FORMAT = ' DD MMM YYYY, HH:mm:ss';
 

--- a/ui/src/container/app/index.jsx
+++ b/ui/src/container/app/index.jsx
@@ -184,25 +184,30 @@ const useNavigateNavBarWithKeyboard = () => {
 
       if ((isMac && e.ctrlKey && e.code === 'Digit2')) {
         e.preventDefault();
-        navigate(`/${PathsEnum.ROUTES}`);
+        navigate(`/${PathsEnum.CONFIGURATIONS}`);
       }
 
       if ((isMac && e.ctrlKey && e.code === 'Digit3')) {
         e.preventDefault();
-        navigate(`/${PathsEnum.USAGE}`);
+        navigate(`/${PathsEnum.ROUTES}`);
       }
 
       if ((isMac && e.ctrlKey && e.code === 'Digit4')) {
         e.preventDefault();
-        navigate(`/${PathsEnum.TRACING}`);
+        navigate(`/${PathsEnum.USAGE}`);
       }
 
       if ((isMac && e.ctrlKey && e.code === 'Digit5')) {
         e.preventDefault();
-        navigate(`/${PathsEnum.GROUPS}`);
+        navigate(`/${PathsEnum.TRACING}`);
       }
 
       if ((isMac && e.ctrlKey && e.code === 'Digit6')) {
+        e.preventDefault();
+        navigate(`/${PathsEnum.GROUPS}`);
+      }
+
+      if ((isMac && e.ctrlKey && e.code === 'Digit7')) {
         e.preventDefault();
         navigate(`/${PathsEnum.CREDENTIALS}`);
       }

--- a/ui/src/container/layout/index.jsx
+++ b/ui/src/container/layout/index.jsx
@@ -72,7 +72,7 @@ const projects = (hasLeftColumnCollapsed) => ({
 
 const configurations = (hasLeftColumnCollapsed) => ({
   position: 3,
-  title: hasLeftColumnCollapsed ? <CollapsedTitle>Configurations</CollapsedTitle> : 'Configurations',
+  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '2', shape: 'circle' }] }}>Configurations</CollapsedTitle> : 'Configurations',
   icon: <Lucide icon={Settings2} size="md" />,
   key: PathsEnum.CONFIGURATIONS,
   link: getLink(PathsEnum.CONFIGURATIONS),
@@ -80,7 +80,7 @@ const configurations = (hasLeftColumnCollapsed) => ({
 
 const routes = (hasLeftColumnCollapsed) => ({
   position: 6,
-  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '2', shape: 'circle' }] }}>Routes</CollapsedTitle> : 'Routes',
+  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '3', shape: 'circle' }] }}>Routes</CollapsedTitle> : 'Routes',
   icon: <Lucide icon={Gauge} size="md" />,
   key: PathsEnum.ROUTES,
   link: getLink(PathsEnum.ROUTES),
@@ -88,7 +88,7 @@ const routes = (hasLeftColumnCollapsed) => ({
 
 const usage = (hasLeftColumnCollapsed) => ({
   position: 7,
-  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '3', shape: 'circle' }] }}>Usage</CollapsedTitle> : 'Usage',
+  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '4', shape: 'circle' }] }}>Usage</CollapsedTitle> : 'Usage',
   icon: <Lucide icon={Signpost} size="md" />,
   key: PathsEnum.USAGE,
   link: getLink(PathsEnum.USAGE),
@@ -96,7 +96,7 @@ const usage = (hasLeftColumnCollapsed) => ({
 
 const tracing = (hasLeftColumnCollapsed) => ({
   position: 8,
-  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '4', shape: 'circle' }] }}>Tracing</CollapsedTitle> : 'Tracing',
+  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '5', shape: 'circle' }] }}>Tracing</CollapsedTitle> : 'Tracing',
   icon: <Lucide icon={Route} size="md" />,
   key: PathsEnum.TRACING,
   link: getLink(PathsEnum.TRACING),
@@ -104,7 +104,7 @@ const tracing = (hasLeftColumnCollapsed) => ({
 
 const groups = (hasLeftColumnCollapsed) => ({
   position: 11,
-  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '5', shape: 'circle' }] }}>Groups</CollapsedTitle> : 'Groups',
+  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '6', shape: 'circle' }] }}>Groups</CollapsedTitle> : 'Groups',
   icon: <Lucide icon={Users} size="md" />,
   key: PathsEnum.GROUPS,
   link: getLink(PathsEnum.GROUPS),
@@ -112,7 +112,7 @@ const groups = (hasLeftColumnCollapsed) => ({
 
 const keys = (hasLeftColumnCollapsed) => ({
   position: 12,
-  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '6', shape: 'circle' }] }}>Credentials</CollapsedTitle> : 'Credentials',
+  title: hasLeftColumnCollapsed ? <CollapsedTitle keys={{ mac: [{ label: 'Ctrl' }, { label: '7', shape: 'circle' }] }}>Credentials</CollapsedTitle> : 'Credentials',
   icon: <Lucide icon={Key} size="md" />,
   key: PathsEnum.CREDENTIALS,
   link: getLink(PathsEnum.CREDENTIALS),

--- a/ui/src/container/layout/index.jsx
+++ b/ui/src/container/layout/index.jsx
@@ -163,7 +163,7 @@ export function CollapsedTitle({ children, keys: keyboardKeys = {}, buttonProps 
       {mac && (
         <div className="flex gap-2 items-center">
           {mac.map(({ label, shape }) => (
-            <Button shape={shape} size="small" type="secondary-outlined" {...buttonProps}>
+            <Button shape={shape} size="small" type="secondary" {...buttonProps}>
               {label}
             </Button>
           ))}

--- a/ui/src/container/pages/alerts/list/body/columns.jsx
+++ b/ui/src/container/pages/alerts/list/body/columns.jsx
@@ -1,9 +1,9 @@
 import Lucide from '@Components/lucide';
 import {
-  DataTableAction, Tooltip, Truncate,
+  Button, DataTableAction, Tooltip, Truncate,
 } from '@radicalbit/radicalbit-design-system';
 import {
-  CircleCheck, CircleX, TriangleAlert, Trash2,
+  CircleCheck, CircleX, TriangleAlert, Trash,
 } from 'lucide-react';
 import DeleteAlert from '../delete-alert';
 
@@ -105,7 +105,9 @@ function Actions({ uuid, name }) {
     <DataTableAction noHide>
       <span onClick={handleOnClick} role="presentation">
         <DeleteAlert name={name} uuid={uuid}>
-          <Lucide className="px-4" icon={Trash2} />
+          <Button size="small" type="text">
+            <Lucide icon={Trash} type="error" />
+          </Button>
         </DeleteAlert>
       </span>
     </DataTableAction>

--- a/ui/src/container/pages/groups/detail/body/keys/columns.jsx
+++ b/ui/src/container/pages/groups/detail/body/keys/columns.jsx
@@ -3,12 +3,13 @@ import SuccessMessage from '@Components/success-message';
 import { DATE_FORMAT, GATEWAY_OWNER } from '@Src/constants';
 import { useGetGroupQuery, useRemoveKeyFromGroupMutation } from '@State/groups/api';
 import {
+  Button,
   DataTableAction,
   Popconfirm, RelativeDateTime, SectionTitle, Skeleton, TextWithBold,
   Tooltip,
   Truncate,
 } from '@radicalbit/radicalbit-design-system';
-import { Trash2 } from 'lucide-react';
+import { Trash } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 
 const columns = [
@@ -42,7 +43,7 @@ const columns = [
     dataIndex: 'uuid',
     align: 'uuid',
     width: '10%',
-    render: (uuid, record) => <DataTableAction><Actions record={record} uuid={uuid} /></DataTableAction>,
+    render: (uuid, record) => <DataTableAction noHide><Actions record={record} uuid={uuid} /></DataTableAction>,
   },
 ];
 
@@ -79,31 +80,33 @@ function Actions({ uuid: keyUUID, record: { name } }) {
 
   if (isExternallyManaged) {
     return (
-      <div className="flex">
-        <Tooltip title={DISABLED_GROUP_TOOLTIP}>
-          <span>
-            <Lucide icon={Trash2} />
-          </span>
-        </Tooltip>
-      </div>
+      <Tooltip title={DISABLED_GROUP_TOOLTIP}>
+        <div>
+          <Button disabled size="small" type="text">
+            <Lucide disabled icon={Trash} />
+          </Button>
+        </div>
+      </Tooltip>
     );
   }
 
   return (
-    <div className="flex">
-      <Tooltip title="Remove">
-        <Popconfirm
-          cancelButtonProps={{ type: 'secondary-light' }}
-          description={<TextWithBold bold={name} isQuestion text="Are you sure you want to remove the group from the credential" />}
-          label={<Lucide icon={Trash2} />}
-          okText={<div className="is-error">Remove</div>}
-          okType="error-light"
-          onCancel={handleOnCancel}
-          onConfirm={handleOnDelete}
-          title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
-        />
-      </Tooltip>
-    </div>
+    <Tooltip title="Remove">
+      <Popconfirm
+        cancelButtonProps={{ type: 'secondary-light' }}
+        description={<TextWithBold bold={name} isQuestion text="Are you sure you want to remove the group from the credential" />}
+        label={(
+          <Button size="small" type="text">
+            <Lucide icon={Trash} type="error" />
+          </Button>
+          )}
+        okText={<div className="is-error">Remove</div>}
+        okType="error-light"
+        onCancel={handleOnCancel}
+        onConfirm={handleOnDelete}
+        title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
+      />
+    </Tooltip>
   );
 }
 

--- a/ui/src/container/pages/groups/detail/body/routes/columns.jsx
+++ b/ui/src/container/pages/groups/detail/body/routes/columns.jsx
@@ -3,10 +3,11 @@ import SuccessMessage from '@Components/success-message';
 import { useRemoveRouteFromGroupMutation } from '@State/groups/api';
 import { useGetProjectQuery } from '@State/projects/api';
 import {
+  Button,
   DataTableAction, Popconfirm,
   SectionTitle, Skeleton, TextWithBold, Tooltip, Truncate,
 } from '@radicalbit/radicalbit-design-system';
-import { Trash2 } from 'lucide-react';
+import { Trash } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 
 const columns = [
@@ -33,7 +34,7 @@ const columns = [
     dataIndex: 'name',
     key: 'actions',
     width: '10%',
-    render: (name, record) => <DataTableAction><Actions name={name} record={record} /></DataTableAction>,
+    render: (name, record) => <DataTableAction noHide><Actions name={name} record={record} /></DataTableAction>,
   },
 ];
 
@@ -80,20 +81,22 @@ function Actions({ name, record }) {
   const handleOnCancel = (e) => { e.stopPropagation(); };
 
   return (
-    <div className="flex">
-      <Tooltip title="Remove">
-        <Popconfirm
-          cancelButtonProps={{ type: 'secondary-light' }}
-          description={<TextWithBold bold={name} isQuestion text="Are you sure you want to remove the group from the route" />}
-          label={<Lucide icon={Trash2} />}
-          okText={<div className="is-error">Remove</div>}
-          okType="error-light"
-          onCancel={handleOnCancel}
-          onConfirm={handleOnDelete}
-          title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
-        />
-      </Tooltip>
-    </div>
+    <Tooltip title="Remove">
+      <Popconfirm
+        cancelButtonProps={{ type: 'secondary-light' }}
+        description={<TextWithBold bold={name} isQuestion text="Are you sure you want to remove the group from the route" />}
+        label={(
+          <Button size="small" type="text">
+            <Lucide icon={Trash} type="error" />
+          </Button>
+          )}
+        okText={<div className="is-error">Remove</div>}
+        okType="error-light"
+        onCancel={handleOnCancel}
+        onConfirm={handleOnDelete}
+        title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
+      />
+    </Tooltip>
   );
 }
 

--- a/ui/src/container/pages/groups/list/body/index.jsx
+++ b/ui/src/container/pages/groups/list/body/index.jsx
@@ -85,7 +85,8 @@ function GroupsCount({ searchValue }) {
 }
 
 function GroupsTable({ searchValue }) {
-  const { popup, openPopup, closePopup } = usePopup();
+  // const { popup, openPopup, closePopup } = usePopup();
+  const { popup, closePopup } = usePopup();
   const items = useGetThreeDotsMenuItems(popup?.record?.uuid);
 
   const navigate = useNavigate();
@@ -138,9 +139,10 @@ function GroupsTable({ searchValue }) {
           onClick: () => {
             handleOnRowClick(record);
           },
-          onContextMenu: (event) => {
-            openPopup(event, record);
-          },
+          // FIXME: UI is broken
+          // onContextMenu: (event) => {
+          //   openPopup(event, record);
+          // },
         })}
         pagination={{
           hideOnSinglePage: true,

--- a/ui/src/container/pages/keys/list/body/columns.jsx
+++ b/ui/src/container/pages/keys/list/body/columns.jsx
@@ -6,6 +6,7 @@ import { DATE_FORMAT, GATEWAY_OWNER, PathsEnum, SEARCH_PARAMS } from '@Src/const
 import { useRemoveKeyFromGroupMutation } from '@State/groups/api';
 import { useGetKeyQuery } from '@State/keys/api';
 import {
+  Button,
   DataTableAction,
   Popconfirm,
   RelativeDateTime,
@@ -14,11 +15,12 @@ import {
   TextWithBold,
   Tooltip, Truncate,
 } from '@radicalbit/radicalbit-design-system';
-import { Pencil, Plus, Trash2, X } from 'lucide-react';
+import { PencilLine, Plus, Trash, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import DeleteKey from '../delete-key';
 
 const DISABLED_CREDENTIALS_TOOLTIP = 'This credential is managed externally and cannot be modified';
+const NO_GROUPS_TOOLTIP = 'No groups are available to associate';
 
 const columns = [
   {
@@ -74,7 +76,7 @@ const columns = [
     title: '',
     dataIndex: 'uuid',
     key: 'uuid',
-    render: (uuid) => <DataTableAction><Actions uuid={uuid} /></DataTableAction>,
+    render: (uuid) => <DataTableAction noHide><Actions uuid={uuid} /></DataTableAction>,
   },
 ];
 
@@ -98,7 +100,7 @@ function AssociatedGroup({ group }) {
 
 function Actions({ uuid }) {
   return (
-    <div className="flex">
+    <div className="flex justify-center items-center">
       <ActionAssociateGroup uuid={uuid} />
 
       <ActionRemoveGroup uuid={uuid} />
@@ -123,7 +125,7 @@ function ActionAssociateGroup({ uuid }) {
   };
 
   if (isLoading) {
-    return <Skeleton.Avatar active shape="square" size="small" />;
+    return <IsLoadingAction />;
   }
 
   if (!isSuccess || isError) {
@@ -131,22 +133,34 @@ function ActionAssociateGroup({ uuid }) {
   }
 
   if (isAssociateGroupDisabled) {
-    return false;
+    return (
+      <Tooltip title={NO_GROUPS_TOOLTIP}>
+        <div>
+          <Button disabled size="small" type="text">
+            <Lucide icon={Plus} />
+          </Button>
+        </div>
+      </Tooltip>
+    );
   }
 
   if (isExternallyManaged) {
     return (
       <Tooltip title={DISABLED_CREDENTIALS_TOOLTIP}>
-        <span>
-          <Lucide className="px-4" icon={Plus} />
-        </span>
+        <div>
+          <Button disabled size="small" type="text">
+            <Lucide icon={Plus} />
+          </Button>
+        </div>
       </Tooltip>
     );
   }
 
   return (
     <Tooltip title="Associate group">
-      <Lucide className="px-4" icon={Plus} onClick={handleOnAdd} />
+      <Button onClick={handleOnAdd} size="small" type="text">
+        <Lucide icon={Plus} />
+      </Button>
     </Tooltip>
   );
 }
@@ -175,7 +189,7 @@ function ActionRemoveGroup({ uuid }) {
   const handleOnCancel = (e) => { e.stopPropagation(); };
 
   if (isLoading) {
-    return <Skeleton.Avatar active shape="square" size="small" />;
+    return <IsLoadingAction />;
   }
 
   if (!groupName || !isSuccess || isError) {
@@ -184,31 +198,33 @@ function ActionRemoveGroup({ uuid }) {
 
   if (isExternallyManaged) {
     return (
-      <div className="flex">
-        <Tooltip title={DISABLED_CREDENTIALS_TOOLTIP}>
-          <span>
-            <Lucide className="px-4" icon={Trash2} />
-          </span>
-        </Tooltip>
-      </div>
+      <Tooltip title={DISABLED_CREDENTIALS_TOOLTIP}>
+        <div>
+          <Button disabled size="small" type="text">
+            <Lucide icon={X} />
+          </Button>
+        </div>
+      </Tooltip>
     );
   }
 
   return (
-    <div className="flex">
-      <Tooltip title="Remove group">
-        <Popconfirm
-          cancelButtonProps={{ type: 'secondary-light' }}
-          description={<TextWithBold bold={groupName} isQuestion text="Are you sure you want to remove the credential from the group" />}
-          label={<Lucide className="px-4" icon={X} />}
-          okText={<div className="is-error">Remove</div>}
-          okType="error-light"
-          onCancel={handleOnCancel}
-          onConfirm={handleOnDelete}
-          title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
-        />
-      </Tooltip>
-    </div>
+    <Tooltip title="Remove group">
+      <Popconfirm
+        cancelButtonProps={{ type: 'secondary-light' }}
+        description={<TextWithBold bold={groupName} isQuestion text="Are you sure you want to remove the credential from the group" />}
+        label={(
+          <Button size="small" type="text">
+            <Lucide icon={X} />
+          </Button>
+          )}
+        okText={<div className="is-error">Remove</div>}
+        okType="error-light"
+        onCancel={handleOnCancel}
+        onConfirm={handleOnDelete}
+        title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
+      />
+    </Tooltip>
   );
 }
 
@@ -224,7 +240,7 @@ function ActionEditKey({ uuid }) {
   };
 
   if (isLoading) {
-    return <Skeleton.Avatar active shape="square" size="small" />;
+    return <IsLoadingAction />;
   }
 
   if (!isSuccess || isError) {
@@ -234,16 +250,20 @@ function ActionEditKey({ uuid }) {
   if (isExternallyManaged) {
     return (
       <Tooltip title={DISABLED_CREDENTIALS_TOOLTIP}>
-        <span>
-          <Lucide className="px-4" icon={Pencil} />
-        </span>
+        <div>
+          <Button disabled size="small" type="text">
+            <Lucide icon={PencilLine} />
+          </Button>
+        </div>
       </Tooltip>
     );
   }
 
   return (
     <Tooltip title="Edit credential">
-      <Lucide className="px-4" icon={Pencil} onClick={handleOnEditKey} />
+      <Button onClick={handleOnEditKey} size="small" type="text">
+        <Lucide icon={PencilLine} />
+      </Button>
     </Tooltip>
   );
 }
@@ -254,7 +274,7 @@ function ActionDeleteKey({ uuid }) {
   const isExternallyManaged = owner !== GATEWAY_OWNER;
 
   if (isLoading) {
-    return <Skeleton.Avatar active shape="square" size="small" />;
+    return <IsLoadingAction />;
   }
 
   if (!isSuccess || isError) {
@@ -264,9 +284,11 @@ function ActionDeleteKey({ uuid }) {
   if (isExternallyManaged) {
     return (
       <Tooltip title={DISABLED_CREDENTIALS_TOOLTIP}>
-        <span>
-          <Lucide className="px-4" icon={Trash2} />
-        </span>
+        <div>
+          <Button disabled size="small" type="text">
+            <Lucide icon={Trash} />
+          </Button>
+        </div>
       </Tooltip>
     );
   }
@@ -274,9 +296,19 @@ function ActionDeleteKey({ uuid }) {
   return (
     <DeleteKey uuid={uuid}>
       <Tooltip title="Delete credential">
-        <Lucide className="px-4" icon={Trash2} />
+        <Button size="small" type="text">
+          <Lucide icon={Trash} type="error" />
+        </Button>
       </Tooltip>
     </DeleteKey>
+  );
+}
+
+function IsLoadingAction() {
+  return (
+    <div className="p-4">
+      <Skeleton.Avatar active shape="square" size="small" />
+    </div>
   );
 }
 

--- a/ui/src/container/pages/keys/list/body/index.jsx
+++ b/ui/src/container/pages/keys/list/body/index.jsx
@@ -134,7 +134,8 @@ function RowWithSpinner({ children, ...other }) {
 }
 
 function IsSuccess({ searchValue }) {
-  const { popup, openPopup, closePopup } = usePopup();
+  // const { popup, openPopup, closePopup } = usePopup();
+  const { popup, closePopup } = usePopup();
   const items = useGetThreeDotsMenuItems(popup?.record?.uuid);
 
   const { uuid } = useParams();
@@ -153,11 +154,12 @@ function IsSuccess({ searchValue }) {
         columns={columns}
         components={components}
         dataSource={filteredData}
-        onRow={(record) => ({
-          onContextMenu: (event) => {
-            openPopup(event, record);
-          },
-        })}
+        // FIXME: UI is broken
+        // onRow={(record) => ({
+        //   onContextMenu: (event) => {
+        //     openPopup(event, record);
+        //   },
+        // })}
         pagination={{
           hideOnSinglePage: true,
         }}

--- a/ui/src/container/pages/projects/list/body/three-dots-menu.jsx
+++ b/ui/src/container/pages/projects/list/body/three-dots-menu.jsx
@@ -17,7 +17,7 @@ import {
   Play,
   Square,
   SquarePen,
-  Trash2,
+  Trash,
 } from 'lucide-react';
 
 export const useGetThreeDotsMenuItems = (uuid) => {
@@ -179,7 +179,7 @@ const useDeleteProjectItems = (uuid) => [
     label: (
       <DeleteProject uuid={uuid}>
         <div className="is-error flex items-center gap-2">
-          <Lucide icon={Trash2} />
+          <Lucide icon={Trash} type="error" />
 
           Delete project
         </div>

--- a/ui/src/container/pages/routes/detail/body/associated-groups/columns.jsx
+++ b/ui/src/container/pages/routes/detail/body/associated-groups/columns.jsx
@@ -3,10 +3,11 @@ import SuccessMessage from '@Components/success-message';
 import { DATE_FORMAT } from '@Src/constants';
 import { useRemoveRouteFromGroupMutation } from '@State/groups/api';
 import {
+  Button,
   DataTableAction,
   Popconfirm, RelativeDateTime, SectionTitle, TextWithBold, Tooltip, Truncate,
 } from '@radicalbit/radicalbit-design-system';
-import { Trash2 } from 'lucide-react';
+import { Trash } from 'lucide-react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
 const columns = [
@@ -38,7 +39,7 @@ const columns = [
     title: '',
     dataIndex: 'groups',
     key: 'actions',
-    render: (name, record) => <DataTableAction><Actions name={name} record={record} /></DataTableAction>,
+    render: (name, record) => <DataTableAction noHide><Actions name={name} record={record} /></DataTableAction>,
   },
 ];
 
@@ -64,20 +65,22 @@ function Actions({ record: { uuid } }) {
   const handleOnCancel = (e) => { e.stopPropagation(); };
 
   return (
-    <div className="flex gap-4">
-      <Tooltip title="Remove">
-        <Popconfirm
-          cancelButtonProps={{ type: 'secondary-light' }}
-          description={<TextWithBold bold={name} isQuestion text="Are you sure you want to remove from the route the group" />}
-          label={<Lucide icon={Trash2} />}
-          okText={<div className="is-error">Remove</div>}
-          okType="error-light"
-          onCancel={handleOnCancel}
-          onConfirm={handleOnDelete}
-          title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
-        />
-      </Tooltip>
-    </div>
+    <Tooltip title="Remove">
+      <Popconfirm
+        cancelButtonProps={{ type: 'secondary-light' }}
+        description={<TextWithBold bold={name} isQuestion text="Are you sure you want to remove from the route the group" />}
+        label={(
+          <Button size="small" type="text">
+            <Lucide icon={Trash} type="error" />
+          </Button>
+          )}
+        okText={<div className="is-error">Remove</div>}
+        okType="error-light"
+        onCancel={handleOnCancel}
+        onConfirm={handleOnDelete}
+        title={<SectionTitle size="small" title="Remove group" titleColor="error" />}
+      />
+    </Tooltip>
   );
 }
 

--- a/ui/src/container/pages/routes/list/body/metrics/02-most-requested.jsx
+++ b/ui/src/container/pages/routes/list/body/metrics/02-most-requested.jsx
@@ -13,6 +13,7 @@ import {
   echarts,
   ReactEChartsCore,
   GRANULARITY_LABEL,
+  SPARKLINE_COLOR,
   sparklineOption,
   formatIncrement,
 } from './options';
@@ -103,7 +104,7 @@ function IsSuccess({ data }) {
           echarts={echarts}
           lazyUpdate
           notMerge={false}
-          option={sparklineOption(chart, numberFormatterInt)}
+          option={sparklineOption(chart, numberFormatterInt, SPARKLINE_COLOR.mostRequested)}
           style={sparklineWidthAndHeight}
         />
       )}

--- a/ui/src/container/pages/routes/list/body/metrics/03-top-error.jsx
+++ b/ui/src/container/pages/routes/list/body/metrics/03-top-error.jsx
@@ -13,6 +13,7 @@ import {
   echarts,
   ReactEChartsCore,
   GRANULARITY_LABEL,
+  SPARKLINE_COLOR,
   sparklineOption,
   formatIncrement,
 } from './options';
@@ -103,7 +104,7 @@ function IsSuccess({ data }) {
           echarts={echarts}
           lazyUpdate
           notMerge={false}
-          option={sparklineOption(chart, numberFormatterInt)}
+          option={sparklineOption(chart, numberFormatterInt, SPARKLINE_COLOR.topError)}
           style={sparklineWidthAndHeight}
         />
       )}

--- a/ui/src/container/pages/routes/list/body/metrics/04-top-cost.jsx
+++ b/ui/src/container/pages/routes/list/body/metrics/04-top-cost.jsx
@@ -13,6 +13,7 @@ import {
   echarts,
   ReactEChartsCore,
   GRANULARITY_LABEL,
+  SPARKLINE_COLOR,
   sparklineOption,
   formatIncrement,
 } from './options';
@@ -111,7 +112,7 @@ function IsSuccess({ data }) {
           echarts={echarts}
           lazyUpdate
           notMerge={false}
-          option={sparklineOption(chart, formatDollar)}
+          option={sparklineOption(chart, formatDollar, SPARKLINE_COLOR.topCost)}
           style={sparklineWidthAndHeight}
         />
       )}

--- a/ui/src/container/pages/routes/list/body/metrics/index.jsx
+++ b/ui/src/container/pages/routes/list/body/metrics/index.jsx
@@ -5,7 +5,7 @@ import TopCost from './04-top-cost';
 
 function Metrics() {
   return (
-    <div className="flex gap-8 p-8 overflow-x-auto">
+    <div className="flex gap-8 py-8 overflow-x-auto">
       <RoutesCounter />
 
       <MostRequested />

--- a/ui/src/container/pages/routes/list/body/metrics/options.js
+++ b/ui/src/container/pages/routes/list/body/metrics/options.js
@@ -14,7 +14,14 @@ const GRANULARITY_LABEL = {
   months: 'month',
 };
 
-function sparklineOption(chart, formatter) {
+// Sparkline line colors from the design-system "Visualization Colors" (Light row).
+const SPARKLINE_COLOR = {
+  mostRequested: '#006FFA', // Chart 5 Light (blue)
+  topCost: '#D16900', // Chart 4 Light (orange)
+  topError: '#B61CD4', // Chart 2 Light (purple)
+};
+
+function sparklineOption(chart, formatter, color) {
   const isSinglePoint = chart.data.length === 1;
 
   return {
@@ -36,8 +43,9 @@ function sparklineOption(chart, formatter) {
         smooth: true,
         showSymbol: isSinglePoint,
         symbolSize: isSinglePoint ? 6 : 4,
-        lineStyle: { width: 2 },
-        areaStyle: { opacity: 0.1 },
+        ...(color ? { itemStyle: { color } } : {}),
+        lineStyle: { width: 2, ...(color ? { color } : {}) },
+        areaStyle: { opacity: 0.1, ...(color ? { color } : {}) },
       },
     ],
     tooltip: {
@@ -61,4 +69,6 @@ function formatIncrement(value) {
   return `${sign}${Math.round(value)}%`;
 }
 
-export { GRANULARITY_LABEL, ReactEChartsCore, echarts, formatIncrement, sparklineOption };
+export {
+  GRANULARITY_LABEL, ReactEChartsCore, SPARKLINE_COLOR, echarts, formatIncrement, sparklineOption,
+};

--- a/ui/src/container/pages/routes/list/body/table/columns/analytics.jsx
+++ b/ui/src/container/pages/routes/list/body/table/columns/analytics.jsx
@@ -14,9 +14,9 @@ function Analytics({ record }) {
   };
 
   return (
-    <DataTableAction>
+    <DataTableAction noHide>
       <Tooltip title="Open route analytics">
-        <Lucide className="p-4" icon={ChartLine} onClick={handleOnClick} />
+        <Lucide icon={ChartLine} onClick={handleOnClick} />
       </Tooltip>
     </DataTableAction>
   );

--- a/ui/src/container/pages/routes/list/body/table/index.jsx
+++ b/ui/src/container/pages/routes/list/body/table/index.jsx
@@ -16,7 +16,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import columns from './columns';
 
 function RoutesTable({ searchValue }) {
-  const { popup, openPopup, closePopup } = usePopup();
+  // const { popup, openPopup, closePopup } = usePopup();
+  const { popup, closePopup } = usePopup();
   const items = useGetThreeDotsMenuItems(popup?.record?.routeName);
 
   const navigate = useNavigate();
@@ -64,9 +65,10 @@ function RoutesTable({ searchValue }) {
           onClick: () => {
             handleOnRowClick(record);
           },
-          onContextMenu: (event) => {
-            openPopup(event, record);
-          },
+          // FIXME: UI is broken
+          // onContextMenu: (event) => {
+          //   openPopup(event, record);
+          // },
         })}
         pagination={{
           hideOnSinglePage: true,

--- a/ui/src/container/pages/tracing/list/body/index.jsx
+++ b/ui/src/container/pages/tracing/list/body/index.jsx
@@ -46,7 +46,7 @@ function TracingList() {
 
 function NoProjectSelected() {
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="flex flex-col gap-4 py-4">
       <Void description="Select a project to view tracing data" />
     </div>
   );
@@ -62,7 +62,7 @@ function ProjectSelected() {
   };
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="flex flex-col gap-4 py-4">
       <Tabs
         activeKey={activeKey}
         items={items}

--- a/ui/src/container/pages/tracing/list/header/index.jsx
+++ b/ui/src/container/pages/tracing/list/header/index.jsx
@@ -67,7 +67,7 @@ function RouteSelector() {
       <Select
         disabled
         placeholder="Select a project first"
-        style={{ width: 400 }}
+        style={{ width: 250 }}
       />
     );
   }
@@ -80,7 +80,7 @@ function RouteSelector() {
       onChange={handleChange}
       options={routeNames.map((name) => ({ label: name, value: name }))}
       placeholder="All routes"
-      style={{ width: 400 }}
+      style={{ width: 250 }}
       value={selectedRoutes}
     />
   );

--- a/ui/src/container/pages/tracing/list/header/project-filter.jsx
+++ b/ui/src/container/pages/tracing/list/header/project-filter.jsx
@@ -49,7 +49,7 @@ function ProjectFilter() {
       onChange={handleOnChange}
       options={options}
       placeholder="Please select"
-      style={{ width: 400 }}
+      style={{ width: 250 }}
       value={projectUuid}
     />
   );

--- a/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-drill-down/index.jsx
+++ b/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-drill-down/index.jsx
@@ -7,7 +7,7 @@ import {
   useGetCostsByKeyStreamWithRange,
   useGetCostsByModelStreamWithRange,
 } from '@State/usage/vertical-hooks';
-import { Button, Skeleton, Void } from '@radicalbit/radicalbit-design-system';
+import { Board, Button, Skeleton, Void } from '@radicalbit/radicalbit-design-system';
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 import { BarChart } from 'echarts/charts';
 import {
@@ -67,13 +67,20 @@ function CostsGraphDrillDown() {
 function IsEmpty() {
   return (
     <div className="relative">
-      <Void
-        description="No cost data available yet. Chart will appear automatically when some data arrived."
-        style={chartWidthAndHeight}
-        title="Cost Analysis Overview"
-      />
+      <Board
+        main={(
+          <>
+            <Void
+              description="No cost data available yet. Chart will appear automatically when some data arrived."
+              style={chartWidthAndHeight}
+              title="Cost Analysis Overview"
+            />
 
-      <BackButton />
+            <BackButton />
+          </>
+        )}
+        size="xsmall"
+      />
     </div>
   );
 }

--- a/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-inner/index.jsx
+++ b/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-inner/index.jsx
@@ -1,7 +1,7 @@
 import SomethingWentWrong from '@Components/error-page/something-went-wrong';
 import useDarkModeChart, { updateTheme } from '@Hooks/use-chart-dark-mode';
 import { useGetCostsChartStreamWithRange } from '@State/usage/vertical-hooks';
-import { Board, Radio, Skeleton, Void } from '@radicalbit/radicalbit-design-system';
+import { Board, Segmented, Spinner, Void } from '@radicalbit/radicalbit-design-system';
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 import { BarChart } from 'echarts/charts';
 import {
@@ -43,17 +43,17 @@ function CostsGraphInner() {
     ? searchParams.get('routes').split(',')
     : [];
 
-  const { data, isError, isLoading, isSuccess } = useGetCostsChartStreamWithRange({ routes, groupBy });
+  const { data, isError, isSuccess } = useGetCostsChartStreamWithRange({ routes, groupBy });
 
-  if (isLoading) {
-    return <Skeleton.Input active block style={chartWidthAndHeight} />;
+  if (data?.loading) {
+    return <IsLoading />;
   }
 
-  if (isError) {
+  if (isError || data?.error) {
     return <SomethingWentWrong size="small" style={chartWidthAndHeight} />;
   }
 
-  if (!data?.data?.length) {
+  if (!data?.chart?.data?.length) {
     return <IsEmpty />;
   }
 
@@ -62,6 +62,28 @@ function CostsGraphInner() {
   }
 
   return <IsSuccess />;
+}
+
+function IsLoading() {
+  return (
+    <div className="relative">
+      <Board
+        main={(
+          <>
+            <Void
+              actions={<Spinner spinning />}
+              description="Fetching the latest cost data. The chart will appear as soon as it is ready."
+              style={chartWidthAndHeight}
+              title="Loading Cost Analysis"
+            />
+
+            <GroupByTabs />
+          </>
+        )}
+        size="xsmall"
+      />
+    </div>
+  );
 }
 
 function IsEmpty() {
@@ -80,7 +102,6 @@ function IsEmpty() {
           </>
         )}
         size="xsmall"
-        type="secondary-light"
       />
     </div>
   );
@@ -98,10 +119,11 @@ function IsSuccess() {
   const { routeBreakdownCacheRef, handleOnMouseOver } = useRouteBreakdownTooltip(chartRef);
 
   const { data } = useGetCostsChartStreamWithRange({ routes, groupBy });
-  const series = useMemo(() => (data.data || []).map(({ name, data: d }) => ({
+  const chart = data?.chart;
+  const series = useMemo(() => (chart?.data || []).map(({ name, data: d }) => ({
     name,
     data: d || [],
-  })), [data.data]);
+  })), [chart?.data]);
 
   const handleOnClick = (params) => {
     const id = nameToId[params.seriesName];
@@ -128,10 +150,10 @@ function IsSuccess() {
         onChartReady={() => updateTheme(chartRef)}
         onEvents={{ click: handleOnClick, mouseover: handleOnMouseOver }}
         option={option({
-          xAxisData: data.timestamp || [],
+          xAxisData: chart?.timestamp || [],
           series,
-          granularity: data.granularity,
-          total: data.total,
+          granularity: chart?.granularity,
+          total: chart?.total,
           routeBreakdownCache: routeBreakdownCacheRef.current,
         })}
         ref={chartRef}
@@ -151,26 +173,28 @@ function GroupByTabs() {
   const [searchParams, setSearchParams] = useSearchParams();
   const groupBy = searchParams.get('groupBy') || DEFAULT_GROUP_BY;
 
-  const handleOnChangeGroupBy = (e) => {
+  const options = [
+    { value: GROUP_BY.groups.key, label: GROUP_BY.groups.label },
+    { value: GROUP_BY.credentials.key, label: GROUP_BY.credentials.label },
+    { value: GROUP_BY.models.key, label: GROUP_BY.models.label },
+  ];
+
+  const handleOnChangeGroupBy = (value) => {
     setSearchParams((prev) => {
-      prev.set('groupBy', e.target.value);
+      prev.set('groupBy', value);
       return prev;
     });
   };
 
   return (
     <div className="absolute right-4 top-4 z-10">
-      <Radio.Group
-        className="c-echart-radio-button"
+      <Segmented
         onChange={handleOnChangeGroupBy}
+        options={options}
+        size="large"
+        type="highlighted"
         value={groupBy}
-      >
-        <Radio.Button value={GROUP_BY.groups.key}>{GROUP_BY.groups.label}</Radio.Button>
-
-        <Radio.Button value={GROUP_BY.credentials.key}>{GROUP_BY.credentials.label}</Radio.Button>
-
-        <Radio.Button value={GROUP_BY.models.key}>{GROUP_BY.models.label}</Radio.Button>
-      </Radio.Group>
+      />
     </div>
   );
 }
@@ -188,7 +212,7 @@ const useRouteBreakdownTooltip = (chartRef) => {
   const routes = searchParams.get('routes')?.split(',') ?? [];
 
   const { data } = useGetCostsChartStreamWithRange({ routes, groupBy });
-  const granularity = data?.granularity;
+  const granularity = data?.chart?.granularity;
   const routesKey = routes.join(',');
 
   useEffect(() => {

--- a/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-inner/use-get-name-to-id.js
+++ b/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-inner/use-get-name-to-id.js
@@ -13,7 +13,7 @@ const useGetNameToId = () => {
   const { data } = useGetCostsChartStreamWithRange({ routes, groupBy });
 
   return useMemo(() => {
-    const d = data?.data || [];
+    const d = data?.chart?.data || [];
     const idMap = {};
 
     d.forEach(({ name, uuid }) => {
@@ -25,7 +25,7 @@ const useGetNameToId = () => {
     });
 
     return idMap;
-  }, [data?.data, groupBy]);
+  }, [data?.chart?.data, groupBy]);
 };
 
 export default useGetNameToId;

--- a/ui/src/container/pages/usage/list/body/consumptions/invocations-graph/option.js
+++ b/ui/src/container/pages/usage/list/body/consumptions/invocations-graph/option.js
@@ -28,7 +28,7 @@ export default ({ xAxisData, series = [], granularity, total }) => ({
     axisLine: {
       show: true,
       lineStyle: {
-        color: '#dedede',
+        color: '#e4e4dd',
         width: 1,
       },
     },

--- a/ui/src/container/pages/usage/list/body/consumptions/tokens-graph/option.js
+++ b/ui/src/container/pages/usage/list/body/consumptions/tokens-graph/option.js
@@ -28,7 +28,7 @@ export default ({ xAxisData, series = [], granularity, total }) => ({
     axisLine: {
       show: true,
       lineStyle: {
-        color: '#dedede',
+        color: '#e4e4dd',
         width: 1,
       },
     },

--- a/ui/src/hooks/use-chart-dark-mode.js
+++ b/ui/src/hooks/use-chart-dark-mode.js
@@ -9,25 +9,29 @@ export const updateTheme = (chartRef) => {
   }
 
   const isDark = document.body.classList.contains('dark');
+  // Light-mode colors aligned to the new design-system palette:
+  // bg = --coo-bk-lv1 (#fdfdfe, components resting on the page),
+  // text = --coo-fg-black (#14141a), axes/grid = light secondary greys.
+  // Dark mode left untouched for now.
   const themeColors = {
-    backgroundColor: isDark ? '#000' : '#ecece7',
-    textStyle: { color: isDark ? '#e0e0e0' : '#333' },
-    title: { textStyle: { color: isDark ? '#e0e0e0' : '#333' } },
-    legend: { textStyle: { color: isDark ? '#e0e0e0' : '#333' } },
+    backgroundColor: isDark ? '#000' : '#fdfdfe',
+    textStyle: { color: isDark ? '#e0e0e0' : '#14141a' },
+    title: { textStyle: { color: isDark ? '#e0e0e0' : '#14141a' } },
+    legend: { textStyle: { color: isDark ? '#e0e0e0' : '#14141a' } },
     tooltip: { backgroundColor: isDark ? '#000' : '#fff' },
     grid: {
       ...chartInstance.getOption().grid,
     },
     xAxis: {
-      axisLine: { lineStyle: { color: isDark ? '#444' : '#ccc' } },
-      splitLine: { lineStyle: { color: isDark ? '#333' : '#e0e0e0' } },
+      axisLine: { lineStyle: { color: isDark ? '#444' : '#e4e4dd' } },
+      splitLine: { lineStyle: { color: isDark ? '#333' : '#ecece7' } },
     },
     yAxis: {
-      axisLine: { lineStyle: { color: isDark ? '#444' : '#ccc' } },
-      splitLine: { lineStyle: { color: isDark ? '#333' : '#e0e0e0' } },
+      axisLine: { lineStyle: { color: isDark ? '#444' : '#e4e4dd' } },
+      splitLine: { lineStyle: { color: isDark ? '#333' : '#ecece7' } },
     },
 
-    series: [{ lineStyle: { color: isDark ? '#666' : '#333' } }],
+    series: [{ lineStyle: { color: isDark ? '#666' : '#14141a' } }],
   };
 
   chartInstance.setOption(themeColors, { notMerge: false });

--- a/ui/src/store/state/usage/api.js
+++ b/ui/src/store/state/usage/api.js
@@ -159,7 +159,7 @@ export const usageApiSlice = apiService.injectEndpoints({
 
     getCostsChartStream: builder.query({
       keepUnusedDataFor: 0,
-      queryFn: () => ({ data: null }),
+      queryFn: () => ({ data: { loading: true, error: false, chart: null } }),
       async onCacheEntryAdded(
         {
           projectUuid, routes, groupBy, from, to, gte,
@@ -182,15 +182,22 @@ export const usageApiSlice = apiService.injectEndpoints({
 
           eventSource.onmessage = ({ data }) => {
             const parsed = JSON.parse(data);
-            updateCachedData(() => parsed);
+            updateCachedData(() => ({ loading: false, error: false, chart: parsed }));
           };
 
-          eventSource.onerror = (e) => { console.error(e); };
+          eventSource.onerror = (e) => {
+            console.error(e);
+
+            if (eventSource.readyState === EventSource.CLOSED) {
+              updateCachedData((draft) => { draft.loading = false; draft.error = true; });
+            }
+          };
 
           await cacheEntryRemoved;
           eventSource.close();
         } catch (error) {
           console.error(error);
+          updateCachedData((draft) => { draft.loading = false; draft.error = true; });
         }
       },
     }),

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -575,10 +575,10 @@
     uuid "^10.0.0"
     yup "^1.4.0"
 
-"@radicalbit/radicalbit-design-system@2.19.1":
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/@radicalbit/radicalbit-design-system/-/radicalbit-design-system-2.19.1.tgz#9a1f9853a53aeb320ebf87c95c531a326c6ee8d5"
-  integrity sha512-RWQHgPl3gydrRDiGM8jEzixj5+mQeXD9cBu9i+wpNTcOPIaNgwXo5RTF8Vd5xlcYduGXEmuv1aIbAcxABfaJZw==
+"@radicalbit/radicalbit-design-system@2.19.5":
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/@radicalbit/radicalbit-design-system/-/radicalbit-design-system-2.19.5.tgz#5099f2c7699b4b0a8f00ef0dee07a07c4335129d"
+  integrity sha512-jkkualwnXtf/lWjHpZ6ALJR/TQIHNfbltdxG1+tp4VcPs1BsZLGm/t+YPhLpEOSz8vSQhaCVeg2aozf2VOL2hA==
   dependencies:
     "@babel/polyfill" "7.12.1"
     "@fortawesome/fontawesome-svg-core" "6.7.2"


### PR DESCRIPTION
## What

  A batch of frontend refinements across tables, modals and the costs chart,
  plus the design-system bump they depend on.

  Bumps `@radicalbit/radicalbit-design-system` `2.19.1` → `2.19.5`. The
  `<Button />` and Lucide changes below are adaptations to that version, so
  the bump is required rather than incidental.

  ### Table action icons

  Action icons in the Routes, Credentials and Groups tables were laid out
  with `p-4` / `px-4` padding on the icon itself, which made hitboxes
  inconsistent and misaligned the columns. They are now wrapped in
  `<Button type="text" size="small">` and the manual padding is gone.

  `<Lucide />` gains two variants to support this:

  - `type="error"` — for destructive actions (remove, delete)
  - `disabled` — proper `opacity` + `pointer-events: none`, also honouring
    `[aria-disabled="true"]`

  These live in a new `components/lucide/_styles.less`, following the
  existing `components/*/_styles.less` convention. Icon set updated to
  `PencilLine` / `Trash`.

  ### Costs chart

  - The group-by control moves from `Radio.Group` to `<Segmented>`.
  - **Explicit loading and error states.** The costs query resolves
    immediately with a placeholder and the real data arrives later over
    SSE, so RTK Query's `isLoading` / `isFetching` never reflected the
    actual "waiting for the stream" state — the chart rendered as empty
    until the first message landed. The cache entry is now wrapped as
    `{ loading, error, chart }`: it starts `loading: true` (also on every
    `groupBy` change, via `keepUnusedDataFor: 0`), flips to `false` on the
    first SSE message, and only sets `error: true` when the `EventSource`
    reaches `CLOSED`, so automatic reconnects no longer flash an error.
    Consumers read `data.chart.*` and render a `Void` + `Spinner` while
    loading, `SomethingWentWrong` on a fatal error.
  - Drill-down empty state is wrapped in a `Board` so the back button sits
    inside the panel.

  ### Modals

  - Associate modals (groups→route, keys→group, routes→group) no longer
    enable Submit on an empty selection.
  - `backgroundLevel={0}` on the edit-project-config modal and its chatbot
    and prompt boards, fixing the layered background.
  - Spacing fixes in the config code editor and chatbot draft.

  ### Navbar

  Configurations gets a keyboard shortcut (`Ctrl+2`) and the rest shift
  down accordingly:

  | Shortcut | Page |
  |---|---|
  | `Ctrl+1` | Projects |
  | `Ctrl+2` | Configurations |
  | `Ctrl+3` | Routes |
  | `Ctrl+4` | Usage |
  | `Ctrl+5` | Tracing |
  | `Ctrl+6` | Groups |
  | `Ctrl+7` | Credentials |

  Alerts stays without a shortcut. `<Logo />` becomes a `<div>` instead of
  an `<a>` with no `href`.

  ### Tracing

  Project and route filter widths `400` → `250`.

  ## Note

  Right-click context menus in the Routes, Credentials and Groups tables

Right-click context menus in the Routes, Credentials and Groups tables
are commented out with a `FIXME`: the popup renders incorrectly and needs
a separate fix. Row click is unaffected.

## Testing

- `yarn lint` (`--max-warnings 0`) — passes
- `yarn build:prod` — passes
- Verified the new `lucide/_styles.less` compiles into the bundle
  (`c-lucide--disabled`, `--type-error`, `[aria-disabled]` all present in
  the emitted CSS)

Visual check on Usage, Credentials and Routes recommended before merge —
most of these are presentational.