### PR TITLE
feat: add project uuid to limiting

### DIFF
--- a/gateway/radicalbit_ai_gateway/limiter/base.py
+++ b/gateway/radicalbit_ai_gateway/limiter/base.py
@@ -29,10 +29,20 @@ class BaseFixedWindowLimiter(ABC):
     def _build_key(self, config: WindowConfig) -> str:
         """Build the storage key from config.
 
-        Key format: limiter:{route_name}:{scenario_type}:{window_type}:{window_seconds}
-        Example: limiter:gpt-4:token_input:fixed:60
+        Key format: limiter:{project_uuid}:{route_name}:{scenario_type}:{window_type}:{window_seconds}
+        Example: limiter:0e6f...:my-route:token_input:fixed:60
+
+        The project segment is omitted when ``project_uuid`` is empty, which
+        keeps the key stable for call sites that have no project context.
+        Route names are unique only within a project, so scoping by project is
+        what stops two projects sharing one window.
         """
-        return f'limiter:{config.route_name}:{config.scenario_type.value}:{self._window_type}:{config.window_seconds}'
+        scope = (
+            f'{config.project_uuid}:{config.route_name}'
+            if config.project_uuid
+            else config.route_name
+        )
+        return f'limiter:{scope}:{config.scenario_type.value}:{self._window_type}:{config.window_seconds}'
 
     async def test(self, item: WindowConfig, cost: int = 1) -> bool:
         """Test if operation is allowed WITHOUT consuming capacity.

--- a/gateway/radicalbit_ai_gateway/limiter/base.py
+++ b/gateway/radicalbit_ai_gateway/limiter/base.py
@@ -32,10 +32,11 @@ class BaseFixedWindowLimiter(ABC):
         Key format: limiter:{project_uuid}:{route_name}:{scenario_type}:{window_type}:{window_seconds}
         Example: limiter:0e6f...:my-route:token_input:fixed:60
 
-        The project segment is omitted when ``project_uuid`` is empty, which
-        keeps the key stable for call sites that have no project context.
-        Route names are unique only within a project, so scoping by project is
-        what stops two projects sharing one window.
+        Route names are unique only within a project, so the project segment
+        is what stops two projects sharing one window. It is always present:
+        ``project_uuid`` is a required field. Passing an empty string yields a
+        third, malformed keyspace (``limiter::route:...``) that matches neither
+        the scoped nor the pre-fix format — callers must supply a real uuid.
         """
         return f'limiter:{config.project_uuid}:{config.route_name}:{config.scenario_type.value}:{self._window_type}:{config.window_seconds}'
 

--- a/gateway/radicalbit_ai_gateway/limiter/base.py
+++ b/gateway/radicalbit_ai_gateway/limiter/base.py
@@ -37,12 +37,7 @@ class BaseFixedWindowLimiter(ABC):
         Route names are unique only within a project, so scoping by project is
         what stops two projects sharing one window.
         """
-        scope = (
-            f'{config.project_uuid}:{config.route_name}'
-            if config.project_uuid
-            else config.route_name
-        )
-        return f'limiter:{scope}:{config.scenario_type.value}:{self._window_type}:{config.window_seconds}'
+        return f'limiter:{config.project_uuid}:{config.route_name}:{config.scenario_type.value}:{self._window_type}:{config.window_seconds}'
 
     async def test(self, item: WindowConfig, cost: int = 1) -> bool:
         """Test if operation is allowed WITHOUT consuming capacity.

--- a/gateway/radicalbit_ai_gateway/limiter/window_config.py
+++ b/gateway/radicalbit_ai_gateway/limiter/window_config.py
@@ -93,6 +93,10 @@ class WindowConfig:
         window_seconds: Window duration in seconds.
         route_name: Name of the route for key isolation.
         scenario_type: Type of rate limiting scenario (request_rate, token_input, token_output).
+        project_uuid: UUID of the owning project, for key isolation only. Route
+            names are unique only within a project, so without this two projects
+            declaring the same route name share one window. Empty string keeps
+            the unscoped key format, for call sites with no project context.
 
     """
 
@@ -100,6 +104,7 @@ class WindowConfig:
     window_seconds: int
     route_name: str
     scenario_type: ScenarioType
+    project_uuid: str = ''
 
     @classmethod
     def from_parts(
@@ -108,6 +113,7 @@ class WindowConfig:
         window: str | int,
         route_name: str,
         scenario_type: ScenarioType,
+        project_uuid: str = '',
     ) -> WindowConfig:
         """Create WindowConfig from limit and window size.
 
@@ -116,6 +122,7 @@ class WindowConfig:
             window: Window size as string (e.g., '1 minute') or seconds (int).
             route_name: Name of the route for key isolation.
             scenario_type: Type of rate limiting scenario.
+            project_uuid: UUID of the owning project, for key isolation only.
 
         Returns:
             WindowConfig instance.
@@ -127,4 +134,5 @@ class WindowConfig:
             window_seconds=window_seconds,
             route_name=route_name,
             scenario_type=scenario_type,
+            project_uuid=project_uuid,
         )

--- a/gateway/radicalbit_ai_gateway/limiter/window_config.py
+++ b/gateway/radicalbit_ai_gateway/limiter/window_config.py
@@ -91,38 +91,37 @@ class WindowConfig:
     Attributes:
         limit: Maximum allowed in the window.
         window_seconds: Window duration in seconds.
-        route_name: Name of the route for key isolation.
-        scenario_type: Type of rate limiting scenario (request_rate, token_input, token_output).
         project_uuid: UUID of the owning project, for key isolation only. Route
             names are unique only within a project, so without this two projects
-            declaring the same route name share one window. Empty string keeps
-            the unscoped key format, for call sites with no project context.
+            declaring the same route name share one window.
+        route_name: Name of the route for key isolation.
+        scenario_type: Type of rate limiting scenario (request_rate, token_input, token_output).
 
     """
 
     limit: int
     window_seconds: int
+    project_uuid: str
     route_name: str
     scenario_type: ScenarioType
-    project_uuid: str = ''
 
     @classmethod
     def from_parts(
         cls,
         limit: int,
         window: str | int,
+        project_uuid: str,
         route_name: str,
         scenario_type: ScenarioType,
-        project_uuid: str = '',
     ) -> WindowConfig:
         """Create WindowConfig from limit and window size.
 
         Args:
             limit: Maximum allowed in the window.
             window: Window size as string (e.g., '1 minute') or seconds (int).
+            project_uuid: UUID of the owning project, for key isolation only.
             route_name: Name of the route for key isolation.
             scenario_type: Type of rate limiting scenario.
-            project_uuid: UUID of the owning project, for key isolation only.
 
         Returns:
             WindowConfig instance.
@@ -132,7 +131,7 @@ class WindowConfig:
         return cls(
             limit=limit,
             window_seconds=window_seconds,
+            project_uuid=project_uuid,
             route_name=route_name,
             scenario_type=scenario_type,
-            project_uuid=project_uuid,
         )

--- a/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
+++ b/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
@@ -25,9 +25,13 @@ class BudgetLimiter:
         self,
         route_name: str,
         config: Limiting | None = None,
+        project_uuid: str = '',
     ):
         self.route_name = route_name
         self.config = config
+        # Key isolation only: route_name stays the bare route everywhere it is
+        # reported (metrics, limit events, logs).
+        self.project_uuid = project_uuid
 
         # Use Redis storage if Redis config are provided, otherwise fall back to MemoryStorage
         if app_config.redis_config.redis_url:
@@ -37,7 +41,7 @@ class BudgetLimiter:
 
         self.limiter = self._create_limiter(config) if config else None
         self.item = (
-            self._create_item(config, route_name, ScenarioType.BUDGET)
+            self._create_item(config, route_name, ScenarioType.BUDGET, project_uuid)
             if config
             else None
         )
@@ -52,7 +56,10 @@ class BudgetLimiter:
 
     @staticmethod
     def _create_item(
-        config: Limiting, route_name: str, scenario_type: ScenarioType
+        config: Limiting,
+        route_name: str,
+        scenario_type: ScenarioType,
+        project_uuid: str = '',
     ) -> WindowConfig:
         """Create the item for the window to store max_budget inside the window_size"""
         if config.max_budget_in_units is None:
@@ -62,6 +69,7 @@ class BudgetLimiter:
             window=config.window_size,
             route_name=route_name,
             scenario_type=scenario_type,
+            project_uuid=project_uuid,
         )
 
     async def count_input(self, token_count: int, input_cost_per_token: float) -> None:

--- a/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
+++ b/gateway/radicalbit_ai_gateway/limiting/budget_limiting.py
@@ -23,9 +23,9 @@ logger = logging.getLogger(app_config.log_config.logger_name)
 class BudgetLimiter:
     def __init__(
         self,
+        project_uuid: str,
         route_name: str,
         config: Limiting | None = None,
-        project_uuid: str = '',
     ):
         self.route_name = route_name
         self.config = config
@@ -41,7 +41,7 @@ class BudgetLimiter:
 
         self.limiter = self._create_limiter(config) if config else None
         self.item = (
-            self._create_item(config, route_name, ScenarioType.BUDGET, project_uuid)
+            self._create_item(config, project_uuid, route_name, ScenarioType.BUDGET)
             if config
             else None
         )
@@ -57,9 +57,9 @@ class BudgetLimiter:
     @staticmethod
     def _create_item(
         config: Limiting,
+        project_uuid: str,
         route_name: str,
         scenario_type: ScenarioType,
-        project_uuid: str = '',
     ) -> WindowConfig:
         """Create the item for the window to store max_budget inside the window_size"""
         if config.max_budget_in_units is None:

