### PR TITLE
feat: add fallback support for transcription models

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -160,10 +160,14 @@ class GatewayRoute:
         transcription_models = self._transcription_models
 
         if transcription_models:
-            # TODO(AG-901): no fallback support yet for transcription models.
+            transcription_fallbacks = [
+                fb
+                for fb in (fallback_models or [])
+                if fb.type == FallbackModelType.TRANSCRIPTION
+            ]
             self.transcription_invoker = TranscriptionModelInvoker(
                 models=transcription_models,
-                fallbacks=None,
+                fallbacks=transcription_fallbacks,
                 cost_service=self.cost_service,
                 httpx_client=httpx_client,
             )

--- a/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
+++ b/gateway/radicalbit_ai_gateway/invocation/transcription_model_invoker.py
@@ -51,6 +51,21 @@ def _set_transcription_request_attributes(
         pass
 
 
+def _set_transcription_fallback_attributes(
+    model_id_invoked: str,
+    fallback_triggered: bool,
+) -> None:
+    try:
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute('transcription.response.model_id', model_id_invoked)
+            span.set_attribute(
+                'transcription.response.fallback_triggered', fallback_triggered
+            )
+    except Exception:
+        pass
+
+
 def _set_transcription_response_attributes(
     response: Transcription | TranscriptionVerbose,
     is_whisper: bool,
@@ -117,13 +132,40 @@ class TranscriptionModelInvoker(ModelInvoker):
 
     def _resolve_model(
         self, model_id: str
-    ) -> tuple[Model, AsyncOpenAI | AsyncAzureOpenAI, bool, str]:
+    ) -> tuple[Model, AsyncOpenAI | AsyncAzureOpenAI, bool, str, list]:
         if model_id not in self.model_map:
             raise ModelInvokerBadRequest(f'Transcription model {model_id} not defined')
-        model, client, _fallbacks = self.model_map[model_id]
+        model, client, fallbacks = self.model_map[model_id]
         _, model_name = parse_provider_and_model(model.model)
         is_whisper = model_name.startswith(WHISPER_FAMILY_PREFIX)
-        return model, client, is_whisper, model_name
+        return model, client, is_whisper, model_name, fallbacks
+
+    @staticmethod
+    def _build_create_kwargs(
+        model_name: str,
+        audio_bytes: bytes,
+        filename: str,
+        content_type: str | None,
+        response_format: str,
+        language: str | None,
+        prompt: str | None,
+        temperature: float | None,
+        stream: bool = False,
+    ) -> dict:
+        create_kwargs: dict = {
+            'model': model_name,
+            'file': (filename, audio_bytes, content_type or 'application/octet-stream'),
+            'response_format': response_format,
+        }
+        if stream:
+            create_kwargs['stream'] = True
+        if language:
+            create_kwargs['language'] = language
+        if prompt:
+            create_kwargs['prompt'] = prompt
+        if temperature is not None:
+            create_kwargs['temperature'] = temperature
+        return create_kwargs
 
     @staticmethod
     async def _create_upstream(
@@ -157,6 +199,7 @@ class TranscriptionModelInvoker(ModelInvoker):
         model: Model,
         latency_ms: float,
         usage,
+        fallback_triggered: bool = False,
         project_uuid: str = '',
         project_name: str = '',
     ) -> None:
@@ -171,6 +214,7 @@ class TranscriptionModelInvoker(ModelInvoker):
             model=model,
             latency_ms=latency_ms,
             model_type='transcription',
+            fallback_triggered=fallback_triggered,
             project_uuid=project_uuid,
             project_name=project_name,
         )
@@ -207,7 +251,7 @@ class TranscriptionModelInvoker(ModelInvoker):
         project_uuid: str = '',
         project_name: str = '',
     ) -> Transcription | TranscriptionVerbose:
-        model, client, is_whisper, model_name = self._resolve_model(model_id)
+        model, client, is_whisper, model_name, fallbacks = self._resolve_model(model_id)
         if requested_response_format not in SUPPORTED_RESPONSE_FORMATS:
             raise ModelInvokerBadRequest(
                 f'Unsupported response_format {requested_response_format!r}. '
@@ -217,7 +261,6 @@ class TranscriptionModelInvoker(ModelInvoker):
             raise ModelInvokerBadRequest(
                 'response_format=verbose_json is only supported for whisper-1 models.'
             )
-        upstream_format = 'verbose_json' if is_whisper else 'json'
 
         _set_transcription_request_attributes(
             filename=filename,
@@ -226,28 +269,75 @@ class TranscriptionModelInvoker(ModelInvoker):
             model_id=model_id,
         )
 
-        create_kwargs: dict = {
-            'model': model_name,
-            'file': (filename, audio_bytes, content_type or 'application/octet-stream'),
-            'response_format': upstream_format,
-        }
-        if language:
-            create_kwargs['language'] = language
-        if prompt:
-            create_kwargs['prompt'] = prompt
-        if temperature is not None:
-            create_kwargs['temperature'] = temperature
-
         start_time = time.monotonic()
-        response: Transcription | TranscriptionVerbose = await self._create_upstream(
-            client, create_kwargs
+        model_invoked = model
+        fallback_triggered = False
+        create_kwargs = self._build_create_kwargs(
+            model_name,
+            audio_bytes,
+            filename,
+            content_type,
+            'verbose_json' if is_whisper else 'json',
+            language,
+            prompt,
+            temperature,
         )
+        try:
+            response = await self._create_upstream(client, create_kwargs)
+        except Exception as primary_error:
+            # A 4xx client-input error would fail identically on any fallback.
+            if isinstance(primary_error, ModelInvokerBadRequest):
+                raise
+            logger.warning(
+                'Primary transcription model %s failed: %s. Trying fallbacks...',
+                model_id,
+                str(primary_error),
+            )
+            response = None
+            for fallback_model, fallback_client in fallbacks or []:
+                _, fallback_model_name = parse_provider_and_model(fallback_model.model)
+                fallback_is_whisper = fallback_model_name.startswith(
+                    WHISPER_FAMILY_PREFIX
+                )
+                fallback_create_kwargs = self._build_create_kwargs(
+                    fallback_model_name,
+                    audio_bytes,
+                    filename,
+                    content_type,
+                    'verbose_json' if fallback_is_whisper else 'json',
+                    language,
+                    prompt,
+                    temperature,
+                )
+                try:
+                    response = await self._create_upstream(
+                        fallback_client, fallback_create_kwargs
+                    )
+                    model_invoked = fallback_model
+                    is_whisper = fallback_is_whisper
+                    fallback_triggered = True
+                    break
+                except Exception as fallback_error:
+                    if isinstance(fallback_error, ModelInvokerBadRequest):
+                        raise
+                    logger.warning(
+                        'Fallback transcription model %s failed: %s',
+                        fallback_model.model_id,
+                        str(fallback_error),
+                    )
+            if response is None:
+                raise ModelInvokerInternalError(
+                    f'All transcription models failed for route {route_name}: {primary_error}'
+                ) from primary_error
+
         latency_ms = (time.monotonic() - start_time) * 1000
         _set_transcription_response_attributes(response, is_whisper)
+        _set_transcription_fallback_attributes(
+            model_invoked.model_id, fallback_triggered
+        )
 
         usage = response.usage
-        if requested_response_format == 'verbose_json':
-            # Only reachable for whisper-1
+        if requested_response_format == 'verbose_json' and is_whisper:
             body = response
         elif is_whisper:
             body = Transcription(
@@ -265,9 +355,10 @@ class TranscriptionModelInvoker(ModelInvoker):
             group_name=group_name,
             route_name=route_name,
             model_id=model_id,
-            model=model,
+            model=model_invoked,
             latency_ms=latency_ms,
             usage=usage,
+            fallback_triggered=fallback_triggered,
             project_uuid=project_uuid,
             project_name=project_name,
         )
@@ -293,7 +384,7 @@ class TranscriptionModelInvoker(ModelInvoker):
         project_uuid: str = '',
         project_name: str = '',
     ) -> AsyncIterator[TranscriptionStreamEvent]:
-        model, client, is_whisper, model_name = self._resolve_model(model_id)
+        model, client, is_whisper, model_name, fallbacks = self._resolve_model(model_id)
         if is_whisper:
             raise ModelInvokerBadRequest(
                 'stream=true is only supported for the gpt-4o-transcribe family; '
@@ -307,30 +398,83 @@ class TranscriptionModelInvoker(ModelInvoker):
             model_id=model_id,
         )
 
-        create_kwargs: dict = {
-            'model': model_name,
-            'file': (filename, audio_bytes, content_type or 'application/octet-stream'),
-            'response_format': 'json',
-            'stream': True,
-        }
-        if language:
-            create_kwargs['language'] = language
-        if prompt:
-            create_kwargs['prompt'] = prompt
-        if temperature is not None:
-            create_kwargs['temperature'] = temperature
-
-        start_time = time.monotonic()
-        upstream_stream = await self._create_upstream(client, create_kwargs)
-
         final_usage = None
         text_parts: list[str] = []
-        async for event in upstream_stream:
-            if event.type == 'transcript.text.delta':
-                text_parts.append(event.delta)
-            elif event.type == 'transcript.text.done':
-                final_usage = event.usage
-            yield event
+
+        async def _run_stream(
+            target_client: AsyncOpenAI | AsyncAzureOpenAI, target_model_name: str
+        ) -> AsyncIterator[TranscriptionStreamEvent]:
+            nonlocal final_usage
+            upstream_stream = await self._create_upstream(
+                target_client,
+                self._build_create_kwargs(
+                    target_model_name,
+                    audio_bytes,
+                    filename,
+                    content_type,
+                    'json',
+                    language,
+                    prompt,
+                    temperature,
+                    stream=True,
+                ),
+            )
+            async for event in upstream_stream:
+                if event.type == 'transcript.text.delta':
+                    text_parts.append(event.delta)
+                elif event.type == 'transcript.text.done':
+                    final_usage = event.usage
+                yield event
+
+        start_time = time.monotonic()
+        model_invoked = model
+        fallback_triggered = False
+        try:
+            async for event in _run_stream(client, model_name):
+                yield event
+        except Exception as primary_error:
+            # See transcribe()'s equivalent check: a 4xx client-input error
+            # propagates immediately, it would fail identically on any fallback.
+            if isinstance(primary_error, ModelInvokerBadRequest):
+                raise
+            logger.warning(
+                'Primary transcription model %s stream failed: %s. Trying fallbacks...',
+                model_id,
+                str(primary_error),
+            )
+            fallback_success = False
+            for fallback_model, fallback_client in fallbacks or []:
+                _, fallback_model_name = parse_provider_and_model(fallback_model.model)
+                if fallback_model_name.startswith(WHISPER_FAMILY_PREFIX):
+                    logger.warning(
+                        'Skipping fallback transcription model %s for streaming: '
+                        'whisper-1 does not support streaming.',
+                        fallback_model.model_id,
+                    )
+                    continue
+                try:
+                    text_parts.clear()
+                    final_usage = None
+                    async for event in _run_stream(
+                        fallback_client, fallback_model_name
+                    ):
+                        yield event
+                    model_invoked = fallback_model
+                    fallback_triggered = True
+                    fallback_success = True
+                    break
+                except Exception as fallback_error:
+                    if isinstance(fallback_error, ModelInvokerBadRequest):
+                        raise
+                    logger.warning(
+                        'Fallback transcription model %s stream failed: %s',
+                        fallback_model.model_id,
+                        str(fallback_error),
+                    )
+            if not fallback_success:
+                raise ModelInvokerInternalError(
+                    f'All transcription models failed for streaming {route_name}: {primary_error}'
+                ) from primary_error
         latency_ms = (time.monotonic() - start_time) * 1000
 
         try:
@@ -341,6 +485,9 @@ class TranscriptionModelInvoker(ModelInvoker):
                 )
         except Exception:
             pass
