### PR TITLE
fix: fix release step

### DIFF
--- a/.github/workflows/gateway-workflow.yaml
+++ b/.github/workflows/gateway-workflow.yaml
@@ -203,12 +203,29 @@ jobs:
           APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
           MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
         run: |
+          # Docker Hub can take a moment to make a just-pushed signature manifest
+          # readable to a fresh GET (read-after-write lag), so retry a few times
+          # before treating a "no signatures found" as a real failure.
+          verify_with_retry() {
+            local ref="$1"
+            local attempts=6
+            local delay=5
+            for ((i = 1; i <= attempts; i++)); do
+              if cosign verify "${ref}" \
+                --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
+                --certificate-oidc-issuer https://token.actions.githubusercontent.com; then
+                return 0
+              fi
+              echo "Verification attempt ${i}/${attempts} failed for ${ref}, retrying in ${delay}s..."
+              sleep "${delay}"
+            done
+            return 1
+          }
+
           for REF in \
             "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
             "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"; do
-            cosign verify "${REF}" \
-              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+            verify_with_retry "${REF}"
           done
 
   source-sbom:

--- a/.github/workflows/gateway-workflow.yaml
+++ b/.github/workflows/gateway-workflow.yaml
@@ -125,6 +125,9 @@ jobs:
       contents: read
       packages: write
       id-token: write # needed for keyless signing with the GitHub OIDC token