--- a/gateway/radicalbit_ai_gateway/limiting/rate_limiter.py
+++ b/gateway/radicalbit_ai_gateway/limiting/rate_limiter.py
@@ -28,9 +28,9 @@ class RequestRateLimiter:
 
     def __init__(
         self,
+        project_uuid: str,
         route_name: str,
         rate_limiting_config: RateLimiting | None = None,
-        project_uuid: str = '',
     ):
         self.route_name = route_name
         self.rate_limiting_config = rate_limiting_config
@@ -47,7 +47,7 @@ class RequestRateLimiter:
         # Create rate limiter and item if config provided
         self.limiter = self._create_limiter() if rate_limiting_config else None
         self.item = (
-            self._create_item(rate_limiting_config, route_name, project_uuid)
+            self._create_item(rate_limiting_config, project_uuid, route_name)
             if rate_limiting_config
             else None
         )
@@ -62,7 +62,7 @@ class RequestRateLimiter:
 
     @staticmethod
     def _create_item(
-        config: RateLimiting, route_name: str, project_uuid: str = ''
+        config: RateLimiting, project_uuid: str, route_name: str
     ) -> WindowConfig:
         if not config.max_requests:
             raise ValueError('max_requests must be set for rate limiting')

--- a/gateway/radicalbit_ai_gateway/limiting/rate_limiter.py
+++ b/gateway/radicalbit_ai_gateway/limiting/rate_limiter.py
@@ -27,10 +27,16 @@ class RequestRateLimiter:
     """Rate limiter for request counting using limits library."""
 
     def __init__(
-        self, route_name: str, rate_limiting_config: RateLimiting | None = None
+        self,
+        route_name: str,
+        rate_limiting_config: RateLimiting | None = None,
+        project_uuid: str = '',
     ):
         self.route_name = route_name
         self.rate_limiting_config = rate_limiting_config
+        # Key isolation only: route_name stays the bare route everywhere it is
+        # reported (metrics, limit events, logs).
+        self.project_uuid = project_uuid
 
         # Use Redis storage if available, else MemoryStorage
         if app_config.redis_config.redis_url:
@@ -41,7 +47,7 @@ class RequestRateLimiter:
         # Create rate limiter and item if config provided
         self.limiter = self._create_limiter() if rate_limiting_config else None
         self.item = (
-            self._create_item(rate_limiting_config, route_name)
+            self._create_item(rate_limiting_config, route_name, project_uuid)
             if rate_limiting_config
             else None
         )
@@ -55,7 +61,9 @@ class RequestRateLimiter:
         return FixedWindowLimiter(self.storage)
 
     @staticmethod
-    def _create_item(config: RateLimiting, route_name: str) -> WindowConfig:
+    def _create_item(
+        config: RateLimiting, route_name: str, project_uuid: str = ''
+    ) -> WindowConfig:
         if not config.max_requests:
             raise ValueError('max_requests must be set for rate limiting')
         return WindowConfig.from_parts(
@@ -63,6 +71,7 @@ class RequestRateLimiter:
             window=config.window_size,
             route_name=route_name,
             scenario_type=ScenarioType.REQUEST_RATE,
+            project_uuid=project_uuid,
         )
 
     async def _check_request(

--- a/gateway/radicalbit_ai_gateway/limiting/token_limiter.py
+++ b/gateway/radicalbit_ai_gateway/limiting/token_limiter.py
@@ -34,10 +34,10 @@ logger = logging.getLogger(app_config.log_config.logger_name)
 class TokenLimiter:
     def __init__(
         self,
+        project_uuid: str,
         route_name: str,
         input_config: Limiting | None = None,
         output_config: Limiting | None = None,
-        project_uuid: str = '',
     ):
         self.route_name = route_name
         self.input_config = input_config
@@ -61,14 +61,14 @@ class TokenLimiter:
         )
         self.input_item = (
             self._create_item(
-                input_config, route_name, ScenarioType.TOKEN_INPUT, project_uuid
+                input_config, project_uuid, route_name, ScenarioType.TOKEN_INPUT
             )
             if input_config
             else None
         )
         self.output_item = (
             self._create_item(
-                output_config, route_name, ScenarioType.TOKEN_OUTPUT, project_uuid
+                output_config, project_uuid, route_name, ScenarioType.TOKEN_OUTPUT
             )
             if output_config
             else None
@@ -85,9 +85,9 @@ class TokenLimiter:
     @staticmethod
     def _create_item(
         config: Limiting,
+        project_uuid: str,
         route_name: str,
         scenario_type: ScenarioType,
-        project_uuid: str = '',
     ) -> WindowConfig:
         """Create the item for the window to store max_tokens inside the window_size"""
         if not config.max_tokens:

--- a/gateway/radicalbit_ai_gateway/limiting/token_limiter.py
+++ b/gateway/radicalbit_ai_gateway/limiting/token_limiter.py
@@ -37,10 +37,14 @@ class TokenLimiter:
         route_name: str,
         input_config: Limiting | None = None,
         output_config: Limiting | None = None,
+        project_uuid: str = '',
     ):
         self.route_name = route_name
         self.input_config = input_config
         self.output_config = output_config
+        # Key isolation only: route_name stays the bare route everywhere it is
+        # reported (metrics, limit events, logs).
+        self.project_uuid = project_uuid
 
         # Use Redis storage if Redis config are provided, otherwise fall back to MemoryStorage
         if app_config.redis_config.redis_url:
@@ -56,12 +60,16 @@ class TokenLimiter:
             self._create_limiter(output_config) if output_config else None
         )
         self.input_item = (
-            self._create_item(input_config, route_name, ScenarioType.TOKEN_INPUT)
+            self._create_item(
+                input_config, route_name, ScenarioType.TOKEN_INPUT, project_uuid
+            )
             if input_config
             else None
         )
         self.output_item = (
-            self._create_item(output_config, route_name, ScenarioType.TOKEN_OUTPUT)
+            self._create_item(
+                output_config, route_name, ScenarioType.TOKEN_OUTPUT, project_uuid
+            )
             if output_config
             else None
         )
@@ -76,7 +84,10 @@ class TokenLimiter:
 
     @staticmethod
     def _create_item(
-        config: Limiting, route_name: str, scenario_type: ScenarioType
+        config: Limiting,
+        route_name: str,
+        scenario_type: ScenarioType,
+        project_uuid: str = '',
     ) -> WindowConfig:
         """Create the item for the window to store max_tokens inside the window_size"""
         if not config.max_tokens:
@@ -86,6 +97,7 @@ class TokenLimiter:
             window=config.window_size,
             route_name=route_name,
             scenario_type=scenario_type,
+            project_uuid=project_uuid,
         )
 
     @task(name='check_token_input_limit')

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -70,24 +70,24 @@ class GatewayRouteConfig(BaseModel):
         description='Aliases of top-level MCP servers exposed on this route.',
     )
 
-    def get_token_limiter(self, project_uuid: str = '') -> TokenLimiter:
+    def get_token_limiter(self, project_uuid: str) -> TokenLimiter:
         return TokenLimiter(
+            project_uuid=project_uuid,
             route_name=self.route_name,
             input_config=getattr(self.token_limiting, 'input', None),
             output_config=getattr(self.token_limiting, 'output', None),
-            project_uuid=project_uuid,
         )
 
-    def get_budget_limiter(self, project_uuid: str = '') -> BudgetLimiter:
+    def get_budget_limiter(self, project_uuid: str) -> BudgetLimiter:
         return BudgetLimiter(
+            project_uuid=project_uuid,
             route_name=self.route_name,
             config=self.budget_limiting,
-            project_uuid=project_uuid,
         )
 
-    def get_rate_limiter(self, project_uuid: str = '') -> RequestRateLimiter:
+    def get_rate_limiter(self, project_uuid: str) -> RequestRateLimiter:
         return RequestRateLimiter(
+            project_uuid=project_uuid,
             route_name=self.route_name,
             rate_limiting_config=self.rate_limiting,
-            project_uuid=project_uuid,
         )

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -70,21 +70,24 @@ class GatewayRouteConfig(BaseModel):
         description='Aliases of top-level MCP servers exposed on this route.',
     )
 
-    def get_token_limiter(self) -> TokenLimiter:
+    def get_token_limiter(self, project_uuid: str = '') -> TokenLimiter:
         return TokenLimiter(
             route_name=self.route_name,
             input_config=getattr(self.token_limiting, 'input', None),
             output_config=getattr(self.token_limiting, 'output', None),
+            project_uuid=project_uuid,
         )
 
-    def get_budget_limiter(self) -> BudgetLimiter:
+    def get_budget_limiter(self, project_uuid: str = '') -> BudgetLimiter:
         return BudgetLimiter(
             route_name=self.route_name,
             config=self.budget_limiting,
+            project_uuid=project_uuid,
         )
 
-    def get_rate_limiter(self) -> RequestRateLimiter:
+    def get_rate_limiter(self, project_uuid: str = '') -> RequestRateLimiter:
         return RequestRateLimiter(
             route_name=self.route_name,
             rate_limiting_config=self.rate_limiting,
+            project_uuid=project_uuid,
         )

--- a/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
+++ b/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
@@ -96,7 +96,14 @@ def build_gateway_routes_from_config(
     redis_client: redis.Redis | None,
     cost_service: CostService,
     httpx_client,
+    project_uuid: str = '',
 ) -> dict[str, GatewayRoute]:
+    """Build the live routes declared by ``gateway_config``.
+
+    ``project_uuid`` scopes the limiter storage keys. Route names are unique
+    only within a project, so omitting it makes two projects that declare the
+    same route name share one limit window.
+    """
     routes: dict[str, GatewayRoute] = {}
     chat_by_id = gateway_config.chat_models_by_id
     emb_by_id = gateway_config.embedding_models_by_id
@@ -124,13 +131,19 @@ def build_gateway_routes_from_config(
         cache_client = get_proper_cache(route_config, redis_client)
         gateway_cache = GatewayCache(cache_client) if cache_client is not None else None
         token_limiter = (
-            route_config.get_token_limiter() if route_config.token_limiting else None
+            route_config.get_token_limiter(project_uuid)
+            if route_config.token_limiting
+            else None
         )
         rate_limiter = (
-            route_config.get_rate_limiter() if route_config.rate_limiting else None
+            route_config.get_rate_limiter(project_uuid)
+            if route_config.rate_limiting
+            else None
         )
         budget_limiter = (
-            route_config.get_budget_limiter() if route_config.budget_limiting else None
+            route_config.get_budget_limiter(project_uuid)
+            if route_config.budget_limiting
+            else None
         )
         router = None
         if route_config.routing and gateway_config.routing:
@@ -226,14 +239,15 @@ def build_project_route_registrar(
                 port=project_gateway_config.cache.redis_port,
                 decode_responses=True,
             )
+        uuid_str = str(project_uuid)
         routes = build_gateway_routes_from_config(
             project_gateway_config,
             project_guardrail_engine,
             project_redis_client,
             project_cost_service,
             httpx_client,
+            project_uuid=uuid_str,
         )
-        uuid_str = str(project_uuid)
         await initialize_async_routers(routes)
         for route_name, route in routes.items():
             full_key = f'{project_name}/{route_name}'

--- a/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
+++ b/gateway/radicalbit_ai_gateway/utils/gateway_route_factory.py
@@ -74,7 +74,7 @@ async def initialize_async_routers(routes: dict[str, GatewayRoute]) -> None:
 
 
 def get_proper_cache(
-    route_config: GatewayRouteConfig, redis_client: redis.Redis | None
+    route_config: GatewayRouteConfig, redis_client: redis.asyncio.Redis | None
 ) -> AbstractCache | None:
     if not route_config.caching:
         return None
@@ -93,10 +93,10 @@ def get_proper_cache(
 def build_gateway_routes_from_config(
     gateway_config: GatewayConfig,
     guardrail_engine: GuardrailEngine,
-    redis_client: redis.Redis | None,
+    redis_client: redis.asyncio.Redis | None,
     cost_service: CostService,
     httpx_client,
-    project_uuid: str = '',
+    project_uuid: str,
 ) -> dict[str, GatewayRoute]:
     """Build the live routes declared by ``gateway_config``.
 

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -763,7 +763,7 @@ async def test_invoke_embeddings_token_limit_exceeded(
         gateway_config, 'rb-gateway'
     )
 
-    token_limiter = route_cfg.get_token_limiter()
+    token_limiter = route_cfg.get_token_limiter('2f1c6d4e-0000-4000-8000-0000000000aa')
 
     ai_gateway = GatewayRoute(
         gateway_route_config=route_cfg,
@@ -813,7 +813,9 @@ async def test_invoke_embeddings_budget_limit_exceeded(
     route_cfg, chat_models, embedding_models = resolve_route_models(
         gateway_config, 'rb-gateway'
     )
-    budget_limiter = route_cfg.get_budget_limiter()
+    budget_limiter = route_cfg.get_budget_limiter(
+        '2f1c6d4e-0000-4000-8000-0000000000aa'
+    )
     ai_gateway = GatewayRoute(
         gateway_route_config=route_cfg,
         chat_models=chat_models,
@@ -1024,7 +1026,9 @@ async def test_invoke_transcription_counts_budget_duration():
         input_cost_per_second=Decimal('0.0001'),
     )
     route_cfg = _make_transcription_route_config(max_budget=10.0, window_size=3600)
-    budget_limiter = route_cfg.get_budget_limiter()
+    budget_limiter = route_cfg.get_budget_limiter(
+        '2f1c6d4e-0000-4000-8000-0000000000aa'
+    )
     budget_limiter.check_budget = AsyncMock()
     budget_limiter.count_duration = AsyncMock()
     budget_limiter.count_input = AsyncMock()
@@ -1083,7 +1087,9 @@ async def test_invoke_transcription_counts_budget_tokens():
     route_cfg = _make_transcription_route_config(
         model_id='gpt4o-transcribe', max_budget=10.0, window_size=3600
     )
-    budget_limiter = route_cfg.get_budget_limiter()
+    budget_limiter = route_cfg.get_budget_limiter(
+        '2f1c6d4e-0000-4000-8000-0000000000aa'
+    )
     budget_limiter.check_budget = AsyncMock()
     budget_limiter.count_input = AsyncMock()
     budget_limiter.count_output = AsyncMock()
@@ -1179,7 +1185,9 @@ async def test_invoke_transcription_stream_relays_events_and_counts_usage_once()
     route_cfg = _make_transcription_route_config(
         model_id='gpt4o-transcribe', max_budget=10.0, window_size=3600
     )
-    budget_limiter = route_cfg.get_budget_limiter()
+    budget_limiter = route_cfg.get_budget_limiter(
+        '2f1c6d4e-0000-4000-8000-0000000000aa'
+    )
     budget_limiter.check_budget = AsyncMock()
     budget_limiter.count_input = AsyncMock()
     budget_limiter.count_output = AsyncMock()

--- a/gateway/tests/limiter/test_aligned_fixed_window_limiter.py
+++ b/gateway/tests/limiter/test_aligned_fixed_window_limiter.py
@@ -440,7 +440,7 @@ class TestKeyStructure:
     """Tests for the Redis key structure."""
 
     def test_build_key_format(self, limiter: AlignedFixedWindowLimiter) -> None:
-        """A config with no project falls back to the unscoped key format."""
+        """Key format: limiter:{project}:{route}:{scenario}:aligned:{seconds}."""
         config = WindowConfig(
             limit=10,
             window_seconds=60,

--- a/gateway/tests/limiter/test_aligned_fixed_window_limiter.py
+++ b/gateway/tests/limiter/test_aligned_fixed_window_limiter.py
@@ -432,7 +432,7 @@ class TestKeyStructure:
     """Tests for the Redis key structure."""
 
     def test_build_key_format(self, limiter: AlignedFixedWindowLimiter) -> None:
-        """Verify key format: limiter:{route_name}:{scenario_type}:{window_type}:{window_seconds}"""
+        """A config with no project falls back to the unscoped key format."""
         config = WindowConfig(
             limit=10,
             window_seconds=60,
@@ -453,3 +453,39 @@ class TestKeyStructure:
         )
         key = limiter._build_key(config)
         assert key == 'limiter:claude-3-sonnet:request_rate:aligned:3600'
+
+    def test_build_key_includes_project_uuid(
+        self, limiter: AlignedFixedWindowLimiter
+    ) -> None:
+        """A project-scoped config puts the project ahead of the route."""
+        config = WindowConfig(
+            limit=10,
+            window_seconds=3600,
+            route_name='my-route',
+            scenario_type=ScenarioType.BUDGET,
+            project_uuid='2f1c6d4e-0000-4000-8000-000000000001',
+        )
+        key = limiter._build_key(config)
+        assert (
+            key
+            == 'limiter:2f1c6d4e-0000-4000-8000-000000000001:my-route:budget:aligned:3600'
+        )
+
+    def test_same_route_name_in_two_projects_gets_distinct_keys(
+        self, limiter: AlignedFixedWindowLimiter
+    ) -> None:
+        """Regression: route names are unique only within a project."""
+        first, second = (
+            WindowConfig(
+                limit=10,
+                window_seconds=3600,
+                route_name='default',
+                scenario_type=ScenarioType.TOKEN_INPUT,
+                project_uuid=uuid,
+            )
+            for uuid in (
+                '2f1c6d4e-0000-4000-8000-000000000001',
+                '2f1c6d4e-0000-4000-8000-000000000002',
+            )
+        )
+        assert limiter._build_key(first) != limiter._build_key(second)

--- a/gateway/tests/limiter/test_aligned_fixed_window_limiter.py
+++ b/gateway/tests/limiter/test_aligned_fixed_window_limiter.py
@@ -12,6 +12,8 @@ from radicalbit_ai_gateway.limiter import (
 )
 from radicalbit_ai_gateway.limiter.window_config import WindowConfig
 
+_PROJECT_UUID = '2f1c6d4e-0000-4000-8000-0000000000aa'
+
 
 @pytest.fixture
 def storage() -> InMemoryStorage:
@@ -28,6 +30,7 @@ def config() -> WindowConfig:
     return WindowConfig(
         limit=10,
         window_seconds=60,
+        project_uuid=_PROJECT_UUID,
         route_name='test-route',
         scenario_type=ScenarioType.REQUEST_RATE,
     )
@@ -48,6 +51,7 @@ class TestAlignedWindowBoundaries:
         config = WindowConfig(
             limit=10,
             window_seconds=3600,
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -74,6 +78,7 @@ class TestAlignedWindowBoundaries:
         config = WindowConfig(
             limit=10,
             window_seconds=86400,
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -100,6 +105,7 @@ class TestAlignedWindowBoundaries:
         config = WindowConfig(
             limit=10,
             window_seconds=43200,
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -374,12 +380,14 @@ class TestKeyIsolation:
         config1 = WindowConfig(
             limit=10,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='route-a',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
         config2 = WindowConfig(
             limit=10,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='route-b',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -436,11 +444,12 @@ class TestKeyStructure:
         config = WindowConfig(
             limit=10,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='gpt-4',
             scenario_type=ScenarioType.TOKEN_INPUT,
         )
         key = limiter._build_key(config)
-        assert key == 'limiter:gpt-4:token_input:aligned:60'
+        assert key == f'limiter:{_PROJECT_UUID}:gpt-4:token_input:aligned:60'
 
     def test_build_key_with_different_scenario(
         self, limiter: AlignedFixedWindowLimiter
@@ -448,11 +457,14 @@ class TestKeyStructure:
         config = WindowConfig(
             limit=10,
             window_seconds=3600,
+            project_uuid=_PROJECT_UUID,
             route_name='claude-3-sonnet',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
         key = limiter._build_key(config)
-        assert key == 'limiter:claude-3-sonnet:request_rate:aligned:3600'
+        assert (
+            key == f'limiter:{_PROJECT_UUID}:claude-3-sonnet:request_rate:aligned:3600'
+        )
 
     def test_build_key_includes_project_uuid(
         self, limiter: AlignedFixedWindowLimiter

--- a/gateway/tests/limiter/test_fixed_window_limiter.py
+++ b/gateway/tests/limiter/test_fixed_window_limiter.py
@@ -313,7 +313,7 @@ class TestKeyStructure:
     """Tests for the Redis key structure."""
 
     def test_build_key_format(self, limiter: FixedWindowLimiter) -> None:
-        """Verify key format: limiter:{route_name}:{scenario_type}:{window_type}:{window_seconds}"""
+        """A config with no project falls back to the unscoped key format."""
         config = WindowConfig(
             limit=10,
             window_seconds=60,
@@ -344,3 +344,87 @@ class TestKeyStructure:
         )
         key = limiter._build_key(config)
         assert key == 'limiter:my-model:token_output:fixed:120'
+
+    def test_build_key_includes_project_uuid(self, limiter: FixedWindowLimiter) -> None:
+        """A project-scoped config puts the project ahead of the route."""
+        config = WindowConfig(
+            limit=10,
+            window_seconds=60,
+            route_name='my-route',
+            scenario_type=ScenarioType.REQUEST_RATE,
+            project_uuid='2f1c6d4e-0000-4000-8000-000000000001',
+        )
+        key = limiter._build_key(config)
+        assert (
+            key
+            == 'limiter:2f1c6d4e-0000-4000-8000-000000000001:my-route:request_rate:fixed:60'
+        )
+
+    def test_same_route_name_in_two_projects_gets_distinct_keys(
+        self, limiter: FixedWindowLimiter
+    ) -> None:
+        """Regression: route names are unique only within a project."""
+        first, second = (
+            WindowConfig(
+                limit=10,
+                window_seconds=60,
+                route_name='default',
+                scenario_type=ScenarioType.REQUEST_RATE,
+                project_uuid=uuid,
+            )
+            for uuid in (
+                '2f1c6d4e-0000-4000-8000-000000000001',
+                '2f1c6d4e-0000-4000-8000-000000000002',
+            )
+        )
+        assert limiter._build_key(first) != limiter._build_key(second)
+
+
+class TestProjectIsolation:
+    """Two projects sharing a route name must not share a window."""
+
+    @staticmethod
+    def _config(project_uuid: str) -> WindowConfig:
+        return WindowConfig(
+            limit=2,
+            window_seconds=60,
+            route_name='default',
+            scenario_type=ScenarioType.REQUEST_RATE,
+            project_uuid=project_uuid,
+        )
+
+    @pytest.mark.asyncio
+    async def test_windows_are_independent(self, limiter: FixedWindowLimiter) -> None:
+        project_a = self._config('2f1c6d4e-0000-4000-8000-00000000000a')
+        project_b = self._config('2f1c6d4e-0000-4000-8000-00000000000b')
+
+        # Exhaust project A's window.
+        assert await limiter.hit(project_a) is True
+        assert await limiter.hit(project_a) is True
+        assert await limiter.hit(project_a) is False
+
+        # Project B is untouched and still has its full allowance.
+        stats_b = await limiter.get_window_stats(project_b)
+        assert stats_b.remaining == 2
+        assert await limiter.hit(project_b) is True
+
+    @pytest.mark.asyncio
+    async def test_unscoped_configs_still_share_a_window(
+        self, limiter: FixedWindowLimiter
+    ) -> None:
+        """Without a project the pre-fix behaviour is preserved deliberately."""
+        first = WindowConfig(
+            limit=2,
+            window_seconds=60,
+            route_name='default',
+            scenario_type=ScenarioType.REQUEST_RATE,
+        )
+        second = WindowConfig(
+            limit=2,
+            window_seconds=60,
+            route_name='default',
+            scenario_type=ScenarioType.REQUEST_RATE,
+        )
+        await limiter.hit(first)
+        stats = await limiter.get_window_stats(second)
+        assert stats.remaining == 1

--- a/gateway/tests/limiter/test_fixed_window_limiter.py
+++ b/gateway/tests/limiter/test_fixed_window_limiter.py
@@ -321,7 +321,7 @@ class TestKeyStructure:
     """Tests for the Redis key structure."""
 
     def test_build_key_format(self, limiter: FixedWindowLimiter) -> None:
-        """A config with no project falls back to the unscoped key format."""
+        """Key format: limiter:{project}:{route}:{scenario}:fixed:{seconds}."""
         config = WindowConfig(
             limit=10,
             window_seconds=60,
@@ -420,10 +420,14 @@ class TestProjectIsolation:
         assert await limiter.hit(project_b) is True
 
     @pytest.mark.asyncio
-    async def test_unscoped_configs_still_share_a_window(
+    async def test_same_project_and_route_share_a_window(
         self, limiter: FixedWindowLimiter
     ) -> None:
-        """Without a project the pre-fix behaviour is preserved deliberately."""
+        """The counterpart to isolation: scoping must not over-isolate.
+
+        Two configs naming the same project and route are the same window, so a
+        route's budget is shared across the requests that target it.
+        """
         first = WindowConfig(
             limit=2,
             window_seconds=60,

--- a/gateway/tests/limiter/test_fixed_window_limiter.py
+++ b/gateway/tests/limiter/test_fixed_window_limiter.py
@@ -13,6 +13,8 @@ from radicalbit_ai_gateway.limiter import (
 )
 from radicalbit_ai_gateway.limiter.window_config import WindowConfig
 
+_PROJECT_UUID = '2f1c6d4e-0000-4000-8000-0000000000aa'
+
 
 @pytest.fixture
 def storage() -> InMemoryStorage:
@@ -29,6 +31,7 @@ def config() -> WindowConfig:
     return WindowConfig(
         limit=10,
         window_seconds=60,
+        project_uuid=_PROJECT_UUID,
         route_name='test-route',
         scenario_type=ScenarioType.REQUEST_RATE,
     )
@@ -256,12 +259,14 @@ class TestKeyIsolation:
         config1 = WindowConfig(
             limit=10,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='route-a',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
         config2 = WindowConfig(
             limit=10,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='route-b',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -281,18 +286,21 @@ class TestKeyIsolation:
         config_request = WindowConfig(
             limit=10,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='gpt-4',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
         config_input = WindowConfig(
             limit=1000,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='gpt-4',
             scenario_type=ScenarioType.TOKEN_INPUT,
         )
         config_output = WindowConfig(
             limit=500,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='gpt-4',
             scenario_type=ScenarioType.TOKEN_OUTPUT,
         )
@@ -317,11 +325,12 @@ class TestKeyStructure:
         config = WindowConfig(
             limit=10,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='gpt-4',
             scenario_type=ScenarioType.TOKEN_INPUT,
         )
         key = limiter._build_key(config)
-        assert key == 'limiter:gpt-4:token_input:fixed:60'
+        assert key == f'limiter:{_PROJECT_UUID}:gpt-4:token_input:fixed:60'
 
     def test_build_key_with_different_scenario(
         self, limiter: FixedWindowLimiter
@@ -329,21 +338,23 @@ class TestKeyStructure:
         config = WindowConfig(
             limit=10,
             window_seconds=3600,
+            project_uuid=_PROJECT_UUID,
             route_name='claude-3-sonnet',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
         key = limiter._build_key(config)
-        assert key == 'limiter:claude-3-sonnet:request_rate:fixed:3600'
+        assert key == f'limiter:{_PROJECT_UUID}:claude-3-sonnet:request_rate:fixed:3600'
 
     def test_build_key_with_token_output(self, limiter: FixedWindowLimiter) -> None:
         config = WindowConfig(
             limit=500,
             window_seconds=120,
+            project_uuid=_PROJECT_UUID,
             route_name='my-model',
             scenario_type=ScenarioType.TOKEN_OUTPUT,
         )
         key = limiter._build_key(config)
-        assert key == 'limiter:my-model:token_output:fixed:120'
+        assert key == f'limiter:{_PROJECT_UUID}:my-model:token_output:fixed:120'
 
     def test_build_key_includes_project_uuid(self, limiter: FixedWindowLimiter) -> None:
         """A project-scoped config puts the project ahead of the route."""
@@ -416,12 +427,14 @@ class TestProjectIsolation:
         first = WindowConfig(
             limit=2,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='default',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
         second = WindowConfig(
             limit=2,
             window_seconds=60,
+            project_uuid=_PROJECT_UUID,
             route_name='default',
             scenario_type=ScenarioType.REQUEST_RATE,
         )

--- a/gateway/tests/limiter/test_window_config.py
+++ b/gateway/tests/limiter/test_window_config.py
@@ -8,6 +8,8 @@ from radicalbit_ai_gateway.limiter.window_config import (
     parse_window,
 )
 
+_PROJECT_UUID = '2f1c6d4e-0000-4000-8000-0000000000aa'
+
 
 class TestFromParts:
     """Tests for WindowConfig.from_parts() factory method."""
@@ -16,6 +18,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=100,
             window='1 minute',
+            project_uuid=_PROJECT_UUID,
             route_name='gpt-4',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -28,6 +31,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=50,
             window=30,
+            project_uuid=_PROJECT_UUID,
             route_name='my-route',
             scenario_type=ScenarioType.TOKEN_INPUT,
         )
@@ -39,6 +43,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=100,
             window='1 second',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -48,6 +53,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=50,
             window='10 seconds',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -57,6 +63,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=100,
             window='1 minute',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -66,6 +73,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=200,
             window='5 minutes',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -75,6 +83,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=1000,
             window='1 hour',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -84,6 +93,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=5000,
             window='2 hours',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -93,6 +103,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=10000,
             window='1 day',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -102,6 +113,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=50000,
             window='1 week',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -111,6 +123,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=100000,
             window='2 weeks',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -120,6 +133,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=100000,
             window='1 month',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )
@@ -129,6 +143,7 @@ class TestFromParts:
         config = WindowConfig.from_parts(
             limit=200000,
             window='3 months',
+            project_uuid=_PROJECT_UUID,
             route_name='test',
             scenario_type=ScenarioType.REQUEST_RATE,
         )

--- a/gateway/tests/limiting/test_budget_limiting.py
+++ b/gateway/tests/limiting/test_budget_limiting.py
@@ -7,10 +7,12 @@ from radicalbit_ai_gateway.limiting.budget_limiting import BudgetLimiter
 from radicalbit_ai_gateway.models.limiting import Limiting, LimitingAlgorithmType
 from radicalbit_ai_gateway.utils.exceptions import BudgetLimitExceededError
 
+_PROJECT_UUID = '2f1c6d4e-0000-4000-8000-0000000000aa'
+
 
 class TestBudgetLimiter:
     def test_init_without_config(self):
-        limiter = BudgetLimiter(route_name='rb-gateway')
+        limiter = BudgetLimiter(project_uuid=_PROJECT_UUID, route_name='rb-gateway')
         assert limiter.limiter is None
         assert limiter.item is None
 
@@ -20,7 +22,9 @@ class TestBudgetLimiter:
             window_size='1 minute',
             max_budget=10,
         )
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
         assert limiter.limiter is not None
         assert limiter.item is not None
 
@@ -29,11 +33,13 @@ class TestBudgetLimiter:
         with pytest.raises(
             ValueError, match='max_budget must be set for budget limiting'
         ):
-            BudgetLimiter(route_name='rb-gateway', config=config)
+            BudgetLimiter(
+                project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+            )
 
     @pytest.mark.asyncio
     async def test_check_and_count_no_config(self):
-        limiter = BudgetLimiter(route_name='rb-gateway')
+        limiter = BudgetLimiter(project_uuid=_PROJECT_UUID, route_name='rb-gateway')
         await limiter.count_input(10, 2.5e-06)
         await limiter.count_output(10, 2.5e-06)
         await limiter.check_budget()
@@ -41,7 +47,9 @@ class TestBudgetLimiter:
     @pytest.mark.asyncio
     async def test_check_and_count_within_limit(self):
         config = Limiting(max_budget=1, window_size='1 minute')
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
         await limiter.count_input(10, 2.5e-06)
         await limiter.count_output(10, 2.5e-06)
         await limiter.check_budget()
@@ -49,7 +57,9 @@ class TestBudgetLimiter:
     @pytest.mark.asyncio
     async def test_count_input_exceeds_limit(self):
         config = Limiting(max_budget=3.46, window_size='1 minute')
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
 
         with pytest.raises(BudgetLimitExceededError) as exc:
             await limiter.count_input(10_000_000, 2.5e-06)
@@ -68,7 +78,9 @@ class TestBudgetLimiter:
     @pytest.mark.asyncio
     async def test_count_output_exceeds_limit(self):
         config = Limiting(max_budget=0.25, window_size='1 minute')
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
 
         await limiter.count_output(100000, 2.51e-06)
 
@@ -92,7 +104,9 @@ class TestBudgetLimiter:
         int token counts.
         """
         config = Limiting(max_budget=0.0005, window_size='1 minute')
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
 
         await limiter.count_duration(8.25, 0.0001)
 
@@ -108,7 +122,9 @@ class TestBudgetLimiter:
     async def test_combined_input_output_exhausts_budget(self):
         """Input + output costs together exhaust the shared budget."""
         config = Limiting(max_budget=1, window_size='1 minute')
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
 
         # Each call spends ~0.25, three calls = 0.75 — still under 1.0
         await limiter.count_input(100000, 2.5e-06)
@@ -135,7 +151,9 @@ class TestBudgetLimiter:
     @pytest.mark.asyncio
     async def test_budget_accumulates(self):
         config = Limiting(max_budget=1, window_size='1 minute')
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
 
         await limiter.count_input(100000, 2.5e-06)
         await limiter.check_budget()
@@ -158,7 +176,9 @@ class TestBudgetLimiter:
     @pytest.mark.asyncio
     async def test_budget_accumulates_with_reset_time(self):
         config = Limiting(max_budget=1, window_size='1 minute')
-        limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+        limiter = BudgetLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+        )
 
         initial_datetime = datetime.datetime(
             year=2025, month=6, day=25, hour=15, minute=0, second=0
@@ -197,7 +217,9 @@ class TestBudgetLimiter:
                 max_budget=0.25,
                 window_size='10 second',
             )
-            limiter = BudgetLimiter(route_name='rb-gateway', config=config)
+            limiter = BudgetLimiter(
+                project_uuid=_PROJECT_UUID, route_name='rb-gateway', config=config
+            )
 
             await limiter.count_input(100000, 2.4e-06)
             await limiter.check_budget()

--- a/gateway/tests/limiting/test_rate_limiter.py
+++ b/gateway/tests/limiting/test_rate_limiter.py
@@ -10,6 +10,8 @@ from radicalbit_ai_gateway.limiting.rate_limiter import RequestRateLimiter
 from radicalbit_ai_gateway.models.limiting import LimitingAlgorithmType, RateLimiting
 from radicalbit_ai_gateway.utils.exceptions import RequestRateLimitExceeded
 
+_PROJECT_UUID = '2f1c6d4e-0000-4000-8000-0000000000aa'
+
 
 @pytest.fixture(autouse=True)
 def mock_emit_event():
@@ -21,7 +23,9 @@ def mock_emit_event():
 class TestRequestRateLimiter:
     def test_init_without_config(self):
         """Test RequestRateLimiter initialization without any configuration."""
-        limiter = RequestRateLimiter(route_name='rb-gateway')
+        limiter = RequestRateLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway'
+        )
         assert limiter.limiter is None
 
     def test_init_with_config(self):