+        _set_transcription_fallback_attributes(
+            model_invoked.model_id, fallback_triggered
+        )
 
         self._finalize_transcription(
             request_uuid=request_uuid,
@@ -350,9 +497,10 @@ class TranscriptionModelInvoker(ModelInvoker):
             group_name=group_name,
             route_name=route_name,
             model_id=model_id,
-            model=model,
+            model=model_invoked,
             latency_ms=latency_ms,
             usage=final_usage,
+            fallback_triggered=fallback_triggered,
             project_uuid=project_uuid,
             project_name=project_name,
         )

--- a/gateway/radicalbit_ai_gateway/models/fallback.py
+++ b/gateway/radicalbit_ai_gateway/models/fallback.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, field_validator
 class FallbackModelType(str, Enum):
     CHAT = 'CHAT'
     EMBEDDING = 'EMBEDDING'
+    TRANSCRIPTION = 'TRANSCRIPTION'
 
 
 class Fallback(BaseModel):
@@ -22,6 +23,7 @@ class Fallback(BaseModel):
         examples=[
             'CHAT',
             'EMBEDDING',
+            'TRANSCRIPTION',
         ],
     )
 

--- a/gateway/radicalbit_ai_gateway/models/gateway_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_config.py
@@ -227,6 +227,9 @@ class GatewayConfig(BaseModel):
                     elif fb.type == FallbackModelType.EMBEDDING:
                         valid_ids = set(route_emb_ids)
                         label = 'embedding'
