### PR TITLE
feat(docker): add SMTP_USER and SMTP_PASSWORD to docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,9 +51,11 @@ services:
       # CORS configs
       CORS_ALLOW_ORIGINS: '["http://localhost:5173"]'
       CORS_ALLOW_CREDENTIALS: True
-      # SMTP Email Notifications (Mailpit)
+      # SMTP Email Notifications
       SMTP_HOST: "${SMTP_HOST:-host.docker.internal}"
       SMTP_PORT: "${SMTP_PORT:-1025}"
+      SMTP_USER: "${SMTP_USER:-}"
+      SMTP_PASSWORD: "${SMTP_PASSWORD:-}"
       SMTP_FROM_EMAIL: "${SMTP_FROM_EMAIL:-alerts@radicalbit.ai}"
       # AI Config Generator
       CONFIG_GENERATOR_OPENAI_API_KEY: "OPENAI_API_KEY"


### PR DESCRIPTION
## Summary
Add user and password arguments into docker compose config file

## Linked Issue
Closes #123

## Type of Change
- [X] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
