### PR TITLE
feat: add filter for tag in traces

### DIFF
--- a/gateway/radicalbit_ai_gateway/auth/request_auth.py
+++ b/gateway/radicalbit_ai_gateway/auth/request_auth.py
@@ -6,6 +6,7 @@ from radicalbit_ai_gateway.middleware.request_event_context import RequestEventC
 from radicalbit_ai_gateway.models.auth_dto import KeyDetails
 from radicalbit_ai_gateway.services.group_service import GroupService
 from radicalbit_ai_gateway.utils.exceptions import InvalidApiKey, MissingApiKey
+from radicalbit_ai_gateway.utils.request_context import get_current_request_tags
 from radicalbit_ai_gateway.utils.trace_attributes import set_trace_attributes
 
 
@@ -42,6 +43,7 @@ async def authenticate_bearer_request(
         group_name=key_details.group_name,
         project_uuid=project_uuid,
         project_name=project_name,
+        tags=list(get_current_request_tags()),
     )
     return key_details
 

--- a/gateway/radicalbit_ai_gateway/db/dao/otel_traces_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/otel_traces_dao.py
@@ -7,6 +7,7 @@ from fastapi_pagination.ext.sqlalchemy import paginate
 from sqlalchemy import Row, func as F, literal_column, select, text
 
 from radicalbit_ai_gateway.db.clickhouse_database import ClickHouseDatabase