@@ -32,7 +36,9 @@ class TestRequestRateLimiter:
             window_size='1 minute',
         )
         limiter = RequestRateLimiter(
-            route_name='rb-gateway', rate_limiting_config=config
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            rate_limiting_config=config,
         )
         assert limiter.limiter is not None
 
@@ -42,12 +48,18 @@ class TestRequestRateLimiter:
         with pytest.raises(
             ValueError, match='max_requests must be set for rate limiting'
         ):
-            RequestRateLimiter(route_name='rb-gateway', rate_limiting_config=config)
+            RequestRateLimiter(
+                project_uuid=_PROJECT_UUID,
+                route_name='rb-gateway',
+                rate_limiting_config=config,
+            )
 
     @pytest.mark.asyncio
     async def test_check_request_no_config(self):
         """Test request checking without configuration does nothing."""
-        limiter = RequestRateLimiter(route_name='rb-gateway')
+        limiter = RequestRateLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway'
+        )
         # Should not raise any exception
         await limiter._check_request(
             request_uuid=str(REQUEST_UUID),
@@ -64,7 +76,9 @@ class TestRequestRateLimiter:
         """Test request checking within limit, and then count_request consumes."""
         config = RateLimiting(max_requests=5, window_size='1 minute')
         limiter = RequestRateLimiter(
-            route_name='rb-gateway', rate_limiting_config=config
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            rate_limiting_config=config,
         )
 
         # check_request should NOT consume
@@ -88,7 +102,9 @@ class TestRequestRateLimiter:
         """Test request checking that exceeds the limit (check-only, no hit)."""
         config = RateLimiting(max_requests=2, window_size='1 minute')
         limiter = RequestRateLimiter(
-            route_name='rb-gateway', rate_limiting_config=config
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            rate_limiting_config=config,
         )
 
         # First request: check passes, then we consume
@@ -134,7 +150,9 @@ class TestRequestRateLimiter:
         """Test that consumption accumulates over multiple requests."""
         config = RateLimiting(max_requests=3, window_size='1 minute')
         limiter = RequestRateLimiter(
-            route_name='rb-gateway', rate_limiting_config=config
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            rate_limiting_config=config,
         )
 
         # First 2: check passes, then we consume via count_request
@@ -184,7 +202,9 @@ class TestRequestRateLimiter:
         with freeze_time(initial_datetime) as frozen_datetime:
             config = RateLimiting(max_requests=2, window_size='10 second')
             limiter = RequestRateLimiter(
-                route_name='rb-gateway', rate_limiting_config=config
+                project_uuid=_PROJECT_UUID,
+                route_name='rb-gateway',
+                rate_limiting_config=config,
             )
 
             # Use up limit
@@ -234,14 +254,18 @@ class TestRequestRateLimiter:
         # Test with string format
         config = RateLimiting(max_requests=100, window_size='1 minute')
         limiter = RequestRateLimiter(
-            route_name='rb-gateway', rate_limiting_config=config
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            rate_limiting_config=config,
         )
         assert limiter.limiter is not None
 
         # Test with per-second format
         config2 = RateLimiting(max_requests=100, window_size='100 seconds')
         limiter2 = RequestRateLimiter(
-            route_name='rb-gateway', rate_limiting_config=config2
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            rate_limiting_config=config2,
         )
         assert limiter2.limiter is not None
 
@@ -250,11 +274,11 @@ class TestProjectScoping:
     """Route names are unique only within a project, so keys must carry it."""
 
     @staticmethod
-    def _limiter(project_uuid: str = '') -> RequestRateLimiter:
+    def _limiter(project_uuid: str) -> RequestRateLimiter:
         return RequestRateLimiter(
+            project_uuid=project_uuid,
             route_name='default',
             rate_limiting_config=RateLimiting(max_requests=2, window_size='1 minute'),
-            project_uuid=project_uuid,
         )
 
     def test_project_uuid_scopes_the_key_but_not_the_route_name(self):
@@ -269,13 +293,15 @@ class TestProjectScoping:
             f'limiter:{project_uuid}:default:request_rate:'
         )
 