+                    elif fb.type == FallbackModelType.TRANSCRIPTION:
+                        valid_ids = set(route_transcription_ids)
+                        label = 'transcription'
                     else:
                         raise ValueError(
                             f'Route {route_name}: Unknown fallback type {fb.type.value}'

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -30,6 +30,7 @@ from radicalbit_ai_gateway.guardrails.judges.judge_engine import JudgeEngine
 from radicalbit_ai_gateway.guardrails.presidio import PresidioEngine
 from radicalbit_ai_gateway.limiting.token_limiter import InputTokenLimitExceeded
 from radicalbit_ai_gateway.models.credentials import Credentials
+from radicalbit_ai_gateway.models.fallback import Fallback, FallbackModelType
 from radicalbit_ai_gateway.models.gateway_route_config import GatewayRouteConfig
 from radicalbit_ai_gateway.models.limiting import BudgetLimiting
 from radicalbit_ai_gateway.models.model import Model
@@ -853,6 +854,56 @@ def _make_transcription_route_config(
         transcription_models=[model_id],
         budget_limiting=budget_limiting,
     )
+
+
+def test_transcription_invoker_only_receives_transcription_fallbacks():
+    """`GatewayRoute` must filter the route's `fallback` list down to
+    `FallbackModelType.TRANSCRIPTION` entries before wiring it into
+    `TranscriptionModelInvoker` — CHAT/EMBEDDING fallbacks aren't meaningful
+    there and would otherwise leak in unfiltered.
+    """
+    cost_service = MagicMock(spec_set=CostService)
+    gpt4o_model = Model(
+        model_id='gpt4o-transcribe',
+        model='openai/gpt-4o-transcribe',
+        credentials=Credentials(api_key='sk-test'),
+    )
+    gpt4o_mini_model = Model(
+        model_id='gpt4o-mini-transcribe',
+        model='openai/gpt-4o-mini-transcribe',
+        credentials=Credentials(api_key='sk-test'),
+    )
+    transcription_fallback = Fallback(
+        type=FallbackModelType.TRANSCRIPTION,
+        target='gpt4o-transcribe',
+        fallbacks=['gpt4o-mini-transcribe'],
+    )
+    chat_fallback = Fallback(
+        type=FallbackModelType.CHAT, target='some-chat-model', fallbacks=['other']
+    )
+    route_cfg = GatewayRouteConfig(
+        route_name='rb-gateway',
+        chat_models=[],
+        transcription_models=['gpt4o-transcribe', 'gpt4o-mini-transcribe'],
+        fallback=[transcription_fallback, chat_fallback],
+    )
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=[gpt4o_model, gpt4o_mini_model],
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=None,
+        cost_service=cost_service,
+    )
+
+    assert ai_gateway.transcription_invoker.fallbacks == [transcription_fallback]
+    fallback_model_ids = {
+        m.model_id
+        for m, _ in ai_gateway.transcription_invoker.model_map['gpt4o-transcribe'][2]
+    }
+    assert fallback_model_ids == {'gpt4o-mini-transcribe'}
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/invoker/test_transcription_model_invoker.py
+++ b/gateway/tests/invoker/test_transcription_model_invoker.py
@@ -32,6 +32,11 @@ GPT4O_TRANSCRIBE_MODEL = Model(
     model='openai/gpt-4o-transcribe',
     credentials={'api_key': 'sk-test'},
 )
+GPT4O_MINI_TRANSCRIBE_MODEL = Model(
+    model_id='gpt4o-mini-transcribe',
+    model='openai/gpt-4o-mini-transcribe',
+    credentials={'api_key': 'sk-test'},
+)
 
 WHISPER_VERBOSE_RESPONSE = TranscriptionVerbose(
     task='transcribe',
@@ -52,6 +57,29 @@ GPT4O_JSON_RESPONSE = Transcription(
         'input_token_details': {'audio_tokens': 82, 'text_tokens': 0},
     },
 )