+from radicalbit_ai_gateway.db.dao.tags_filter import add_tags_filter
 from radicalbit_ai_gateway.db.models.trace import (
     CategoryLatencies,
     CategorySpanLatencies,
@@ -36,6 +37,11 @@ _TOTAL_TOKENS_ATTR = "SpanAttributes['llm.usage.total_tokens']"
 _OPERATION_CATEGORY_ATTR = (
     "SpanAttributes['traceloop.association.properties.rb.gateway.operation_category']"
 )
+_TAGS_ATTR = "SpanAttributes['traceloop.association.properties.tags']"
+# Tags are stamped as one comma-joined "key=value,..." string (see
+# set_trace_attributes) since SpanAttributes values are scalar - splitByChar
+# turns it back into the Array(String) shape `add_tags_filter` expects.
+_TAGS_EXPR = f"if({_TAGS_ATTR} = '', [], splitByChar(',', {_TAGS_ATTR}))"
 
 _FIELD_NAMES = ['span_name', 'p50', 'p90', 'p95', 'p99']
 _SPAN_FIELD_NAMES = [
@@ -56,6 +62,7 @@ _SPAN_FIELD_NAMES = [
     'output_tokens',
     'input_tokens',
     'total_tokens',
+    'tags',
 ]
 _SPAN_DETAIL_FIELD_NAMES = [
     'timestamp',
@@ -116,12 +123,18 @@ class OtelTracesDAO:
         self.db = database
         self.T = OtelTraces.__table__
 
+    def _add_tags_filter(self, conditions: list, tags: list[str] | None) -> None:
+        add_tags_filter(
+            conditions, F.splitByChar(',', literal_column(_TAGS_ATTR)), tags=tags
+        )
+
     def get_span_latencies(
         self,
         project_uuid: UUID,
         route_names: list[str] | None,
         _from: datetime | None,
         _to: datetime | None,
+        tags: list[str] | None = None,
     ) -> list[SpanLatencies]:
         T = self.T
         conditions = [literal_column(_PROJECT_UUID_ATTR) == str(project_uuid)]
@@ -132,6 +145,7 @@ class OtelTracesDAO:
             conditions.append(T.c['Timestamp'] <= _to)
         if route_names:
             conditions.append(literal_column(_ROUTE_NAME_ATTR).in_(route_names))
+        self._add_tags_filter(conditions, tags=tags)
 
         stmt = (
             select(
@@ -160,6 +174,7 @@ class OtelTracesDAO:
         route_names: list[str] | None,
         _from: datetime | None,
         _to: datetime | None,
+        tags: list[str] | None = None,
     ) -> list:
         T = self.T
         conditions = [literal_column(_PROJECT_UUID_ATTR) == str(project_uuid)]
@@ -169,6 +184,7 @@ class OtelTracesDAO:
             conditions.append(T.c['Timestamp'] <= _to)
         if route_names:
             conditions.append(literal_column(_ROUTE_NAME_ATTR).in_(route_names))
+        self._add_tags_filter(conditions, tags=tags)
         return conditions
 
     def _build_category_expr(self, include_others: bool, conditions: list) -> tuple:
@@ -187,9 +203,10 @@ class OtelTracesDAO:
         _from: datetime | None,
         _to: datetime | None,
         include_others: bool = False,
+        tags: list[str] | None = None,
     ) -> list[CategoryLatencies]:
         conditions = self._build_time_route_conditions(
-            project_uuid, route_names, _from, _to
+            project_uuid, route_names, _from, _to, tags=tags
         )
         cat_col, group_expr, order_expr = self._build_category_expr(
             include_others, conditions
@@ -217,9 +234,10 @@ class OtelTracesDAO:
         _from: datetime | None,
         _to: datetime | None,
         include_others: bool = False,
+        tags: list[str] | None = None,
     ) -> list[CategorySpanLatencies]:
         conditions = self._build_time_route_conditions(
-            project_uuid, route_names, _from, _to
+            project_uuid, route_names, _from, _to, tags=tags
         )
         cat_col, group_expr, order_expr = self._build_category_expr(
             include_others, conditions
@@ -267,6 +285,7 @@ class OtelTracesDAO:
                 literal_column(_OUTPUT_TOKENS_ATTR).label('output_tokens'),
                 literal_column(_INPUT_TOKENS_ATTR).label('input_tokens'),
                 literal_column(_TOTAL_TOKENS_ATTR).label('total_tokens'),
+                literal_column(_TAGS_EXPR).label('tags'),
             )
             .select_from(OtelTraces)
             .where(
@@ -381,6 +400,7 @@ class OtelTracesDAO:
         _to: datetime | None,
         granularity: Literal['hours', 'days', 'weeks', 'months'],
         timezone_offset_seconds: int = 0,
+        tags: list[str] | None = None,
     ) -> list[TracesChartDataPoint]:
         """Get trace count data aggregated by time buckets from root spans.
 
@@ -422,6 +442,9 @@ class OtelTracesDAO:
                 F.anyIf(
                     literal_column(_ROUTE_NAME_ATTR), T.c['ParentSpanId'] == ''
                 ).label('route_name'),
+                F.anyIf(literal_column(_TAGS_ATTR), T.c['ParentSpanId'] == '').label(
+                    'tags_str'
+                ),
             )
             .select_from(OtelTraces)
             .where(*conditions)
@@ -433,6 +456,9 @@ class OtelTracesDAO:
         outer_conditions = [trace_agg.c.root_timestamp.isnot(None)]
         if route_names:
             outer_conditions.append(trace_agg.c.route_name.in_(route_names))
+        add_tags_filter(
+            outer_conditions, F.splitByChar(',', trace_agg.c.tags_str), tags=tags
+        )
 
         # Build bucket expression
         bucket_expr = with_timezone_offset(
@@ -494,6 +520,7 @@ class OtelTracesDAO:
         route_names: list[str] | None,
         _from: datetime | None,
         _to: datetime | None,
+        tags: list[str] | None = None,
     ) -> TraceLatencies:
         """Get trace latencies (in ms) from root spans."""
         T = self.T
@@ -510,6 +537,7 @@ class OtelTracesDAO:
             conditions.append(T.c['Timestamp'] >= _from)
         if _to is not None:
             conditions.append(T.c['Timestamp'] <= _to)
+        self._add_tags_filter(conditions, tags=tags)
 
         stmt = select(
             F.quantile(0.50, literal_column('Duration / 1000000')).label('p50'),
@@ -536,6 +564,7 @@ class OtelTracesDAO:
         _from: datetime | None,
         _to: datetime | None,
         params: Params,
+        tags: list[str] | None = None,
     ) -> Page[Row]:
         """Get paginated root spans with metadata."""
         T = self.T
@@ -557,6 +586,7 @@ class OtelTracesDAO:
                 api_key_uuid_attr.label('api_key_uuid'),
                 literal_column('Duration / 1000000').label('duration_ms'),
                 T.c['Timestamp'].label('created_at'),
+                literal_column(_TAGS_EXPR).label('tags'),
             )
             .select_from(OtelTraces)
             .where(
@@ -576,9 +606,16 @@ class OtelTracesDAO:
             stmt = stmt.where(T.c['Timestamp'] >= _from)
         if _to is not None:
             stmt = stmt.where(T.c['Timestamp'] <= _to)
+        tags_conditions: list = []
+        self._add_tags_filter(tags_conditions, tags=tags)
+        if tags_conditions:
+            stmt = stmt.where(*tags_conditions)
 
         with self.db.begin_session() as session:
-            return paginate(session, stmt, params)
+            # unique=False: rows now include the `tags` array column, which
+            # isn't hashable, so paginate()'s default row-dedup can't run.
+            # Every row is already unique (TraceId is unique per root span).
+            return paginate(session, stmt, params, unique=False)
 
     def get_spans_stats_by_trace_ids(
         self,

--- a/gateway/radicalbit_ai_gateway/db/models/trace.py
+++ b/gateway/radicalbit_ai_gateway/db/models/trace.py
@@ -94,6 +94,7 @@ class SpanRecord(BaseModel):
     output_tokens: str | None = None
     input_tokens: str | None = None
     total_tokens: str | None = None
+    tags: list[str] = Field(default_factory=list)
     # Additional fields for span detail
     span_attributes: dict = Field(default_factory=dict)
     status_message: str | None = None

--- a/gateway/radicalbit_ai_gateway/models/trace_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/trace_dto.py
@@ -50,6 +50,7 @@ class TraceDTO(BaseModel):
     api_key_name: str | None = None
     group_uuid: UUID | None = None
     group_name: str | None = None
+    tags: list[str] = Field(default_factory=list)
     tree: TreeNodeDTO | None = None  # Optional - only for detail view
 
     model_config = ConfigDict(

--- a/gateway/radicalbit_ai_gateway/routes/tracing_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/tracing_route.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Annotated, Union
 from uuid import UUID
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi_pagination import Page, Params
 
 from radicalbit_ai_gateway.models.trace_dto import (
@@ -16,6 +16,7 @@ from radicalbit_ai_gateway.models.trace_dto import (
 from radicalbit_ai_gateway.services.project_service import ProjectService
 from radicalbit_ai_gateway.services.tracing_service import TracingService
 from radicalbit_ai_gateway.utils.chart_utils import determine_granularity
+from radicalbit_ai_gateway.utils.request_tags import parse_tags_query
 
 
 class TracingRoute:
@@ -37,6 +38,7 @@ class TracingRoute:
             _from: Annotated[int | None, Query()] = None,
             _to: Annotated[int | None, Query()] = None,
             routes: Annotated[list[str] | None, Query()] = None,
+            tags: Annotated[list[str] | None, Depends(parse_tags_query)] = None,
         ):
             project_service.validate_exists(project_uuid)
             from_dt = datetime.fromtimestamp(_from, timezone.utc) if _from else None
@@ -48,6 +50,7 @@ class TracingRoute:
                 _from=from_dt,
                 _to=to_dt,
                 granularity=granularity,
+                tags=tags,
             )
 
         @router.get(
@@ -61,6 +64,7 @@ class TracingRoute:
             _from: Annotated[int | None, Query()] = None,
             _to: Annotated[int | None, Query()] = None,
             routes: Annotated[list[str] | None, Query()] = None,
+            tags: Annotated[list[str] | None, Depends(parse_tags_query)] = None,
         ):
             project_service.validate_exists(project_uuid)
             from_dt = datetime.fromtimestamp(_from, timezone.utc) if _from else None
@@ -70,6 +74,7 @@ class TracingRoute:
                 route_names=routes,
                 _from=from_dt,
                 _to=to_dt,
+                tags=tags,
             )
 
         @router.get(
@@ -85,6 +90,7 @@ class TracingRoute:
             routes: Annotated[list[str] | None, Query()] = None,
             grouped: Annotated[bool, Query()] = False,
             include_others: Annotated[bool, Query()] = False,
+            tags: Annotated[list[str] | None, Depends(parse_tags_query)] = None,
         ):
             project_service.validate_exists(project_uuid)
             from_dt = datetime.fromtimestamp(_from, timezone.utc) if _from else None
@@ -96,12 +102,14 @@ class TracingRoute:
                     _from=from_dt,
                     _to=to_dt,
                     include_others=include_others,
+                    tags=tags,
                 )
             return tracing_service.get_span_latencies(
                 project_uuid=project_uuid,
                 route_names=routes,
                 _from=from_dt,
                 _to=to_dt,
+                tags=tags,
             )
 
         @router.get(
@@ -119,6 +127,7 @@ class TracingRoute:
             keys: Annotated[list[UUID] | None, Query()] = None,
             _page: Annotated[int, Query(ge=1)] = 1,
             _limit: Annotated[int, Query(ge=1, le=100)] = 50,
+            tags: Annotated[list[str] | None, Depends(parse_tags_query)] = None,
         ):
             project_service.validate_exists(project_uuid)
             from_dt = datetime.fromtimestamp(_from, timezone.utc) if _from else None
@@ -132,6 +141,7 @@ class TracingRoute:
                 _from=from_dt,
                 _to=to_dt,
                 params=params,
+                tags=tags,
             )
 
         @router.get(

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -109,6 +109,7 @@ from radicalbit_ai_gateway.utils.open_ai_types import (
     TranscriptionCreateParamsCustom,
 )
 from radicalbit_ai_gateway.utils.request_context import (
+    get_current_request_tags,
     reset_route_context,
     set_current_route_config,
 )
@@ -446,7 +447,9 @@ def _set_early_project_trace_attributes(
     """
     if route is not None:
         set_trace_attributes(
-            project_uuid=route.project_uuid, project_name=route.project_name
+            project_uuid=route.project_uuid,
+            project_name=route.project_name,
+            tags=list(get_current_request_tags()),
         )
         return
     project_name, _, route_name_part = (route_key or '').partition('/')
@@ -456,9 +459,13 @@ def _set_early_project_trace_attributes(
             project_uuid=str(entry.uuid),
             project_name=project_name,
             route_name=route_name_part or route_key,
+            tags=list(get_current_request_tags()),
         )
     else:
-        set_trace_attributes(route_name=route_name_part or route_key)
+        set_trace_attributes(
+            route_name=route_name_part or route_key,
+            tags=list(get_current_request_tags()),
+        )
 
 
 @app.get('/health')
@@ -552,7 +559,11 @@ async def chat_completions(
     set_operation_category(OperationCategory.ENDPOINT)
 
     # Set early trace attributes
-    set_trace_attributes(request_uuid=request_uuid, route_name=route_name)
+    set_trace_attributes(
+        request_uuid=request_uuid,
+        route_name=route_name,
+        tags=list(get_current_request_tags()),
+    )
 
     ctx = RequestEventContext.get_or_create(request)
     ctx.route_name = route_name
@@ -570,6 +581,7 @@ async def chat_completions(
         group_name=key_details.group_name,
         project_uuid=route.project_uuid,
         project_name=route.project_name,
+        tags=list(get_current_request_tags()),
     )
 
     logger.debug('Chat completion request: %s', completion_create_params)
@@ -785,7 +797,11 @@ async def embeddings(
     set_operation_category(OperationCategory.ENDPOINT)
 
     # Set early trace attributes
-    set_trace_attributes(request_uuid=request_uuid, route_name=route_name)
+    set_trace_attributes(
+        request_uuid=request_uuid,
+        route_name=route_name,
+        tags=list(get_current_request_tags()),
+    )
 
     # Populate request event context first (before auth, so route_name is always captured)
     ctx = RequestEventContext.get_or_create(request)
@@ -806,6 +822,7 @@ async def embeddings(
         group_name=key_details.group_name,
         project_uuid=route.project_uuid,
         project_name=route.project_name,
+        tags=list(get_current_request_tags()),
     )
 
     if isinstance(input_texts, str):
@@ -868,7 +885,11 @@ async def audio_transcriptions(
     set_operation_category(OperationCategory.ENDPOINT)
 
     # Set early trace attributes
-    set_trace_attributes(request_uuid=request_uuid, route_name=route_name)
+    set_trace_attributes(
+        request_uuid=request_uuid,
+        route_name=route_name,
+        tags=list(get_current_request_tags()),
+    )
 
     # Populate request event context first (before auth, so route_name is always captured)
     ctx = RequestEventContext.get_or_create(request)
@@ -889,6 +910,7 @@ async def audio_transcriptions(
         group_name=key_details.group_name,
         project_uuid=route.project_uuid,
         project_name=route.project_name,
+        tags=list(get_current_request_tags()),
     )
 
     if not group_service.check_key_uuid_for_route(
@@ -1027,7 +1049,11 @@ async def responses(
     request.state.otel_route_name = route_name
 
     # Set early trace attributes
-    set_trace_attributes(request_uuid=request_uuid, route_name=route_name)
+    set_trace_attributes(
+        request_uuid=request_uuid,
+        route_name=route_name,
+        tags=list(get_current_request_tags()),
+    )
 
     ctx = RequestEventContext.get_or_create(request)
     ctx.route_name = route_name
@@ -1046,6 +1072,7 @@ async def responses(
         group_name=key_details.group_name,
         project_uuid=route.project_uuid,
         project_name=route.project_name,
+        tags=list(get_current_request_tags()),
     )
 
     instructions = response_create_params.get('instructions')

--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -24,6 +24,7 @@ from radicalbit_ai_gateway.models.project_entry import ProjectEntry
 from radicalbit_ai_gateway.services.group_service import GroupService
 from radicalbit_ai_gateway.utils.app_config import get_app_config
 from radicalbit_ai_gateway.utils.exceptions import McpTransportError
+from radicalbit_ai_gateway.utils.request_context import get_current_request_tags
 from radicalbit_ai_gateway.utils.trace_attributes import (
     OperationCategory,
     ensure_endpoint_category,
@@ -219,6 +220,7 @@ class McpService:
             project_uuid=project_uuid,
             project_name=project_name,
             route_name=route_name,
+            tags=list(get_current_request_tags()),
         )
         ctx = RequestEventContext.get_or_create(request)
         ctx.route_name = route_name

--- a/gateway/radicalbit_ai_gateway/services/tracing_service.py
+++ b/gateway/radicalbit_ai_gateway/services/tracing_service.py
@@ -77,6 +77,7 @@ class TracingService:
         _from: datetime | None,
         _to: datetime | None,
         granularity: Literal['hours', 'days', 'weeks', 'months'],
+        tags: list[str] | None = None,
     ) -> TracesChartDataDTO:
         _from_utc, _to_utc, timezone_offset_seconds = prepare_chart_time_range(
             _from, _to
@@ -89,6 +90,7 @@ class TracingService:
             _to_utc,
             granularity,
             timezone_offset_seconds,
+            tags=tags,
         )
         if not points:
             return TracesChartDataDTO(
@@ -138,9 +140,10 @@ class TracingService:
         route_names: list[str] | None,
         _from: datetime | None,
         _to: datetime | None,
+        tags: list[str] | None = None,
     ) -> LatenciesDTO:
         result = self.otel_traces_dao.get_latencies(
-            project_uuid, route_names, _from, _to
+            project_uuid, route_names, _from, _to, tags=tags
         )
         return LatenciesDTO(
             p50=result.p50, p90=result.p90, p95=result.p95, p99=result.p99
@@ -152,9 +155,10 @@ class TracingService:
         route_names: list[str] | None,
         _from: datetime | None,
         _to: datetime | None,
+        tags: list[str] | None = None,
     ) -> SpanLatenciesDTO:
         results = self.otel_traces_dao.get_span_latencies(
-            project_uuid, route_names, _from, _to
+            project_uuid, route_names, _from, _to, tags=tags
         )
         return SpanLatenciesDTO(
             data=[
@@ -176,12 +180,13 @@ class TracingService:
         _from: datetime | None,
         _to: datetime | None,
         include_others: bool = False,
+        tags: list[str] | None = None,
     ) -> GroupedSpanLatenciesDTO:
         category_results = self.otel_traces_dao.get_category_latencies(
-            project_uuid, route_names, _from, _to, include_others
+            project_uuid, route_names, _from, _to, include_others, tags=tags
         )
         span_results = self.otel_traces_dao.get_category_span_latencies(
-            project_uuid, route_names, _from, _to, include_others
+            project_uuid, route_names, _from, _to, include_others, tags=tags
         )
 
         spans_by_category: dict[str, list[SpanLatencyDTO]] = {}
@@ -306,6 +311,7 @@ class TracingService:
             api_key_name=key_name,
             group_uuid=resolved_group_uuid,
             group_name=group_name,
+            tags=root_span.tags,
             tree=tree,
         )
 
@@ -318,10 +324,18 @@ class TracingService:
         _from: datetime | None,
         _to: datetime | None,
         params: Params,
+        tags: list[str] | None = None,
     ) -> Page[TraceDTO]:
         # Get paginated traces - paginate() handles count query automatically
         traces_page = self.otel_traces_dao.get_root_traces_paginated(
-            project_uuid, route_names, group_uuids, key_uuids, _from, _to, params
+            project_uuid,
+            route_names,
+            group_uuids,
+            key_uuids,
+            _from,
+            _to,
+            params,
+            tags=tags,
         )
 
         if not traces_page.items:
@@ -377,6 +391,7 @@ class TracingService:
                     )
                     if resolved_group_uuid
                     else None,
+                    tags=row.tags,
                     duration_ms=row.duration_ms,
                     total_spans=stats.span_count if stats else 0,
                     error_count=error_count,

--- a/gateway/radicalbit_ai_gateway/utils/request_tags.py
+++ b/gateway/radicalbit_ai_gateway/utils/request_tags.py
@@ -2,7 +2,7 @@
 
 Comma-separated ``key=value`` pairs, e.g.::
 
-    X-RB-Tags: cost_center=retail,env=prod,app=leonardo-clm
+    X-RB-Tags: cost_center=retail,env=prod,app=my-app
 
 The header is gateway-owned: consumed by the request event middleware and
 never forwarded upstream. Tags are deduplicated and sorted, so header order

--- a/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
+++ b/gateway/radicalbit_ai_gateway/utils/trace_attributes.py
@@ -46,6 +46,7 @@ def set_trace_attributes(
     group_name: str | None = None,
     project_uuid: str | None = None,
     project_name: str | None = None,
+    tags: list[str] | None = None,
 ) -> None:
     properties = {
         'request_uuid': request_uuid,
@@ -56,6 +57,7 @@ def set_trace_attributes(
         'group_name': group_name,
         'project_uuid': project_uuid,
         'project_name': project_name,
+        'tags': ','.join(tags) if tags else None,
     }
     properties = {k: v for k, v in properties.items() if v is not None}
     if properties:

--- a/gateway/tests/dao/otel_traces_dao_test.py
+++ b/gateway/tests/dao/otel_traces_dao_test.py
@@ -1621,6 +1621,226 @@ class OtelTracesDAOTest(DatabaseIntegrationClickhouse):
         trace_ids = {r.trace_id for r in res.items}
         assert trace_ids == {'t1', 't4'}
 
+    def test_get_root_traces_returns_tags(self):
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        test_spans = [
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t1',
+                parent_span_id='',
+                span_attributes={
+                    'traceloop.association.properties.tags': 'env=prod,cost_center=retail'
+                },
+            ),
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t2',
+                parent_span_id='',
+                span_attributes={},
+            ),
+        ]
+        self.insert(test_spans)
+
+        res = self.otel_traces_dao.get_root_traces_paginated(
+            project_uuid=TEST_PROJECT_UUID,
+            route_names=None,
+            group_uuids=None,
+            key_uuids=None,
+            _from=None,
+            _to=None,
+            params=Params(page=1, size=10),
+        )
+
+        by_trace_id = {row.trace_id: row.tags for row in res.items}
+        assert by_trace_id['t1'] == ['env=prod', 'cost_center=retail']
+        assert by_trace_id['t2'] == []
+
+    def test_get_root_traces_filters_by_tags(self):
+        """Same key OR's, different keys AND (mirrors dashboard/usage semantics)."""
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        test_spans = [
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t1',
+                parent_span_id='',
+                span_attributes={
+                    'traceloop.association.properties.tags': 'env=prod,cost_center=retail'
+                },
+            ),
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t2',
+                parent_span_id='',
+                span_attributes={
+                    'traceloop.association.properties.tags': 'env=staging,cost_center=retail'
+                },
+            ),
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t3',
+                parent_span_id='',
+                span_attributes={
+                    'traceloop.association.properties.tags': 'env=prod,cost_center=marketing'
+                },
+            ),
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t4',
+                parent_span_id='',
+                span_attributes={},
+            ),
+        ]
+        self.insert(test_spans)
+
+        res = self.otel_traces_dao.get_root_traces_paginated(
+            project_uuid=TEST_PROJECT_UUID,
+            route_names=None,
+            group_uuids=None,
+            key_uuids=None,
+            _from=None,
+            _to=None,
+            params=Params(page=1, size=10),
+            tags=['env=prod', 'env=staging', 'cost_center=retail'],
+        )
+
+        # (env=prod OR env=staging) AND cost_center=retail -> t1, t2 only
+        trace_ids = {r.trace_id for r in res.items}
+        assert trace_ids == {'t1', 't2'}
+
+    def test_get_spans_by_trace_id_returns_tags(self):
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        self.insert(
+            [
+                db_mock.get_sample_otel_span(
+                    timestamp=base_time,
+                    trace_id='trace-tags',
+                    span_id='span-root',
+                    parent_span_id='',
+                    span_attributes={
+                        'traceloop.association.properties.tags': 'env=prod'
+                    },
+                )
+            ]
+        )
+
+        res = self.otel_traces_dao.get_spans_by_trace_id(
+            project_uuid=TEST_PROJECT_UUID, trace_id='trace-tags'
+        )
+
+        assert len(res) == 1
+        assert res[0].tags == ['env=prod']
+
+    def test_get_latencies_filters_by_tags(self):
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        test_spans = [
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t1',
+                parent_span_id='',
+                duration_ns=100 * 1_000_000,
+                span_attributes={'traceloop.association.properties.tags': 'env=prod'},
+            ),
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t2',
+                parent_span_id='',
+                duration_ns=999 * 1_000_000,
+                span_attributes={
+                    'traceloop.association.properties.tags': 'env=staging'
+                },
+            ),
+        ]
+        self.insert(test_spans)
+
+        res = self.otel_traces_dao.get_latencies(
+            project_uuid=TEST_PROJECT_UUID,
+            route_names=None,
+            _from=None,
+            _to=None,
+            tags=['env=prod'],
+        )
+
+        assert res.p50 == pytest.approx(100.0, abs=0.01)
+
+    def test_get_span_latencies_filters_by_tags(self):
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        test_spans = [
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                span_name='invoke',
+                duration_ns=100 * 1_000_000,
+                span_attributes={'traceloop.association.properties.tags': 'env=prod'},
+            ),
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                span_name='other',
+                duration_ns=999 * 1_000_000,
+                span_attributes={
+                    'traceloop.association.properties.tags': 'env=staging'
+                },
+            ),
+        ]
+        self.insert(test_spans)
+
+        res = self.otel_traces_dao.get_span_latencies(
+            project_uuid=TEST_PROJECT_UUID,
+            route_names=None,
+            _from=None,
+            _to=None,
+            tags=['env=prod'],
+        )
+
+        assert [r.span_name for r in res] == ['invoke']
+
+    def test_get_traces_chart_data_filters_by_tags(self):
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+
+        test_spans = [
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t1',
+                parent_span_id='',
+                span_attributes={'traceloop.association.properties.tags': 'env=prod'},
+            ),
+            db_mock.get_sample_otel_span(
+                timestamp=base_time,
+                trace_id='t2',
+                parent_span_id='',
+                span_attributes={
+                    'traceloop.association.properties.tags': 'env=staging'
+                },
+            ),
+        ]
+        self.insert(test_spans)
+
+        res = self.otel_traces_dao.get_traces_chart_data(
+            project_uuid=TEST_PROJECT_UUID,
+            route_names=None,
+            _from=base_time,
+            _to=base_time + datetime.timedelta(hours=1),
+            granularity='hours',
+            tags=['env=prod'],
+        )
+
+        assert sum(point.total_requests for point in res) == 1
+
     # --- get_spans_stats_by_trace_ids ---
 
     def test_get_spans_stats_by_trace_ids_empty_input(self):