-    def test_omitted_project_uuid_keeps_the_unscoped_key(self):
-        limiter = self._limiter()
-
-        assert limiter.item.project_uuid == ''
-        assert limiter.limiter._build_key(limiter.item).startswith(
-            'limiter:default:request_rate:'
-        )
+    def test_project_uuid_is_mandatory(self):
+        """There is no unscoped window: the key always names a project."""
+        with pytest.raises(TypeError):
+            RequestRateLimiter(
+                route_name='default',
+                rate_limiting_config=RateLimiting(
+                    max_requests=2, window_size='1 minute'
+                ),
+            )
 
     @pytest.mark.asyncio
     async def test_two_projects_do_not_share_the_window(self):

--- a/gateway/tests/limiting/test_rate_limiter.py
+++ b/gateway/tests/limiting/test_rate_limiter.py
@@ -309,9 +309,10 @@ class TestProjectScoping:
         project_a = self._limiter('2f1c6d4e-0000-4000-8000-00000000000a')
         project_b = self._limiter('2f1c6d4e-0000-4000-8000-00000000000b')
         # Both limiters must talk to the same storage for the test to mean
-        # anything — in production that is the shared Redis.
-        project_b.storage = project_a.storage
+        # anything — in production that is the shared Redis. Only the limiter's
+        # own reference matters: self.storage is read once, during __init__.
         project_b.limiter._storage = project_a.limiter._storage