+
+GPT4O_MINI_JSON_RESPONSE = Transcription(
+    text='Ciao, questo è un test.',
+    usage={
+        'type': 'tokens',
+        'input_tokens': 82,
+        'output_tokens': 38,
+        'total_tokens': 120,
+        'input_token_details': {'audio_tokens': 82, 'text_tokens': 0},
+    },
+)
+
+
+def _service_unavailable_exception() -> APIStatusError:
+    request = httpx.Request('POST', 'https://api.openai.com/v1/audio/transcriptions')
+    response = httpx.Response(status_code=503, request=request)
+    return APIStatusError('Service unavailable', response=response, body=None)
+
+
+def _invalid_file_exception() -> APIStatusError:
+    request = httpx.Request('POST', 'https://api.openai.com/v1/audio/transcriptions')
+    response = httpx.Response(status_code=400, request=request)
+    return APIStatusError('Invalid file', response=response, body=None)
 
 
 _COMMON_TRANSCRIBE_KWARGS = {
@@ -173,6 +201,12 @@ class TestTranscriptionModelInvoker(unittest.IsolatedAsyncioTestCase):
         )
         mock_span.set_attribute.assert_any_call(
             'transcription.response.segment_count', 0
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.model_id', 'whisper'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.fallback_triggered', False
         )
         # AG-895: never the raw audio content, only its size.
         for call in mock_span.set_attribute.call_args_list:
@@ -339,6 +373,126 @@ class TestTranscriptionModelInvoker(unittest.IsolatedAsyncioTestCase):
                 model_id='whisper',
             )
 
+    async def test_transcribe_falls_back_to_secondary_model_on_5xx(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        invoker._record_metrics = MagicMock()
+        primary_client = MockTranscriptionClient(
+            exception=_service_unavailable_exception()
+        )
+        fallback_client = MockTranscriptionClient(response=GPT4O_MINI_JSON_RESPONSE)
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            primary_client,
+            [(GPT4O_MINI_TRANSCRIBE_MODEL, fallback_client)],
+        )
+
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+        with patch(
+            'radicalbit_ai_gateway.invocation.transcription_model_invoker.trace.get_current_span',
+            return_value=mock_span,
+        ):
+            result = await invoker.transcribe(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            )
+
+        assert result is GPT4O_MINI_JSON_RESPONSE
+        assert fallback_client.captured_kwargs['model'] == 'gpt-4o-mini-transcribe'
+        invoker._record_metrics.assert_called_once()
+        call_kwargs = invoker._record_metrics.call_args.kwargs
+        assert call_kwargs['target_model_id'] == 'gpt4o-transcribe'
+        assert call_kwargs['model'].model_id == 'gpt4o-mini-transcribe'
+        assert call_kwargs['fallback_triggered'] is True
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.model_id', 'gpt4o-mini-transcribe'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.fallback_triggered', True
+        )
+
+    async def test_transcribe_bad_request_does_not_trigger_fallback(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        primary_client = MockTranscriptionClient(exception=_invalid_file_exception())
+        fallback_client = MockTranscriptionClient(response=GPT4O_MINI_JSON_RESPONSE)
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            primary_client,
+            [(GPT4O_MINI_TRANSCRIBE_MODEL, fallback_client)],
+        )
+
+        with pytest.raises(ModelInvokerBadRequest):
+            await invoker.transcribe(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            )
+
+        # A 4xx is a client-input problem, not a model-availability one — it
+        # would fail identically on any fallback, so none is attempted.
+        assert fallback_client.captured_kwargs == {}
+
+    async def test_transcribe_all_models_fail_raises_internal_error(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        primary_client = MockTranscriptionClient(
+            exception=_service_unavailable_exception()
+        )
+        fallback_client = MockTranscriptionClient(
+            exception=_service_unavailable_exception()
+        )
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            primary_client,
+            [(GPT4O_MINI_TRANSCRIBE_MODEL, fallback_client)],
+        )
+
+        with pytest.raises(
+            ModelInvokerInternalError, match='All transcription models failed'
+        ):
+            await invoker.transcribe(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            )
+
+    async def test_transcribe_falls_back_across_families_returns_matching_shape(self):
+        """Primary is whisper-1 (verbose_json validated up front), but it fails
+        and the configured fallback is gpt-4o-transcribe — a different family
+        that only ever returns a plain `Transcription`. The response shape
+        must follow the model that actually served the request, not the
+        originally-selected one.
+        """
+        invoker = self._build_invoker(WHISPER_MODEL)
+        primary_client = MockTranscriptionClient(
+            exception=_service_unavailable_exception()
+        )
+        fallback_client = MockTranscriptionClient(response=GPT4O_JSON_RESPONSE)
+        invoker.model_map['whisper'] = (
+            WHISPER_MODEL,
+            primary_client,
+            [(GPT4O_TRANSCRIBE_MODEL, fallback_client)],
+        )
+
+        result = await invoker.transcribe(
+            **_COMMON_TRANSCRIBE_KWARGS,
+            audio_bytes=b'fake-audio',
+            filename='test.wav',
+            content_type='audio/wav',
+            model_id='whisper',
+            requested_response_format='verbose_json',
+        )
+
+        assert result is GPT4O_JSON_RESPONSE
+        assert not isinstance(result, TranscriptionVerbose)
+        assert fallback_client.captured_kwargs['response_format'] == 'json'
+
     async def test_stream_whisper_rejects_before_any_upstream_call(self):
         invoker = self._build_invoker(WHISPER_MODEL)
         mock_client = MockTranscriptionClient(response=WHISPER_VERBOSE_RESPONSE)