--- a/gateway/tests/dao/request_event_tags_test.py
+++ b/gateway/tests/dao/request_event_tags_test.py
@@ -30,7 +30,7 @@ class RequestEventTagsTest(DatabaseIntegrationClickhouse):
                 db_mock.get_sample_request_event(
                     timestamp=TIMESTAMP,
                     project_uuid=PROJECT_A,
-                    tags=['app=leonardo-clm', 'cost_center=retail', 'env=prod'],
+                    tags=['app=my-app', 'cost_center=retail', 'env=prod'],
                 ),
                 db_mock.get_sample_request_event(
                     timestamp=TIMESTAMP,
@@ -69,13 +69,13 @@ class RequestEventTagsTest(DatabaseIntegrationClickhouse):
         stmt = (
             select(self.T.c['TAGS'])
             .select_from(RequestEvent)
-            .where(func.has(self.T.c['TAGS'], 'app=leonardo-clm'))
+            .where(func.has(self.T.c['TAGS'], 'app=my-app'))
         )
         with self.db.begin_session() as session:
             rows = session.execute(stmt).fetchall()
         assert len(rows) == 1
         assert list(rows[0][0]) == [
-            'app=leonardo-clm',
+            'app=my-app',
             'cost_center=retail',
             'env=prod',
         ]
@@ -91,7 +91,7 @@ class RequestEventTagsTest(DatabaseIntegrationClickhouse):
 
     def test_filter_by_any_of_several_tags(self):
         self._seed()
-        condition = func.hasAny(self.T.c['TAGS'], ['env=staging', 'app=leonardo-clm'])
+        condition = func.hasAny(self.T.c['TAGS'], ['env=staging', 'app=my-app'])
         assert self._count_where(condition) == 2
 
     def test_a_tag_matches_only_on_the_full_key_and_value(self):
@@ -110,7 +110,7 @@ class RequestEventTagsTest(DatabaseIntegrationClickhouse):
     def test_untagged_rows_never_match_a_filter(self):
         self._seed()
         condition = func.hasAny(
-            self.T.c['TAGS'], ['env=prod', 'env=staging', 'app=leonardo-clm']
+            self.T.c['TAGS'], ['env=prod', 'env=staging', 'app=my-app']
         )
         assert self._count_where(condition) == 3
 
@@ -126,7 +126,7 @@ class RequestEventTagsTest(DatabaseIntegrationClickhouse):
             tags = sorted(row[0] for row in session.execute(stmt).fetchall())
 
         assert tags == [
-            'app=leonardo-clm',
+            'app=my-app',
             'cost_center=retail',
             'env=prod',
             'env=staging',
@@ -148,7 +148,7 @@ class RequestEventTagsTest(DatabaseIntegrationClickhouse):
         self._seed()
         dao = RequestEventDAO(self.db)
         assert dao.get_distinct_tags(PROJECT_A) == [
-            'app=leonardo-clm',
+            'app=my-app',
             'cost_center=retail',
             'env=prod',
             'env=staging',

--- a/gateway/tests/routes/test_tracing_route.py
+++ b/gateway/tests/routes/test_tracing_route.py
@@ -153,6 +153,19 @@ class TestTracingRoute(unittest.TestCase):
         call_kwargs = self.tracing_service.get_latencies.call_args.kwargs
         assert set(call_kwargs['route_names']) == {_r('route-a'), _r('route-b')}
 
+    def test_get_latencies_with_tags_filter(self):
+        mock_latencies = LatenciesDTO(p50=120.0, p90=250.0, p95=310.0, p99=500.0)
+        self.tracing_service.get_latencies = MagicMock(return_value=mock_latencies)
+
+        response = self.client.get(
+            f'{self.project_path}/traces/latencies',
+            params={'tags': ['env=prod']},
+        )
+
+        assert response.status_code == 200
+        call_kwargs = self.tracing_service.get_latencies.call_args.kwargs
+        assert call_kwargs['tags'] == ['env=prod']
+
     def test_get_latencies_no_filters(self):
         mock_latencies = LatenciesDTO(p50=None, p90=None, p95=None, p99=None)
         self.tracing_service.get_latencies = MagicMock(return_value=mock_latencies)
@@ -187,6 +200,21 @@ class TestTracingRoute(unittest.TestCase):
         assert response.status_code == 200
         call_kwargs = self.tracing_service.get_traces_chart_data.call_args.kwargs
         assert call_kwargs['route_names'] == [_r('my-route')]
+
+    def test_get_traces_chart_data_with_tags_filter(self):
+        mock_chart = TracesChartDataDTO(
+            granularity='hours', timestamp=[], data=[], total=0
+        )
+        self.tracing_service.get_traces_chart_data = MagicMock(return_value=mock_chart)
+
+        response = self.client.get(
+            f'{self.project_path}/traces/chart',
+            params={'tags': ['env=prod']},
+        )
+
+        assert response.status_code == 200
+        call_kwargs = self.tracing_service.get_traces_chart_data.call_args.kwargs
+        assert call_kwargs['tags'] == ['env=prod']
 
     def test_get_span_latencies(self):
         base_time = datetime.datetime(
@@ -247,6 +275,21 @@ class TestTracingRoute(unittest.TestCase):
         assert call_kwargs['project_uuid'] == PROJECT_UUID
         assert call_kwargs['_from'] is None
         assert call_kwargs['_to'] is None
+
+    def test_get_span_latencies_with_tags_filter(self):
+        mock_span_latencies = SpanLatenciesDTO(data=[])
+        self.tracing_service.get_span_latencies = MagicMock(
+            return_value=mock_span_latencies
+        )
+
+        response = self.client.get(
+            f'{self.project_path}/traces/spans/latencies',
+            params={'tags': ['env=prod']},
+        )
+
+        assert response.status_code == 200
+        call_kwargs = self.tracing_service.get_span_latencies.call_args.kwargs
+        assert call_kwargs['tags'] == ['env=prod']
 
     def test_get_span_latencies_single_route(self):
         mock_span_latencies = SpanLatenciesDTO(
@@ -883,6 +926,19 @@ class TestTracingRoute(unittest.TestCase):
         assert call_kwargs['route_names'] == [_r('my-route')]
         assert call_kwargs['group_uuids'] == [UUID(group_uuid)]
         assert call_kwargs['key_uuids'] == [UUID(key_uuid)]
+
+    def test_get_traces_with_tags_filter(self):
+        mock_result = Page.create(items=[], params=Params(page=1, size=50), total=0)
+        self.tracing_service.get_traces = MagicMock(return_value=mock_result)
+
+        response = self.client.get(
+            f'{self.project_path}/traces',
+            params={'tags': ['env=prod', 'cost_center=retail']},
+        )
+
+        assert response.status_code == 200
+        call_kwargs = self.tracing_service.get_traces.call_args.kwargs
+        assert call_kwargs['tags'] == ['env=prod', 'cost_center=retail']
 
     def test_get_span_by_id_success(self):
         base_time = datetime.datetime(

--- a/gateway/tests/services/request_event_service_test.py
+++ b/gateway/tests/services/request_event_service_test.py
@@ -476,7 +476,7 @@ class RequestEventServiceTest(unittest.TestCase):
     def test_get_tag_keys(self):
         self.request_event_dao.get_distinct_tags = MagicMock(
             return_value=[
-                'app=leonardo-clm',
+                'app=my-app',
                 'cost_center=retail',
                 'env=prod',
                 'env=staging',

--- a/gateway/tests/services/tracing_service_test.py
+++ b/gateway/tests/services/tracing_service_test.py
@@ -438,6 +438,37 @@ class TracingServiceTest(unittest.TestCase):
         assert result.root_span_id == 'span-1'
         assert result.trace_status == TraceStatus.SUCCESS
 
+    def test_get_trace_by_id_includes_tags(self):
+        """TraceDTO.tags comes straight from the root span's parsed tags."""
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        self.otel_traces_dao.get_spans_by_trace_id = MagicMock(
+            return_value=[
+                SpanRecord(
+                    timestamp=base_time,
+                    trace_id='trace-tags',
+                    request_uuid='',
+                    span_id='span-1',
+                    span_name='invoke',
+                    service_name='ai-gateway',
+                    duration=100_000_000,
+                    status_code='Unset',
+                    parent_span_id='',
+                    route_name='test-route',
+                    api_key_uuid='',
+                    api_key_name='',
+                    group_uuid='',
+                    group_name='',
+                    tags=['env=prod', 'cost_center=retail'],
+                )
+            ]
+        )
+
+        result = self.tracing_service.get_trace_by_id(PROJECT_UUID, 'trace-tags')
+
+        assert result.tags == ['env=prod', 'cost_center=retail']
+
     def test_get_trace_by_id_single_span_no_request_uuid(self):
         """Test retrieving a trace without request_uuid."""
         base_time = datetime.datetime(
@@ -797,6 +828,52 @@ class TracingServiceTest(unittest.TestCase):
         assert item.latest_span_ts == int(
             (base_time + datetime.timedelta(seconds=1)).timestamp()
         )
+
+    def test_get_traces_includes_tags(self):
+        """TraceDTO.tags comes straight from the paginated row, no extra DAO call."""
+        base_time = datetime.datetime(
+            2025, 1, 8, 10, 0, 0, tzinfo=datetime.timezone.utc
+        )
+        trace_id = 'trace-tags'
+
+        mock_row = MagicMock()
+        mock_row.trace_id = trace_id
+        mock_row.request_uuid = ''
+        mock_row.route_name = 'my-route'
+        mock_row.group_name = None
+        mock_row.group_uuid = ''
+        mock_row.api_key_name = None
+        mock_row.api_key_uuid = ''
+        mock_row.duration_ms = 1500.0
+        mock_row.created_at = base_time
+        mock_row.tags = ['env=prod']
+
+        mock_page = MagicMock(spec=Page)
+        mock_page.items = [mock_row]
+        mock_page.total = 1
+
+        self.otel_traces_dao.get_root_traces_paginated = MagicMock(
+            return_value=mock_page
+        )
+        self.otel_traces_dao.get_spans_stats_by_trace_ids = MagicMock(return_value={})
+        self.otel_traces_dao.get_root_span_error_by_trace_ids = MagicMock(
+            return_value=set()
+        )
+
+        res = self.tracing_service.get_traces(
+            project_uuid=PROJECT_UUID,
+            route_names=None,
+            group_uuids=None,
+            key_uuids=None,
+            _from=base_time,
+            _to=base_time + datetime.timedelta(hours=1),
+            params=Params(page=1, size=50),
+            tags=['env=prod'],
+        )
+
+        assert res.items[0].tags == ['env=prod']
+        call_args = self.otel_traces_dao.get_root_traces_paginated.call_args
+        assert call_args.kwargs['tags'] == ['env=prod']
 
     def test_get_traces_page_offset_conversion(self):
         """Test that params are passed correctly to the paginated DAO method."""

--- a/gateway/tests/utils/test_request_tags.py
+++ b/gateway/tests/utils/test_request_tags.py
@@ -10,8 +10,8 @@ from radicalbit_ai_gateway.utils.request_tags import (
 
 
 def test_parses_the_documented_example():
-    assert parse_tags_header('cost_center=retail,env=prod,app=leonardo-clm') == (
-        'app=leonardo-clm',
+    assert parse_tags_header('cost_center=retail,env=prod,app=my-app') == (
+        'app=my-app',
         'cost_center=retail',
         'env=prod',
     )

--- a/gateway/tests/utils/test_trace_attributes.py
+++ b/gateway/tests/utils/test_trace_attributes.py
@@ -59,6 +59,40 @@ def test_set_trace_attributes_partial(mock_set_props):
 @patch(
     'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
 )
+def test_set_trace_attributes_comma_joins_tags(mock_set_props):
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value=None,
+    ):
+        set_trace_attributes(
+            request_uuid='req-123',
+            tags=['env=prod', 'cost_center=retail'],
+        )
+
+    mock_set_props.assert_called_once_with(
+        {
+            'request_uuid': 'req-123',
+            'tags': 'env=prod,cost_center=retail',
+        }
+    )
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
+def test_set_trace_attributes_omits_empty_tags(mock_set_props):
+    with patch(
+        'radicalbit_ai_gateway.utils.trace_attributes.get_value',
+        return_value=None,
+    ):
+        set_trace_attributes(request_uuid='req-123', tags=[])
+
+    mock_set_props.assert_called_once_with({'request_uuid': 'req-123'})
+
+
+@patch(
+    'radicalbit_ai_gateway.utils.trace_attributes.Traceloop.set_association_properties'
+)
 def test_set_mcp_attributes(mock_set_props):
     with patch(
         'radicalbit_ai_gateway.utils.trace_attributes.get_value',


### PR DESCRIPTION
## Summary

Adds tag filtering to tracing endpoints and exposes request tags on trace responses.
Tags come from the `X-RB-Tags` request header (e.g. `X-RB-Tags: env=prod,cost_center=retail`); they are now stamped as trace attributes on every gateway request (chat completions, embeddings, audio transcriptions, responses, MCP) and can be used to filter all tracing analytics, consistent with the existing tag filtering on metrics endpoints.

---

## Added

- **`tags`** field on **`TraceDTO`** - Response DTO for `GET /projects/{project_uuid}/traces` (list) and `GET /projects/{project_uuid}/traces/{trace_id}` (detail)

  ```python
  class TraceStatus(str, Enum):  # One of: success, warning, error

  class TreeNodeDTO(BaseModel):
      span_id: str
      span_name: str
      duration_ms: float
      status_code: str
      output_tokens: int
      input_tokens: int
      total_tokens: int
      error_count: int
      created_at: int
      children: list['TreeNodeDTO']

  class TraceDTO(BaseModel):
      trace_id: str
      request_uuid: UUID | None
      root_span_id: str | None          # Only for detail view
      total_spans: int
      duration_ms: float
      error_count: int
      trace_status: TraceStatus
      created_at: int                   # Unix timestamp
      latest_span_ts: int
      output_tokens: int
      input_tokens: int
      total_tokens: int
      route_name: str | None
      api_key_uuid: UUID | None
      api_key_name: str | None
      group_uuid: UUID | None
      group_name: str | None
      tags: list[str]                   # NEW - e.g. ["cost_center=retail", "env=prod"]
      tree: TreeNodeDTO | None          # Only for detail view
  ```

  **Example:**
  ```json
  {
    "traceId": "550e8400-e29b-41d4-a716-446655440000",
    "totalSpans": 3,
    "durationMs": 1250.5,
    "errorCount": 0,
    "traceStatus": "success",
    "createdAt": 1704067200,
    "latestSpanTs": 1704067202,
    "outputTokens": 500,
    "inputTokens": 1000,
    "totalTokens": 1500,
    "routeName": "my-route",
    "apiKeyName": "my-key",
    "tags": ["cost_center=retail", "env=prod"]
  }
  ```

- **`tags` query parameter** - New optional filter on all tracing endpoints. Repeatable `key=value` pairs; values for the same key are OR-ed together, different keys are AND-ed (e.g. `tags=env=prod&tags=env=staging&tags=cost_center=retail` matches `(env=prod OR env=staging) AND cost_center=retail`).

  Applies to:

  | Endpoint | Parameters |
  |----------|------------|
  | `GET /public/api/{version}/projects/{project_uuid}/traces/chart` | `tags` joined with existing `_from`, `_to`, `routes` |
  | `GET /public/api/{version}/projects/{project_uuid}/traces/latencies` | `tags` joined with existing `_from`, `_to`, `routes` |
  | `GET /public/api/{version}/projects/{project_uuid}/traces/spans/latencies` | `tags` joined with existing `_from`, `_to`, `routes`, `grouped`, `include_others` |
  | `GET /public/api/{version}/projects/{project_uuid}/traces` | `tags` joined with existing `_from`, `_to`, `routes`, `groups`, `keys`, `_page`, `_limit` |

- **Tag trace attributes** - Tags from the `X-RB-Tags` header are now recorded on traces for all gateway entry points (chat completions, embeddings, audio transcriptions, responses, MCP, and early project/route attribute stamping before route resolution)

---

## Changed

- **Traces pagination** - `GET /projects/{project_uuid}/traces` rows now include the `tags` array column; pagination no longer performs row deduplication (rows are already unique per root span)

---

## Other Changes

- `db/dao/otel_traces_dao.py` - Tag filter conditions on all trace queries (latencies, span latencies, grouped latencies, chart, paginated traces); tags stored as comma-joined string and split back to array via ClickHouse `splitByChar`
- `services/tracing_service.py` - `tags` parameter threaded through all tracing service methods
- `utils/trace_attributes.py` - `set_trace_attributes` accepts `tags` list
- `auth/request_auth.py`, `services/mcp_service.py`, `server.py` - Stamp tags on trace attributes at auth/MCP/endpoint level
- Tests - Added for DAO tag filtering, tracing routes, tracing service, and trace attributes


## Linked Issue
AG-915 AG-916

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