+        assert project_a.limiter._storage is project_b.limiter._storage
 
         args = {
             'request_uuid': str(REQUEST_UUID),

--- a/gateway/tests/limiting/test_rate_limiter.py
+++ b/gateway/tests/limiting/test_rate_limiter.py
@@ -244,3 +244,65 @@ class TestRequestRateLimiter:
             route_name='rb-gateway', rate_limiting_config=config2
         )
         assert limiter2.limiter is not None
+
+
+class TestProjectScoping:
+    """Route names are unique only within a project, so keys must carry it."""
+
+    @staticmethod
+    def _limiter(project_uuid: str = '') -> RequestRateLimiter:
+        return RequestRateLimiter(
+            route_name='default',
+            rate_limiting_config=RateLimiting(max_requests=2, window_size='1 minute'),
+            project_uuid=project_uuid,
+        )
+
+    def test_project_uuid_scopes_the_key_but_not_the_route_name(self):
+        """Telemetry keeps reporting the bare route; only the key is scoped."""
+        project_uuid = '2f1c6d4e-0000-4000-8000-00000000000a'
+        limiter = self._limiter(project_uuid)
+
+        assert limiter.route_name == 'default'
+        assert limiter.item.route_name == 'default'
+        assert limiter.item.project_uuid == project_uuid
+        assert limiter.limiter._build_key(limiter.item).startswith(
+            f'limiter:{project_uuid}:default:request_rate:'
+        )
+
+    def test_omitted_project_uuid_keeps_the_unscoped_key(self):
+        limiter = self._limiter()
+
+        assert limiter.item.project_uuid == ''
+        assert limiter.limiter._build_key(limiter.item).startswith(
+            'limiter:default:request_rate:'
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_projects_do_not_share_the_window(self):
+        """Regression for the cross-project window collision."""
+        project_a = self._limiter('2f1c6d4e-0000-4000-8000-00000000000a')
+        project_b = self._limiter('2f1c6d4e-0000-4000-8000-00000000000b')
+        # Both limiters must talk to the same storage for the test to mean
+        # anything — in production that is the shared Redis.
+        project_b.storage = project_a.storage
+        project_b.limiter._storage = project_a.limiter._storage
+
+        args = {
+            'request_uuid': str(REQUEST_UUID),
+            'api_key_uuid': str(API_KEY_UUID),
+            'group_uuid': str(GROUP_UUID),
+            'api_key_name': 'fake-name',
+            'group_name': 'test-group',
+        }
+
+        # Exhaust project A's allowance of 2.
+        await project_a.check_and_count_request(**args)
+        await project_a.check_and_count_request(**args)
+        with pytest.raises(RequestRateLimitExceeded):
+            await project_a.check_and_count_request(**args)
+
+        # Project B, same route name, is untouched.
+        await project_b.check_and_count_request(**args)
+        await project_b.check_and_count_request(**args)
+        with pytest.raises(RequestRateLimitExceeded):
+            await project_b.check_and_count_request(**args)

--- a/gateway/tests/limiting/test_token_limiter.py
+++ b/gateway/tests/limiting/test_token_limiter.py
@@ -15,6 +15,8 @@ from radicalbit_ai_gateway.limiting.token_limiter import (
 )
 from radicalbit_ai_gateway.models.limiting import Limiting, LimitingAlgorithmType
 
+_PROJECT_UUID = '2f1c6d4e-0000-4000-8000-0000000000aa'
+
 TEST_MODEL = 'openai/gpt-4o'
 
 
@@ -48,7 +50,7 @@ def emit_notification_mock(mock_emit_functions):
 class TestTokenLimiter:
     def test_init_without_config(self):
         """Test TokenLimiter initialization without any configuration."""
-        limiter = TokenLimiter(route_name='rb-gateway')
+        limiter = TokenLimiter(project_uuid=_PROJECT_UUID, route_name='rb-gateway')
         assert limiter.input_limiter is None
         assert limiter.output_limiter is None
 
@@ -59,7 +61,11 @@ class TestTokenLimiter:
             window_size='1 minute',
             max_tokens=1000,
         )
-        limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            input_config=input_config,
+        )
         assert limiter.input_limiter is not None
         assert limiter.output_limiter is None
 
@@ -70,7 +76,11 @@ class TestTokenLimiter:
             window_size='30 seconds',
             max_tokens=500,
         )
-        limiter = TokenLimiter(route_name='rb-gateway', output_config=output_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            output_config=output_config,
+        )
         assert limiter.input_limiter is None
         assert limiter.output_limiter is not None
 
@@ -79,6 +89,7 @@ class TestTokenLimiter:
         input_config = Limiting(max_tokens=1000, window_size='1 minute')
         output_config = Limiting(max_tokens=500, window_size='30 seconds')
         limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
             route_name='rb-gateway',
             input_config=input_config,
             output_config=output_config,
@@ -92,12 +103,14 @@ class TestTokenLimiter:
         with pytest.raises(
             ValueError, match='max_tokens must be set for token limiting'
         ):
-            TokenLimiter(route_name='rb-gateway', input_config=config)
+            TokenLimiter(
+                project_uuid=_PROJECT_UUID, route_name='rb-gateway', input_config=config
+            )
 
     @pytest.mark.asyncio
     async def test_check_input_no_config(self):
         """Test input checking without configuration does nothing."""