@@ -431,6 +585,127 @@ class TestTranscriptionModelInvoker(unittest.IsolatedAsyncioTestCase):
                 model_id='gpt4o-transcribe',
             ):
                 pass
+
+    async def test_stream_falls_back_to_secondary_model_on_failure(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        invoker._record_metrics = MagicMock()
+        primary_client = MockTranscriptionClient(
+            exception=_service_unavailable_exception()
+        )
+        done = TranscriptionTextDoneEvent(
+            type='transcript.text.done',
+            text='Ciao, questo è un test.',
+            usage={
+                'type': 'tokens',
+                'input_tokens': 82,
+                'output_tokens': 0,
+                'total_tokens': 82,
+                'input_token_details': {'audio_tokens': 82, 'text_tokens': 0},
+            },
+        )
+        fallback_client = MockTranscriptionClient(stream_events=[done])
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            primary_client,
+            [(GPT4O_MINI_TRANSCRIBE_MODEL, fallback_client)],
+        )
+
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+        with patch(
+            'radicalbit_ai_gateway.invocation.transcription_model_invoker.trace.get_current_span',
+            return_value=mock_span,
+        ):
+            events = [
+                event
+                async for event in invoker.stream(
+                    **_COMMON_TRANSCRIBE_KWARGS,
+                    audio_bytes=b'fake-audio',
+                    filename='test.wav',
+                    content_type='audio/wav',
+                    model_id='gpt4o-transcribe',
+                )
+            ]
+
+        assert events == [done]
+        assert fallback_client.captured_kwargs['model'] == 'gpt-4o-mini-transcribe'
+        assert fallback_client.captured_kwargs['stream'] is True
+        invoker._record_metrics.assert_called_once()
+        call_kwargs = invoker._record_metrics.call_args.kwargs
+        assert call_kwargs['target_model_id'] == 'gpt4o-transcribe'
+        assert call_kwargs['model'].model_id == 'gpt4o-mini-transcribe'
+        assert call_kwargs['fallback_triggered'] is True
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.model_id', 'gpt4o-mini-transcribe'
+        )
+        mock_span.set_attribute.assert_any_call(
+            'transcription.response.fallback_triggered', True
+        )
+
+    async def test_stream_skips_whisper_fallback_and_uses_next_compatible_model(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        primary_client = MockTranscriptionClient(
+            exception=_service_unavailable_exception()
+        )
+        whisper_fallback_client = MockTranscriptionClient(
+            response=WHISPER_VERBOSE_RESPONSE
+        )
+        done = TranscriptionTextDoneEvent(
+            type='transcript.text.done', text='ok', usage=None
+        )
+        gpt4o_mini_fallback_client = MockTranscriptionClient(stream_events=[done])
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            primary_client,
+            [
+                (WHISPER_MODEL, whisper_fallback_client),
+                (GPT4O_MINI_TRANSCRIBE_MODEL, gpt4o_mini_fallback_client),
+            ],
+        )
+
+        events = [
+            event
+            async for event in invoker.stream(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            )
+        ]
+
+        assert events == [done]
+        # whisper-1 cannot stream: it must never even be attempted.
+        assert whisper_fallback_client.captured_kwargs == {}
+        assert gpt4o_mini_fallback_client.captured_kwargs['stream'] is True
+
+    async def test_stream_bad_request_does_not_trigger_fallback(self):
+        invoker = self._build_invoker(GPT4O_TRANSCRIBE_MODEL)
+        primary_client = MockTranscriptionClient(exception=_invalid_file_exception())
+        fallback_client = MockTranscriptionClient(
+            stream_events=[
+                TranscriptionTextDoneEvent(
+                    type='transcript.text.done', text='ok', usage=None
+                )
+            ]
+        )
+        invoker.model_map['gpt4o-transcribe'] = (
+            GPT4O_TRANSCRIBE_MODEL,
+            primary_client,
+            [(GPT4O_MINI_TRANSCRIBE_MODEL, fallback_client)],
+        )
+
+        with pytest.raises(ModelInvokerBadRequest):
+            async for _ in invoker.stream(
+                **_COMMON_TRANSCRIBE_KWARGS,
+                audio_bytes=b'fake-audio',
+                filename='test.wav',
+                content_type='audio/wav',
+                model_id='gpt4o-transcribe',
+            ):
+                pass
+
+        assert fallback_client.captured_kwargs == {}
 
     def test_model_map_initialization(self):
         invoker = self._build_invoker(WHISPER_MODEL)