+    outputs:
+      app_digest: ${{ steps.app-manifest.outputs.digest }}
+      migrations_digest: ${{ steps.migrations-manifest.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -198,34 +201,33 @@ jobs:
         run: |
           cosign sign --yes "${{ env.APP_IMAGE }}@${APP_DIGEST}"
           cosign sign --yes "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"
+
+  verify-signatures:
+    runs-on: ubuntu-22.04
+    needs: merge
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Verify signatures
         env:
-          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
-          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
+          APP_DIGEST: ${{ needs.merge.outputs.app_digest }}
+          MIGRATIONS_DIGEST: ${{ needs.merge.outputs.migrations_digest }}
         run: |
-          # Docker Hub can take a moment to make a just-pushed signature manifest
-          # readable to a fresh GET (read-after-write lag), so retry a few times
-          # before treating a "no signatures found" as a real failure.
-          verify_with_retry() {
-            local ref="$1"
-            local attempts=6
-            local delay=5
-            for ((i = 1; i <= attempts; i++)); do
-              if cosign verify "${ref}" \
-                --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
-                --certificate-oidc-issuer https://token.actions.githubusercontent.com; then
-                return 0
-              fi
-              echo "Verification attempt ${i}/${attempts} failed for ${ref}, retrying in ${delay}s..."
-              sleep "${delay}"
-            done
-            return 1
-          }
-
           for REF in \
             "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
             "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"; do
-            verify_with_retry "${REF}"
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
           done
 
   source-sbom:

--- a/.github/workflows/metrics-worker-workflow.yaml
+++ b/.github/workflows/metrics-worker-workflow.yaml
@@ -123,6 +123,9 @@ jobs:
       contents: read
       packages: write
       id-token: write # needed for keyless signing with the GitHub OIDC token
+    outputs:
+      worker_digest: ${{ steps.worker-manifest.outputs.digest }}
+      clickhouse_digest: ${{ steps.clickhouse-manifest.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -196,34 +199,33 @@ jobs:
         run: |
           cosign sign --yes "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"
           cosign sign --yes "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"
+
+  verify-signatures:
+    runs-on: ubuntu-22.04
+    needs: merge
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Verify signatures
         env:
-          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
-          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
+          WORKER_DIGEST: ${{ needs.merge.outputs.worker_digest }}
+          CLICKHOUSE_DIGEST: ${{ needs.merge.outputs.clickhouse_digest }}
         run: |
-          # Docker Hub can take a moment to make a just-pushed signature manifest
-          # readable to a fresh GET (read-after-write lag), so retry a few times
-          # before treating a "no signatures found" as a real failure.
-          verify_with_retry() {
-            local ref="$1"
-            local attempts=6
-            local delay=5
-            for ((i = 1; i <= attempts; i++)); do
-              if cosign verify "${ref}" \
-                --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
-                --certificate-oidc-issuer https://token.actions.githubusercontent.com; then
-                return 0
-              fi
-              echo "Verification attempt ${i}/${attempts} failed for ${ref}, retrying in ${delay}s..."
-              sleep "${delay}"
-            done
-            return 1
-          }
-
           for REF in \
             "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}" \
             "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"; do
-            verify_with_retry "${REF}"
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
           done
 
   source-sbom:

--- a/.github/workflows/metrics-worker-workflow.yaml
+++ b/.github/workflows/metrics-worker-workflow.yaml
@@ -201,12 +201,29 @@ jobs:
           WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
           CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
         run: |
+          # Docker Hub can take a moment to make a just-pushed signature manifest
+          # readable to a fresh GET (read-after-write lag), so retry a few times
+          # before treating a "no signatures found" as a real failure.
+          verify_with_retry() {
+            local ref="$1"
+            local attempts=6
+            local delay=5
+            for ((i = 1; i <= attempts; i++)); do
+              if cosign verify "${ref}" \
+                --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
+                --certificate-oidc-issuer https://token.actions.githubusercontent.com; then
+                return 0
+              fi
+              echo "Verification attempt ${i}/${attempts} failed for ${ref}, retrying in ${delay}s..."
+              sleep "${delay}"
+            done
+            return 1
+          }
+
           for REF in \
             "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}" \
             "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"; do
-            cosign verify "${REF}" \
-              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+            verify_with_retry "${REF}"
           done
 
   source-sbom:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -303,14 +303,31 @@ jobs:
           CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
           WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
         run: |
+          # Docker Hub can take a moment to make a just-pushed signature manifest
+          # readable to a fresh GET (read-after-write lag), so retry a few times
+          # before treating a "no signatures found" as a real failure.
+          verify_with_retry() {
+            local ref="$1"
+            local attempts=6
+            local delay=5
+            for ((i = 1; i <= attempts; i++)); do
+              if cosign verify "${ref}" \
+                --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/tags/.+" \
+                --certificate-oidc-issuer https://token.actions.githubusercontent.com; then
+                return 0
+              fi
+              echo "Verification attempt ${i}/${attempts} failed for ${ref}, retrying in ${delay}s..."
+              sleep "${delay}"
+            done
+            return 1
+          }
+
           for REF in \
             "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
             "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}" \
             "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}" \
             "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"; do
-            cosign verify "${REF}" \
-              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/tags/.+" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+            verify_with_retry "${REF}"
           done
 
   source-sbom:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -155,6 +155,11 @@ jobs:
       contents: read
       packages: write
       id-token: write # needed for keyless signing with the GitHub OIDC token
+    outputs:
+      app_digest: ${{ steps.app-manifest.outputs.digest }}
+      migrations_digest: ${{ steps.migrations-manifest.outputs.digest }}
+      clickhouse_digest: ${{ steps.clickhouse-manifest.outputs.digest }}
+      worker_digest: ${{ steps.worker-manifest.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -296,38 +301,36 @@ jobs:
           cosign sign --yes "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"
           cosign sign --yes "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"
           cosign sign --yes "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"
+
+  verify-signatures:
+    runs-on: ubuntu-22.04
+    needs: merge
+    permissions:
+      contents: read
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Verify signatures
         env:
-          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
-          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
-          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
-          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
+          APP_DIGEST: ${{ needs.merge.outputs.app_digest }}
+          MIGRATIONS_DIGEST: ${{ needs.merge.outputs.migrations_digest }}
+          CLICKHOUSE_DIGEST: ${{ needs.merge.outputs.clickhouse_digest }}
+          WORKER_DIGEST: ${{ needs.merge.outputs.worker_digest }}
         run: |
-          # Docker Hub can take a moment to make a just-pushed signature manifest
-          # readable to a fresh GET (read-after-write lag), so retry a few times
-          # before treating a "no signatures found" as a real failure.
-          verify_with_retry() {
-            local ref="$1"
-            local attempts=6
-            local delay=5
-            for ((i = 1; i <= attempts; i++)); do
-              if cosign verify "${ref}" \
-                --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/tags/.+" \
-                --certificate-oidc-issuer https://token.actions.githubusercontent.com; then
-                return 0
-              fi
-              echo "Verification attempt ${i}/${attempts} failed for ${ref}, retrying in ${delay}s..."
-              sleep "${delay}"
-            done
-            return 1
-          }
-
           for REF in \
             "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
             "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}" \
             "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}" \
             "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"; do
-            verify_with_retry "${REF}"
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/tags/.+" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
           done
 
   source-sbom:

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
+# setuptools-scm derives the package version from git, which isn't available
+# in this build context (only uv.lock/pyproject.toml are copied in) — pin a
+# pretend version so it doesn't need one. The real release version is set by
+# the PyPI publish job, which does a full git checkout.
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_RADICALBIT_AI_GATEWAY=0.0.0
 COPY ./gateway/uv.lock ./gateway/pyproject.toml ./
 RUN pip install --no-cache-dir --no-compile uv==0.9.27 && \
     uv export --no-hashes --format requirements-txt > requirements.txt && \

--- a/gateway/migrations.Dockerfile
+++ b/gateway/migrations.Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /app
 # Install uv
 RUN pip install --no-cache-dir --no-compile uv==0.9.27
 
+# setuptools-scm derives the package version from git, which isn't available
+# in this build context (only uv.lock/pyproject.toml are copied in) — pin a
+# pretend version so it doesn't need one. The real release version is set by
+# the PyPI publish job, which does a full git checkout.
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_RADICALBIT_AI_GATEWAY=0.0.0
+
 # Copy dependency files
 COPY uv.lock pyproject.toml ./
 


### PR DESCRIPTION
## Summary

This branch fixes two problems encountered in the CI/CD pipelines:

1. Docker image builds failing because `setuptools-scm` could not derive a package version inside the container build context.
2. The `cosign verify` step failing intermittently right after signing, due to Docker Hub read-after-write lag on freshly pushed signature manifests.

## 1. Dockerfiles: pin `setuptools-scm` pretend version

**Files:** `Dockerfile`, `gateway/migrations.Dockerfile`

### Problem

The image builds install Python dependencies by exporting `uv.lock` / `pyproject.toml` to a requirements file. The project uses `setuptools-scm`, which derives the package version from git metadata (tags, `.git` directory). Neither is available in the Docker build context — only `uv.lock` and `pyproject.toml` are copied in — so `pip`/`uv` failed when trying to build the package metadata.

### Change

Both Dockerfiles now set:

```dockerfile
ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_RADICALBIT_AI_GATEWAY=0.0.0
```

This env var (the `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_<NORMALIZED_NAME>` form supported by modern `setuptools-scm`) pins a placeholder version so dependency installation succeeds without git metadata. It only affects the image build; the real release version is still produced by the PyPI publish job, which runs from a full git checkout.

## 2. Workflows: restructure cosign verification (OpenFGA pattern)

**Files:** `.github/workflows/gateway-workflow.yaml`, `.github/workflows/metrics-worker-workflow.yaml`, `.github/workflows/release.yaml`

### Problem

Previously, `cosign verify` ran as the last step of the `merge` job, immediately after `cosign sign`. Docker Hub — like most distributed registries — has eventual consistency, so a signature manifest that was just pushed may not be visible to a subsequent `GET` in another connection yet. This made verification fail intermittently with `no signatures found`.

An initial fix wrapped `cosign verify` in a retry loop (~30s total). Reviews of how well-known open-source projects handle this showed that no major project retries verification:

- **openfga/openfga** (also publishing to Docker Hub) signs in the release job and verifies in a **separate downstream job**, with no retry — the job scheduling delay naturally absorbs the registry propagation lag.

### Change

All three workflows were restructured to follow the OpenFGA pattern:

- The `merge` job:
  - keeps all existing steps (manifest creation, digest inspection, SBOM upload to Dependency-Track, `cosign sign`);
  - now exposes the image manifest digests via job `outputs:` (`app_digest`, `migrations_digest`, `worker_digest`, `clickhouse_digest` as applicable).
- A new **`verify-signatures`** job (`needs: merge`):
  - installs cosign and logs in to the registry;
  - runs plain `cosign verify` (no retry loop) against the digests passed from `merge` outputs;
  - uses the same certificate identity checks as before:
    - CI workflows (`gateway`, `metrics-worker`): `refs/heads/main$`
    - release workflow: `refs/tags/.+`
  - both against the GitHub Actions OIDC issuer (`https://token.actions.githubusercontent.com`);
  - runs with minimal permissions (`contents: read` only — verification is keyless read-only and does not need `id-token: write`).

Verification by immutable digest (rather than tag) is unchanged and remains a security best practice.

### Rationale

- Separating signing and verification into different jobs gives the registry time to propagate the signature before it is read, eliminating the flakiness without masking real verification failures behind retries.
- A failed verification now surfaces immediately (a retry loop would have retried even on genuinely invalid signatures).
- This mirrors the approach used by OpenFGA, another Docker Hub publisher.

## Job graph (per workflow)

```
test ─> build ─> merge ─> verify-signatures
                  └────────> source-sbom (unchanged, needs: test/prep)
```

## Validation

- All three workflow files pass YAML parsing; each now contains the `verify-signatures` job with `needs: merge`.
- Bash blocks were syntax-checked (`bash -n`).


## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [x] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