-        limiter = TokenLimiter(route_name='rb-gateway')
+        limiter = TokenLimiter(project_uuid=_PROJECT_UUID, route_name='rb-gateway')
         # Should not raise any exception
         await limiter.check_input(
             request_uuid=str(REQUEST_UUID),
@@ -115,7 +128,11 @@ class TestTokenLimiter:
     async def test_check_input_within_limit_and_count_consumes(self):
         """Test input checking within limit, and then count_input consumes window."""
         input_config = Limiting(max_tokens=100, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            input_config=input_config,
+        )
 
         # Make token estimation deterministic
         with patch(
@@ -148,7 +165,11 @@ class TestTokenLimiter:
     async def test_check_input_exceeds_limit(self):
         """Test input checking that exceeds the token limit (check-only, no hit)."""
         input_config = Limiting(max_tokens=10, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            input_config=input_config,
+        )
 
         # Deterministic token count so we can assert attempted
         with (
@@ -185,7 +206,11 @@ class TestTokenLimiter:
     async def test_input_accumulates_over_multiple_calls(self):
         """Test that consumption accumulates over multiple provider invocations."""
         input_config = Limiting(max_tokens=20, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            input_config=input_config,
+        )
 
         # token estimate sequence for check_input calls
         # 6 + 6 + 6 = 18 (consumed), next attempted 8 => test should fail (> 20)
@@ -252,7 +277,7 @@ class TestTokenLimiter:
     @pytest.mark.asyncio
     async def test_count_output_no_config(self):
         """Test output counting without configuration does nothing."""
-        limiter = TokenLimiter(route_name='rb-gateway')
+        limiter = TokenLimiter(project_uuid=_PROJECT_UUID, route_name='rb-gateway')
         # Should not raise any exception
         await limiter.count_output(
             token_count=100,
@@ -269,7 +294,11 @@ class TestTokenLimiter:
     async def test_count_output_within_limit(self):
         """Test output counting within the token limit."""
         output_config = Limiting(max_tokens=100, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', output_config=output_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            output_config=output_config,
+        )
 
         # Should be within limit
         await limiter.count_output(
@@ -287,7 +316,11 @@ class TestTokenLimiter:
     async def test_count_output_exceeds_limit(self):
         """Test output counting that exceeds the token limit."""
         output_config = Limiting(max_tokens=50, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', output_config=output_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            output_config=output_config,
+        )
 
         await limiter.count_output(
             token_count=100,
@@ -317,7 +350,11 @@ class TestTokenLimiter:
     async def test_count_output_accumulates(self):
         """Test that output token counting accumulates over multiple calls."""
         output_config = Limiting(max_tokens=100, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', output_config=output_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            output_config=output_config,
+        )
 
         initial_datetime = datetime.datetime(
             year=2025, month=6, day=25, hour=15, minute=0, second=0
@@ -373,7 +410,11 @@ class TestTokenLimiter:
                 max_tokens=5,
                 window_size='10 second',
             )
-            limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+            limiter = TokenLimiter(
+                project_uuid=_PROJECT_UUID,
+                route_name='rb-gateway',
+                input_config=input_config,
+            )
 
             # Deterministic token estimation for the 4 check_input calls:
             # 1) first allowed and consumed = 4 -> remaining becomes 1
@@ -462,12 +503,16 @@ class TestTokenLimiter:
         """Test different window size formats."""
         # Test with string format
         config2 = Limiting(max_tokens=100, window_size='1 minute')
-        limiter2 = TokenLimiter(route_name='rb-gateway', input_config=config2)
+        limiter2 = TokenLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', input_config=config2
+        )
         assert limiter2.input_limiter is not None
 
         # Test with per-second format
         config3 = Limiting(max_tokens=100, window_size='100 seconds')
-        limiter3 = TokenLimiter(route_name='rb-gateway', input_config=config3)
+        limiter3 = TokenLimiter(
+            project_uuid=_PROJECT_UUID, route_name='rb-gateway', input_config=config3
+        )
         assert limiter3.input_limiter is not None
 
     def test_init_with_aligned_fixed_window(self):
@@ -477,7 +522,11 @@ class TestTokenLimiter:
             window_size='1 minute',
             max_tokens=1000,
         )
-        limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            input_config=input_config,
+        )
         assert limiter.input_limiter is not None
         assert isinstance(limiter.input_limiter, AlignedFixedWindowLimiter)
 
@@ -488,7 +537,11 @@ class TestTokenLimiter:
             window_size='1 minute',
             max_tokens=1000,
         )
-        limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            input_config=input_config,
+        )
         assert limiter.input_limiter is not None
         assert isinstance(limiter.input_limiter, FixedWindowLimiter)
 
@@ -496,7 +549,11 @@ class TestTokenLimiter:
     async def test_count_input_sends_notification(self, emit_notification_mock):
         """Test that count_input sends notification with correct parameters after deduction."""
         input_config = Limiting(max_tokens=100, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', input_config=input_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            input_config=input_config,
+        )
 
         await limiter.count_input(prompt_tokens=42)
 
@@ -515,7 +572,11 @@ class TestTokenLimiter:
     async def test_count_output_sends_notification(self, emit_notification_mock):
         """Test that count_output sends notification with correct parameters after deduction."""
         output_config = Limiting(max_tokens=50, window_size='1 minute')
-        limiter = TokenLimiter(route_name='rb-gateway', output_config=output_config)
+        limiter = TokenLimiter(
+            project_uuid=_PROJECT_UUID,
+            route_name='rb-gateway',
+            output_config=output_config,
+        )
 
         await limiter.count_output(token_count=17)
 

--- a/gateway/tests/utils/test_gateway_route_factory.py
+++ b/gateway/tests/utils/test_gateway_route_factory.py
@@ -101,6 +101,74 @@ def test_build_gateway_routes_from_config_keys():
     assert isinstance(routes['my-route'], GatewayRoute)
 
 
+_PROJECT_CONFIG_WITH_LIMITS_YAML = """\
+chat_models:
+  - model_id: openai-gpt4o
+    model: openai/gpt-4o-mini
+    credentials:
+      api_key: sk-test-key
+routes:
+  my-route:
+    chat_models:
+      - openai-gpt4o
+    rate_limiting:
+      max_requests: 10
+      window_size: 1 minute
+    token_limiting:
+      input:
+        max_token: 1000
+      output:
+        max_token: 500
+    budget_limiting:
+      max_budget: 5.0
+"""
+
+
+def _build_limited_routes(project_uuid: str = ''):
+    resolved = resolve_secrets_from_string(_PROJECT_CONFIG_WITH_LIMITS_YAML)
+    config = GatewayConfig.model_validate(resolved)
+    return build_gateway_routes_from_config(
+        config,
+        guardrail_engine=_make_guardrail_engine(),
+        redis_client=None,
+        cost_service=MagicMock(spec_set=CostService),
+        httpx_client=None,
+        project_uuid=project_uuid,
+    )
+
+
+def test_build_gateway_routes_scopes_every_limiter_by_project():
+    """Step 3: the project reaches all four limiter windows.
+
+    Route names are unique only within a project, so an unscoped key makes two
+    projects declaring 'my-route' share one window.
+    """
+    project_uuid = '2f1c6d4e-0000-4000-8000-00000000000a'
+    route = _build_limited_routes(project_uuid)['my-route']
+
+    items = [
+        route.request_rate_limiter.item,
+        route.token_limiter.input_item,
+        route.token_limiter.output_item,
+        route.budget_limiter.item,
+    ]
+    assert all(item is not None for item in items)
+    for item in items:
+        assert item.project_uuid == project_uuid
+        # The bare route name is what metrics, limit events and logs report.
+        assert item.route_name == 'my-route'
+
+
+def test_build_gateway_routes_without_project_leaves_limiters_unscoped():
+    """The default keeps the pre-fix key format for call sites with no project."""
+    route = _build_limited_routes()['my-route']
+
+    assert route.request_rate_limiter.item.project_uuid == ''
+    assert route.token_limiter.input_item.project_uuid == ''
+    assert route.token_limiter.output_item.project_uuid == ''
+    assert route.budget_limiter.item.project_uuid == ''
+
+
 _PROJECT_CONFIG_WITH_TRANSCRIPTION_YAML = """\
 chat_models:
   - model_id: openai-gpt4o

--- a/gateway/tests/utils/test_gateway_route_factory.py
+++ b/gateway/tests/utils/test_gateway_route_factory.py
@@ -38,6 +38,8 @@ from radicalbit_ai_gateway.utils.gateway_route_factory import (
 )
 from radicalbit_ai_gateway.utils.secrets import resolve_secrets_from_string
 
+_PROJECT_UUID = '2f1c6d4e-0000-4000-8000-0000000000aa'
+
 # Minimal config with a literal api_key (no !secret refs needed here —
 # secret resolution is already covered in test_secrets.py).
 _PROJECT_CONFIG_YAML = """\
@@ -95,6 +97,7 @@ def test_build_gateway_routes_from_config_keys():
         redis_client=None,
         cost_service=cost_service,
         httpx_client=None,
+        project_uuid=_PROJECT_UUID,
     )
 
     assert set(routes.keys()) == {'my-route'}
@@ -204,6 +207,7 @@ def test_build_gateway_routes_from_config_resolves_transcription_models():
         redis_client=None,
         cost_service=cost_service,
         httpx_client=None,
+        project_uuid=_PROJECT_UUID,
     )
 
     route = routes['my-route']
@@ -226,6 +230,7 @@ def test_build_gateway_routes_from_config_wires_transcription_invoker():
         redis_client=None,
         cost_service=cost_service,
         httpx_client=None,
+        project_uuid=_PROJECT_UUID,
     )
 
     route = routes['my-route']
@@ -267,6 +272,7 @@ def test_build_gateway_routes_from_config_transcription_only_route():
         redis_client=None,
         cost_service=cost_service,
         httpx_client=None,
+        project_uuid=_PROJECT_UUID,
     )
 
     route = routes['transcription-only-route']
@@ -284,6 +290,7 @@ def test_build_gateway_routes_empty_config():
         redis_client=None,
         cost_service=MagicMock(spec_set=CostService),
         httpx_client=None,
+        project_uuid=_PROJECT_UUID,
     )
     assert routes == {}
 
@@ -314,6 +321,7 @@ async def test_project_route_full_pipeline(mock_emit_event, fake_redis_client):
         redis_client=None,
         cost_service=cost_service,
         httpx_client=None,
+        project_uuid=_PROJECT_UUID,
     )
 
     project_name = 'my-project'