--- a/gateway/tests/models/test_gateway_config.py
+++ b/gateway/tests/models/test_gateway_config.py
@@ -185,6 +185,52 @@ def test_transcription_models_reject_duplicate_ids_across_categories():
         GatewayConfig.model_validate(raw)
 
 
+def test_transcription_fallback_valid_config():
+    raw = {
+        'transcription_models': [
+            {'model_id': 'gpt4o', 'model': 'openai/gpt-4o-transcribe'},
+            {'model_id': 'gpt4o-mini', 'model': 'openai/gpt-4o-mini-transcribe'},
+        ],
+        'routes': {
+            'r': {
+                'transcription_models': ['gpt4o', 'gpt4o-mini'],
+                'fallback': [
+                    {
+                        'type': 'TRANSCRIPTION',
+                        'target': 'gpt4o',
+                        'fallbacks': ['gpt4o-mini'],
+                    }
+                ],
+            },
+        },
+    }
+    gateway_config = GatewayConfig.model_validate(raw)
+    assert gateway_config.routes['r'].fallback[0].target == 'gpt4o'
+
+
+def test_transcription_fallback_rejects_target_outside_route_transcription_models():
+    raw = {
+        'transcription_models': [
+            {'model_id': 'gpt4o', 'model': 'openai/gpt-4o-transcribe'},
+            {'model_id': 'gpt4o-mini', 'model': 'openai/gpt-4o-mini-transcribe'},
+        ],
+        'routes': {
+            'r': {
+                'transcription_models': ['gpt4o'],
+                'fallback': [
+                    {
+                        'type': 'TRANSCRIPTION',
+                        'target': 'gpt4o-mini',
+                        'fallbacks': ['gpt4o'],
+                    }
+                ],
+            },
+        },
+    }
+    with pytest.raises(ValueError, match='must be present in the transcription models'):
+        GatewayConfig.model_validate(raw)
+
+
 def test_transcription_models_reject_duplicate_ids_within_list():
     raw = {
         'chat_models': [{'model_id': 'c1', 'model': 'openai/gpt-4o-mini'}],


### PR DESCRIPTION
# PR Summary: AG-901

Adds fallback support for transcription models: if the primary model fails
with a server-side/availability error, the route automatically retries the
configured fallback models in order, mirroring the fallback mechanism
already used by chat and embedding models.

---

## DTO Changes

### `Fallback` (MODIFIED)

**Changes:**
```diff
  type: One of [CHAT, EMBEDDING] = CHAT
+ type: One of [CHAT, EMBEDDING, TRANSCRIPTION] = CHAT
```

| Field | Type | Description |
|-------|------|--------------|
| `target` | string | Target model id for fallback |
| `fallbacks` | string[] | List of fallback model ids to use if the target model fails |
| `type` | string | One of: `CHAT`, `EMBEDDING`, `TRANSCRIPTION` **(TRANSCRIPTION NEW)**. Default: `CHAT` |

**Example config (route-level `fallback` entry):**
```json
{
  "target": "gpt4o-transcribe",
  "fallbacks": ["gpt4o-mini-transcribe"],
  "type": "TRANSCRIPTION"
}
```

**Used by:** `routes.<route_name>.fallback` in the gateway config (validated by `GatewayConfig`, wired into `POST /v1/audio/transcriptions`).

---

## Affected Endpoints

### `POST /v1/audio/transcriptions` (MODIFIED — behavior only, no request/response schema change)

No change to the request or response shape. The behavioral change is server-side: when the route's transcription model fails, a configured `TRANSCRIPTION` fallback is retried transparently before the client sees an error.

- A **4xx** from the upstream provider (e.g. malformed file, unsupported param) is a client-input problem — it propagates immediately, no fallback is attempted, since it would fail identically on any model.
- A **5xx**/connection failure triggers the fallback chain, in the order configured under `fallbacks`.
- In **streaming** (`stream=true`), a `whisper-1` fallback candidate is skipped outright (it structurally can't stream) instead of being attempted and failing.
- If the primary is `whisper-1` and the configured fallback is a different family (e.g. `gpt-4o-transcribe`), the response shape returned to the client follows whichever model actually served the request, not the originally-requested one — so a `verbose_json` request that ends up served by a fallback that only supports `json` still returns a valid `Transcription`, never a malformed `TranscriptionVerbose`.
- If all models (primary + fallbacks) fail, the request fails with the same error mapping as before (`ModelInvokerInternalError` → 500).
- Cost/usage tracking and the `FALLBACK` event (visible in the route health/dashboard) are billed to the model that actually served the request, consistent with chat/embedding fallback.

**Example: fallback config for a route**
```yaml
transcription_models:
  - model_id: gpt4o-transcribe
    model: openai/gpt-4o-transcribe
    credentials:
      api_key: !secret OPENAI_API_KEY
  - model_id: gpt4o-mini-transcribe
    model: openai/gpt-4o-mini-transcribe
    credentials:
      api_key: !secret OPENAI_API_KEY

routes:
  transcribe-route:
    transcription_models:
      - gpt4o-transcribe
      - gpt4o-mini-transcribe
    fallback:
      - type: TRANSCRIPTION
        target: gpt4o-transcribe
        fallbacks:
          - gpt4o-mini-transcribe
```

---

## Other Changes

- `models/gateway_config.py` — fallback validation now recognizes `FallbackModelType.TRANSCRIPTION`, checking `target`/`fallbacks` against the route's `transcription_models` (same validation already applied to `CHAT`/`EMBEDDING`).
- `ai_gateway.py` — `GatewayRoute` filters the route's `fallback` list down to `TRANSCRIPTION`-typed entries before wiring them into `TranscriptionModelInvoker` (previously always `fallbacks=None`, marked `TODO(AG-901)`).
- `invocation/transcription_model_invoker.py`:
  - `_resolve_model()` now also returns the model's configured fallback list.
  - New `_build_create_kwargs()` helper builds the upstream request kwargs for any model (primary or fallback), reused by both `transcribe()` and `stream()`.
  - `transcribe()`/`stream()` both gain a fallback retry loop mirroring `ChatModelInvoker`/`EmbeddingModelInvoker`'s existing pattern, with the transcription-specific rules above (4xx never triggers fallback, whisper-1 skipped for streaming, response shape follows the model actually invoked).
  - `_finalize_transcription()` gains a `fallback_triggered` parameter, threaded into `_record_metrics` so the existing `FALLBACK` event/dashboard pipeline picks it up with no changes on that side.
  - New `_set_transcription_fallback_attributes()` span-attribute helper: sets `transcription.response.model_id` (the model that actually served the request) and `transcription.response.fallback_triggered` on the trace. Added because, unlike chat/embedding — where the invoked model is visible for free via the `model` field already present on `ChatCompletion`/`CreateEmbeddingResponse` — OpenAI's transcription response types (`Transcription`, `TranscriptionVerbose`, and the streaming events) have no `model` field at all, so there is no other way to surface which model answered without inventing a non-standard field on the response body.
- Test coverage added across `tests/invoker/test_transcription_model_invoker.py` (fallback on 5xx for both `transcribe()`/`stream()`, no fallback on 4xx, all-models-fail error, whisper-1 skipped in streaming, cross-family response-shape correctness, new span attributes), `tests/ai_gateway_test.py` (`GatewayRoute` filters fallbacks by type before wiring), and `tests/models/test_gateway_config.py` (valid `TRANSCRIPTION` fallback config, rejection when the target isn't in the route's `transcription_models`).