--- a/gateway/tests/utils/test_gateway_route_factory.py
+++ b/gateway/tests/utils/test_gateway_route_factory.py
@@ -127,7 +127,7 @@ routes:
 """
 
 
-def _build_limited_routes(project_uuid: str = ''):
+def _build_limited_routes(project_uuid: str):
     resolved = resolve_secrets_from_string(_PROJECT_CONFIG_WITH_LIMITS_YAML)
     config = GatewayConfig.model_validate(resolved)
     return build_gateway_routes_from_config(
@@ -162,14 +162,27 @@ def test_build_gateway_routes_scopes_every_limiter_by_project():
         assert item.route_name == 'my-route'
 
 
-def test_build_gateway_routes_without_project_leaves_limiters_unscoped():
-    """The default keeps the pre-fix key format for call sites with no project."""
-    route = _build_limited_routes()['my-route']
+def test_build_gateway_routes_gives_each_project_its_own_keys():
+    """Two projects declaring the same route must not collide in storage."""
+    routes_a = _build_limited_routes('2f1c6d4e-0000-4000-8000-00000000000a')
+    routes_b = _build_limited_routes('2f1c6d4e-0000-4000-8000-00000000000b')
 
-    assert route.request_rate_limiter.item.project_uuid == ''
-    assert route.token_limiter.input_item.project_uuid == ''
-    assert route.token_limiter.output_item.project_uuid == ''
-    assert route.budget_limiter.item.project_uuid == ''
+    def keys(routes):
+        route = routes['my-route']
+        limiter = route.request_rate_limiter.limiter
+        return {
+            limiter._build_key(item)
+            for item in (
+                route.request_rate_limiter.item,
+                route.token_limiter.input_item,
+                route.token_limiter.output_item,
+                route.budget_limiter.item,
+            )
+        }
+
+    keys_a, keys_b = keys(routes_a), keys(routes_b)
+    assert len(keys_a) == 4
+    assert keys_a.isdisjoint(keys_b)
 
 
 _PROJECT_CONFIG_WITH_TRANSCRIPTION_YAML = """\


### PR DESCRIPTION
## Summary

Limiter windows were keyed by the bare route name, so two projects that each declared a route with the same name (`default`, `chat`, `production`) shared a single counter in Redis and one tenant's traffic consumed the other's quota. This PR adds the owning project's UUID to the limiter storage key, making all four limit windows per-project. Fixes AG-929.

---

## DTO Changes

**None.** No Pydantic model field was added, removed, or retyped, so no request or response body changes shape. `models/gateway_route_config.py` is touched, but only in its three internal `get_*_limiter()` factory methods — `GatewayRouteConfig`'s serialized fields are untouched.

---

## Affected Endpoints

**None.** Nothing under `routes/` or `server.py` changed. Every endpoint keeps its current path, parameters, and response schema.

The change is observable at runtime, not in the contract: a route declaring `rate_limiting`, `token_limiting`, or `budget_limiting` now counts against a window scoped to its project, so an HTTP 429 that previously fired because of a *different* project's traffic no longer does.

---

## Behaviour Change

### Redis key format

```diff
- limiter:{route_name}:{scenario_type}:{window_type}:{window_seconds}
+ limiter:{project_uuid}:{route_name}:{scenario_type}:{window_type}:{window_seconds}
```

**Before:** `limiter:default:request_rate:fixed:60`
**After:** `limiter:2f1c6d4e-0000-4000-8000-00000000000a:default:request_rate:fixed:60`

Applies to all four scenario types, since `BaseFixedWindowLimiter._build_key` is the only key producer:

| Limit | Scenario segment | Class |
|-------|------------------|-------|
| Request rate | `request_rate` | `RequestRateLimiter` |
| Input tokens | `token_input` | `TokenLimiter` |
| Output tokens | `token_output` | `TokenLimiter` |
| Budget | `budget` | `BudgetLimiter` |

**Only affects Redis-backed deployments.** Without `redis_url`, each limiter allocates its own `InMemoryStorage`, so no keyspace was ever shared.

**Caching is unaffected.** Cache keys are `response:aigateway:cache:{route_name}:{key_uuid}:{hash}` and already isolate by API key, which belongs to exactly one project.

### Deploy-time window reset — needs a rollout decision

Because the key format changes, every in-flight window is orphaned at rollout and expires on its own TTL. Each project starts its next window empty, which hands back whatever budget was already spent in the current window.

The blast radius scales with `window_size`: seconds or minutes for typical rate limits, but up to 30 days for a `1 month` budget window. Before deploying, either seed the new key from the legacy one, or roll deliberately and accept the reset — and check whether any tenant currently has a `week`/`month` budget window in effect.

---

## Breaking Internal API

These are exported from the `radicalbit_ai_gateway` package, so any out-of-tree caller must be updated. All in-repo call sites already are.

### Limiter constructors (MODIFIED)

```diff
- RequestRateLimiter(route_name, rate_limiting_config=None)
+ RequestRateLimiter(project_uuid, route_name, rate_limiting_config=None)

- TokenLimiter(route_name, input_config=None, output_config=None)
+ TokenLimiter(project_uuid, route_name, input_config=None, output_config=None)

- BudgetLimiter(route_name, config=None)
+ BudgetLimiter(project_uuid, route_name, config=None)
```

`project_uuid` is inserted **first**, matching the key layout. Note that a pre-existing two-positional-argument call such as `RequestRateLimiter('my-route', config)` still binds successfully — `route_name` receives the config object and `rate_limiting_config` stays `None` — which leaves limiting silently disabled rather than raising. Callers using keyword arguments are unaffected.

### `WindowConfig` (MODIFIED)

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `limit` | integer | yes | Maximum allowed in the window |
| `window_seconds` | integer | yes | Window duration in seconds |
| `project_uuid` **NEW** | string | yes | UUID of the owning project; key isolation only |
| `route_name` | string | yes | Route name |
| `scenario_type` | enum | yes | One of: `request_rate`, `token_input`, `token_output`, `budget` |

`project_uuid` is the third of five positional fields, so positional construction shifts: `WindowConfig(10, 60, 'my-route', ScenarioType.REQUEST_RATE)` now raises an arity error. `WindowConfig.from_parts()` takes it in the same position.

There is no default and no validation, so `project_uuid=''` is still constructible and produces a malformed `limiter::my-route:...` key — neither the scoped nor the legacy format.

### Other signatures (MODIFIED)

```diff
- GatewayRouteConfig.get_token_limiter()
+ GatewayRouteConfig.get_token_limiter(project_uuid)

- GatewayRouteConfig.get_budget_limiter()
+ GatewayRouteConfig.get_budget_limiter(project_uuid)

- GatewayRouteConfig.get_rate_limiter()
+ GatewayRouteConfig.get_rate_limiter(project_uuid)

- build_gateway_routes_from_config(config, guardrail_engine, redis_client, cost_service, httpx_client)
+ build_gateway_routes_from_config(config, guardrail_engine, redis_client, cost_service, httpx_client, project_uuid)
```

`project_uuid` is required on `build_gateway_routes_from_config` — deliberately, so a future route-building path cannot silently fall back to an unscoped key. Its single production caller, `build_project_route_registrar`, already holds the value.

---

## Known Gaps

Tracked rather than fixed here:

- **Alerts and metrics are not project-aware.** `emit_notification` (`token_limiter.py`) and the three OTel limit counters still identify a window by bare route name, so two projects with a route named `default` now produce two indistinguishable "route default at 80%" alerts, and one metric series covers both. Tracked as **AG-930**.
- **`GatewayRoute` project identity is still patched post-construction.** The factory has `project_uuid` in scope but does not pass it to the `GatewayRoute` constructor; `build_project_route_registrar` assigns it afterwards. A direct caller of the builder gets project-scoped limiters on a route that reports `project_uuid=''` in its event payloads.
- **Project deregistration does not reclaim `limiter:{uuid}:*`.** Previously keys were reused when a project was recreated; now a deleted project's keyspace is orphaned until TTL.

---

## Other Changes

- `limiter/base.py` — `_build_key` interpolates the project segment; docstring documents the format and the empty-string caveat.
- `limiter/window_config.py` — `project_uuid` field plus `from_parts` passthrough.
- `limiting/rate_limiter.py`, `token_limiter.py`, `budget_limiting.py` — `project_uuid` threaded to each `_create_item`. Stored as a separate attribute so `route_name` stays the bare route in metrics labels, `LimitEventPayload`, and log lines; dashboards are unaffected.
- `utils/gateway_route_factory.py` — `project_uuid` threaded to all three limiter builders; `uuid_str` computed before the build call.
- `utils/gateway_route_factory.py` — **unrelated typing fix:** `redis.Redis | None` → `redis.asyncio.Redis | None` on `get_proper_cache` and `build_gateway_routes_from_config`. The async client was always the one passed (`redis.asyncio.Redis` is constructed in the registrar) and both cache consumers import `from redis.asyncio import Redis`, so the old annotation was simply wrong. Worth reviewing separately from the limiter work.
- Tests — 67 constructions updated for the new argument across 7 files, plus new coverage: scoped key format per limiter type, distinct keys for the same route name in two projects, independent windows against shared storage, and a factory assertion that all four limiter items carry the project.

### Uncommitted in the working tree

Test-quality and documentation only, no API impact:

- `_build_key`'s docstring no longer claims the project segment is omitted when empty — it never was.
- Three tests whose names and docstrings described an "unscoped" path that no longer exists were renamed or replaced; `_build_limited_routes()` lost its `project_uuid=''` default.
- A no-op `project_b.storage = ...` assignment in the cross-project test was removed, replaced with an assertion that the two limiters genuinely share storage.

---

**Test suite:** 1754 passed, ruff clean.


## Linked Issue
Closes #123

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [x] Tests pass (locally/CI)
- [x] Lint/build pass
- [x] No secrets committed
- [ ] Docs updated (if needed)
