### PR TITLE
feat: improve actions for release

### DIFF
--- a/.github/workflows/gateway-pipeline.yaml
+++ b/.github/workflows/gateway-pipeline.yaml
@@ -1,0 +1,214 @@
+name: gateway-pipeline
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        description: Tag applied to the built images (e.g. "main" or the release version).
+        required: true
+        type: string
+      push-latest:
+        description: Also tag images as :latest and mark them as latest in Dependency-Track.
+        required: false
+        default: false
+        type: boolean
+
+env:
+  APP_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway
+  MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-migrations
+  # Dependency-Track project names (registry-independent, stable across builds)
+  APP_PROJECT: radicalbit-ai-gateway
+  MIGRATIONS_PROJECT: radicalbit-ai-gateway-migrations
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            platform_short: amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            platform_short: arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
+            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and push app image by digest
+        id: build-app
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.APP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push migrations image by digest
+        id: build-migrations
+        uses: docker/build-push-action@v6
+        with:
+          context: ./gateway
+          file: ./gateway/migrations.Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/app /tmp/digests/migrations
+          touch "/tmp/digests/app/${APP_DIGEST#sha256:}"
+          touch "/tmp/digests/migrations/${MIGRATIONS_DIGEST#sha256:}"
+        env:
+          APP_DIGEST: ${{ steps.build-app.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.build-migrations.outputs.digest }}
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-gateway-${{ matrix.platform_short }}
+          path: /tmp/digests/**
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for keyless signing with the GitHub OIDC token
+    outputs:
+      app_digest: ${{ steps.app-manifest.outputs.digest }}
+      migrations_digest: ${{ steps.migrations-manifest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-gateway-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Create and push app manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+          PUSH_LATEST: ${{ inputs.push-latest }}
+        run: |
+          TAGS="-t ${APP_IMAGE}:${IMAGE_TAG}"
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
+            TAGS="$TAGS -t ${APP_IMAGE}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${APP_IMAGE}@sha256:%s ' $(ls /tmp/digests/app/))
+      - name: Create and push migrations manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+          PUSH_LATEST: ${{ inputs.push-latest }}
+        run: |
+          TAGS="-t ${MIGRATIONS_IMAGE}:${IMAGE_TAG}"
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
+            TAGS="$TAGS -t ${MIGRATIONS_IMAGE}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${MIGRATIONS_IMAGE}@sha256:%s ' $(ls /tmp/digests/migrations/))
+      - name: Inspect images
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          docker buildx imagetools inspect ${APP_IMAGE}:${IMAGE_TAG}
+          docker buildx imagetools inspect ${MIGRATIONS_IMAGE}:${IMAGE_TAG}
+      - name: Get app manifest digest
+        id: app-manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${APP_IMAGE}:${IMAGE_TAG} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      - name: Get migrations manifest digest
+        id: migrations-manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${MIGRATIONS_IMAGE}:${IMAGE_TAG} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: SBOM → Dependency-Track (app)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.APP_IMAGE }}@${{ steps.app-manifest.outputs.digest }}
+          project-name: ${{ env.APP_PROJECT }}
+          project-version: ${{ inputs.image-tag }}
+          is-latest: ${{ inputs.push-latest }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: SBOM → Dependency-Track (migrations)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.MIGRATIONS_IMAGE }}@${{ steps.migrations-manifest.outputs.digest }}
+          project-name: ${{ env.MIGRATIONS_PROJECT }}
+          project-version: ${{ inputs.image-tag }}
+          is-latest: ${{ inputs.push-latest }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+
+      - name: Sign images with Cosign (keyless)
+        env:
+          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
+          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
+        run: |
+          cosign sign --yes "${APP_IMAGE}@${APP_DIGEST}"
+          cosign sign --yes "${MIGRATIONS_IMAGE}@${MIGRATIONS_DIGEST}"
+
+  verify-signatures:
+    runs-on: ubuntu-22.04
+    needs: merge
+    permissions:
+      contents: read
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Verify signatures
+        env:
+          APP_DIGEST: ${{ needs.merge.outputs.app_digest }}
+          MIGRATIONS_DIGEST: ${{ needs.merge.outputs.migrations_digest }}
+          EXPECTED_REF: ${{ github.ref }}
+        run: |
+          for REF in \
+            "${APP_IMAGE}@${APP_DIGEST}" \
+            "${MIGRATIONS_IMAGE}@${MIGRATIONS_DIGEST}"; do
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@${EXPECTED_REF}$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          done

--- a/.github/workflows/gateway-workflow.yaml
+++ b/.github/workflows/gateway-workflow.yaml
@@ -1,234 +1,42 @@
 name: gateway-wf
 on:
   push:
-    tags:
-      - 'v*.*.*'
     branches:
       - "main"
     paths:
       - "gateway/**"
       - ".github/workflows/gateway-**"
+      - ".github/workflows/tests.yaml"
   pull_request:
     branches:
       - "*"
     paths:
       - "gateway/**"
       - ".github/workflows/gateway-**"
+      - ".github/workflows/tests.yaml"
 
 env:
   PYTHON_VERSION: "3.11"
   UV_VERSION: "0.7.13"
-  APP_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway
-  MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-migrations
   IMAGES_TAG: main
   # Dependency-Track project names (registry-independent, stable across builds)
-  APP_PROJECT: radicalbit-ai-gateway
-  MIGRATIONS_PROJECT: radicalbit-ai-gateway-migrations
   GATEWAY_PYTHON_PROJECT: radicalbit-ai-gateway-python
   UI_PROJECT: radicalbit-ai-gateway-ui
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: ./gateway
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Setup uv
-        run: |
-          curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
-      - name: Run formatting validation
-        run: |
-          uv run ruff check
-      - name: Run format check
-        run: |
-          uv run ruff format --check
-      - name: Run tests
-        run: |
-          uv run pytest -v
+    uses: ./.github/workflows/tests.yaml
+    with:
+      working-directory: ./gateway
+      run-pytest: true
 
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-22.04
-            platform_short: amd64
-          - platform: linux/arm64
-            runner: ubuntu-22.04-arm
-            platform_short: arm64
-    runs-on: ${{ matrix.runner }}
+  pipeline:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            network=host
-            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
-            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Build and push app image by digest
-        id: build-app
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.APP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and push migrations image by digest
-        id: build-migrations
-        uses: docker/build-push-action@v6
-        with:
-          context: ./gateway
-          file: ./gateway/migrations.Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Export digests
-        run: |
-          mkdir -p /tmp/digests/app /tmp/digests/migrations
-          touch "/tmp/digests/app/${APP_DIGEST#sha256:}"
-          touch "/tmp/digests/migrations/${MIGRATIONS_DIGEST#sha256:}"
-        env:
-          APP_DIGEST: ${{ steps.build-app.outputs.digest }}
-          MIGRATIONS_DIGEST: ${{ steps.build-migrations.outputs.digest }}
-      - name: Upload digests
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-gateway-${{ matrix.platform_short }}
-          path: /tmp/digests/**
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-22.04
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-      id-token: write # needed for keyless signing with the GitHub OIDC token
-    outputs:
-      app_digest: ${{ steps.app-manifest.outputs.digest }}
-      migrations_digest: ${{ steps.migrations-manifest.outputs.digest }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-gateway-*
-          merge-multiple: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Create app manifest and push
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.APP_IMAGE }}:${{ env.IMAGES_TAG }} \
-            $(printf '${{ env.APP_IMAGE }}@sha256:%s ' $(ls /tmp/digests/app/))
-      - name: Create migrations manifest and push
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} \
-            $(printf '${{ env.MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/migrations/))
-      - name: Inspect images
-        run: |
-          docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ env.IMAGES_TAG }}
-          docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }}
-
-      - name: Get app manifest digest
-        id: app-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-      - name: Get migrations manifest digest
-        id: migrations-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-
-      - name: SBOM → Dependency-Track (app)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.APP_IMAGE }}@${{ steps.app-manifest.outputs.digest }}
-          project-name: ${{ env.APP_PROJECT }}
-          project-version: ${{ env.IMAGES_TAG }}
-          is-latest: "false"
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-      - name: SBOM → Dependency-Track (migrations)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.MIGRATIONS_IMAGE }}@${{ steps.migrations-manifest.outputs.digest }}
-          project-name: ${{ env.MIGRATIONS_PROJECT }}
-          project-version: ${{ env.IMAGES_TAG }}
-          is-latest: "false"
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-
-      - name: Sign images with Cosign (keyless)
-        env:
-          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
-          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
-        run: |
-          cosign sign --yes "${{ env.APP_IMAGE }}@${APP_DIGEST}"
-          cosign sign --yes "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"
-
-  verify-signatures:
-    runs-on: ubuntu-22.04
-    needs: merge
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Verify signatures
-        env:
-          APP_DIGEST: ${{ needs.merge.outputs.app_digest }}
-          MIGRATIONS_DIGEST: ${{ needs.merge.outputs.migrations_digest }}
-        run: |
-          for REF in \
-            "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
-            "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"; do
-            cosign verify "${REF}" \
-              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
-          done
+    uses: ./.github/workflows/gateway-pipeline.yaml
+    with:
+      image-tag: main
+    secrets: inherit
 
   source-sbom:
     runs-on: ubuntu-22.04

--- a/.github/workflows/metrics-worker-workflow.yaml
+++ b/.github/workflows/metrics-worker-workflow.yaml
@@ -1,14 +1,13 @@
 name: metrics-worker-wf
 on:
   push:
-    tags:
-      - 'v*.*.*'
     branches:
       - "main"
     paths:
       - "metrics-worker/**"
       - "clickhouse-migrations/**"
       - ".github/workflows/metrics-worker-**"
+      - ".github/workflows/tests.yaml"
   pull_request:
     branches:
       - "*"
@@ -16,217 +15,29 @@ on:
       - "metrics-worker/**"
       - "clickhouse-migrations/**"
       - ".github/workflows/metrics-worker-**"
+      - ".github/workflows/tests.yaml"
 
 env:
   PYTHON_VERSION: "3.11"
   UV_VERSION: "0.7.13"
-  WORKER_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-metrics-worker
-  CLICKHOUSE_MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-clickhouse-migrations
   IMAGES_TAG: main
   # Dependency-Track project names (registry-independent, stable across builds)
-  WORKER_PROJECT: metrics-worker
-  CLICKHOUSE_MIGRATIONS_PROJECT: radicalbit-ai-gateway-clickhouse-migrations
   WORKER_PYTHON_PROJECT: metrics-worker-python
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: ./metrics-worker
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Setup uv
-        run: |
-          curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
-      - name: Run formatting validation
-        run: |
-          uv run ruff check
-      - name: Run format check
-        run: |
-          uv run ruff format --check
+    uses: ./.github/workflows/tests.yaml
+    with:
+      working-directory: ./metrics-worker
+      run-pytest: false
 
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-22.04
-            platform_short: amd64
-          - platform: linux/arm64
-            runner: ubuntu-22.04-arm
-            platform_short: arm64
-    runs-on: ${{ matrix.runner }}
+  pipeline:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            network=host
-            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
-            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Build and push metrics-worker image by digest
-        id: build-worker
-        uses: docker/build-push-action@v6
-        with:
-          context: ./metrics-worker
-          file: ./metrics-worker/Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.WORKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and push clickhouse-migrations image by digest
-        id: build-clickhouse-migrations
-        uses: docker/build-push-action@v6
-        with:
-          context: ./clickhouse-migrations
-          file: ./clickhouse-migrations/Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Export digests
-        run: |
-          mkdir -p /tmp/digests/worker /tmp/digests/clickhouse-migrations
-          touch "/tmp/digests/worker/${WORKER_DIGEST#sha256:}"
-          touch "/tmp/digests/clickhouse-migrations/${CLICKHOUSE_DIGEST#sha256:}"
-        env:
-          WORKER_DIGEST: ${{ steps.build-worker.outputs.digest }}
-          CLICKHOUSE_DIGEST: ${{ steps.build-clickhouse-migrations.outputs.digest }}
-      - name: Upload digests
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-worker-${{ matrix.platform_short }}
-          path: /tmp/digests/**
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-22.04
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-      id-token: write # needed for keyless signing with the GitHub OIDC token
-    outputs:
-      worker_digest: ${{ steps.worker-manifest.outputs.digest }}
-      clickhouse_digest: ${{ steps.clickhouse-manifest.outputs.digest }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-worker-*
-          merge-multiple: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Create metrics-worker manifest and push
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.WORKER_IMAGE }}:${{ env.IMAGES_TAG }} \
-            $(printf '${{ env.WORKER_IMAGE }}@sha256:%s ' $(ls /tmp/digests/worker/))
-      - name: Create clickhouse-migrations manifest and push
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} \
-            $(printf '${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/clickhouse-migrations/))
-      - name: Inspect images
-        run: |
-          docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ env.IMAGES_TAG }}
-          docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }}
-
-      - name: Get metrics-worker manifest digest
-        id: worker-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-      - name: Get clickhouse-migrations manifest digest
-        id: clickhouse-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ env.IMAGES_TAG }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-
-      - name: SBOM → Dependency-Track (metrics-worker)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.WORKER_IMAGE }}@${{ steps.worker-manifest.outputs.digest }}
-          project-name: ${{ env.WORKER_PROJECT }}
-          project-version: ${{ env.IMAGES_TAG }}
-          is-latest: "false"
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-      - name: SBOM → Dependency-Track (clickhouse-migrations)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${{ steps.clickhouse-manifest.outputs.digest }}
-          project-name: ${{ env.CLICKHOUSE_MIGRATIONS_PROJECT }}
-          project-version: ${{ env.IMAGES_TAG }}
-          is-latest: "false"
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-
-      - name: Sign images with Cosign (keyless)
-        env:
-          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
-          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
-        run: |
-          cosign sign --yes "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"
-          cosign sign --yes "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"
-
-  verify-signatures:
-    runs-on: ubuntu-22.04
-    needs: merge
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Verify signatures
-        env:
-          WORKER_DIGEST: ${{ needs.merge.outputs.worker_digest }}
-          CLICKHOUSE_DIGEST: ${{ needs.merge.outputs.clickhouse_digest }}
-        run: |
-          for REF in \
-            "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}" \
-            "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"; do
-            cosign verify "${REF}" \
-              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/heads/main$" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
-          done
+    uses: ./.github/workflows/worker-pipeline.yaml
+    with:
+      image-tag: main
+    secrets: inherit
 
   source-sbom:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,15 +11,7 @@ concurrency:
 env:
   PYTHON_VERSION: "3.11"
   UV_VERSION: "0.7.13"
-  APP_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway
-  MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-migrations
-  CLICKHOUSE_MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-clickhouse-migrations
-  WORKER_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-metrics-worker
   # Dependency-Track project names (registry-independent, stable across builds)
-  APP_PROJECT: radicalbit-ai-gateway
-  MIGRATIONS_PROJECT: radicalbit-ai-gateway-migrations
-  CLICKHOUSE_MIGRATIONS_PROJECT: radicalbit-ai-gateway-clickhouse-migrations
-  WORKER_PROJECT: metrics-worker
   GATEWAY_PYTHON_PROJECT: radicalbit-ai-gateway-python
   WORKER_PYTHON_PROJECT: metrics-worker-python
   UI_PROJECT: radicalbit-ai-gateway-ui
@@ -29,17 +21,31 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       is_semver: ${{ steps.check.outputs.is_semver }}
+      is_final: ${{ steps.check.outputs.is_final }}
       version: ${{ steps.check.outputs.version }}
     steps:
       - name: Set version/tag
         id: check
         run: |
           echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
-          echo "is_semver=$(if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_OUTPUT
+          echo "is_semver=$(if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_OUTPUT
+          echo "is_final=$(if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_OUTPUT
+
+  test-gateway:
+    uses: ./.github/workflows/tests.yaml
+    with:
+      working-directory: ./gateway
+      run-pytest: true
+
+  test-worker:
+    uses: ./.github/workflows/tests.yaml
+    with:
+      working-directory: ./metrics-worker
+      run-pytest: false
 
   publish-pypi:
     runs-on: ubuntu-22.04
-    needs: prep
+    needs: [prep, test-gateway]
     if: needs.prep.outputs.is_semver == 'true'
     permissions:
       id-token: write # needed for PyPI trusted publishing (OIDC)
@@ -64,274 +70,21 @@ jobs:
         run: |
           uv publish --trusted-publishing always
 
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-22.04
-            platform_short: amd64
-          - platform: linux/arm64
-            runner: ubuntu-22.04-arm
-            platform_short: arm64
-    runs-on: ${{ matrix.runner }}
-    needs: prep
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            network=host
-            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
-            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Build and push app image by digest
-        id: build-app
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.APP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and push migrations image by digest
-        id: build-migrations
-        uses: docker/build-push-action@v6
-        with:
-          context: ./gateway
-          file: ./gateway/migrations.Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and push clickhouse-migrations image by digest
-        id: build-clickhouse-migrations
-        uses: docker/build-push-action@v6
-        with:
-          context: ./clickhouse-migrations
-          file: ./clickhouse-migrations/Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Build and push metrics-worker image by digest
-        id: build-worker
-        uses: docker/build-push-action@v6
-        with:
-          context: ./metrics-worker
-          file: ./metrics-worker/Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.WORKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Export digests
-        run: |
-          mkdir -p /tmp/digests/app /tmp/digests/migrations /tmp/digests/clickhouse-migrations /tmp/digests/worker
-          touch "/tmp/digests/app/${APP_DIGEST#sha256:}"
-          touch "/tmp/digests/migrations/${MIGRATIONS_DIGEST#sha256:}"
-          touch "/tmp/digests/clickhouse-migrations/${CLICKHOUSE_DIGEST#sha256:}"
-          touch "/tmp/digests/worker/${WORKER_DIGEST#sha256:}"
-        env:
-          APP_DIGEST: ${{ steps.build-app.outputs.digest }}
-          MIGRATIONS_DIGEST: ${{ steps.build-migrations.outputs.digest }}
-          CLICKHOUSE_DIGEST: ${{ steps.build-clickhouse-migrations.outputs.digest }}
-          WORKER_DIGEST: ${{ steps.build-worker.outputs.digest }}
-      - name: Upload digests
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-release-${{ matrix.platform_short }}
-          path: /tmp/digests/**
-          if-no-files-found: error
-          retention-days: 1
+  gateway-images:
+    needs: [prep, test-gateway, test-worker]
+    uses: ./.github/workflows/gateway-pipeline.yaml
+    with:
+      image-tag: ${{ needs.prep.outputs.version }}
+      push-latest: ${{ needs.prep.outputs.is_final == 'true' }}
+    secrets: inherit
 
-  merge:
-    runs-on: ubuntu-22.04
-    needs: [prep, build]
-    permissions:
-      contents: read
-      packages: write
-      id-token: write # needed for keyless signing with the GitHub OIDC token
-    outputs:
-      app_digest: ${{ steps.app-manifest.outputs.digest }}
-      migrations_digest: ${{ steps.migrations-manifest.outputs.digest }}
-      clickhouse_digest: ${{ steps.clickhouse-manifest.outputs.digest }}
-      worker_digest: ${{ steps.worker-manifest.outputs.digest }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-release-*
-          merge-multiple: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Create and push app manifest
-        run: |
-          TAGS="-t ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }}"
-          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
-            TAGS="$TAGS -t ${{ env.APP_IMAGE }}:latest"
-          fi
-          docker buildx imagetools create $TAGS \
-            $(printf '${{ env.APP_IMAGE }}@sha256:%s ' $(ls /tmp/digests/app/))
-      - name: Create and push migrations manifest
-        run: |
-          TAGS="-t ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
-          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
-            TAGS="$TAGS -t ${{ env.MIGRATIONS_IMAGE }}:latest"
-          fi
-          docker buildx imagetools create $TAGS \
-            $(printf '${{ env.MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/migrations/))
-      - name: Create and push clickhouse-migrations manifest
-        run: |
-          TAGS="-t ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
-          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
-            TAGS="$TAGS -t ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:latest"
-          fi
-          docker buildx imagetools create $TAGS \
-            $(printf '${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@sha256:%s ' $(ls /tmp/digests/clickhouse-migrations/))
-      - name: Create and push metrics-worker manifest
-        run: |
-          TAGS="-t ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }}"
-          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
-            TAGS="$TAGS -t ${{ env.WORKER_IMAGE }}:latest"
-          fi
-          docker buildx imagetools create $TAGS \
-            $(printf '${{ env.WORKER_IMAGE }}@sha256:%s ' $(ls /tmp/digests/worker/))
-      - name: Inspect images
-        run: |
-          docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }}
-          docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}
-          docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}
-          docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }}
-      - name: Output image information
-        run: |
-          echo "Successfully built and pushed images:"
-          echo "   Gateway: ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }}"
-          echo "   Migrations: ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
-          echo "   Clickhouse Migrations: ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }}"
-          echo "   Metrics Worker: ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }}"
-          if [[ "${{ needs.prep.outputs.is_semver }}" == "true" ]]; then
-            echo "   Latest tags also created for semantic version"
-          fi
-
-      - name: Get app manifest digest
-        id: app-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.APP_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-      - name: Get migrations manifest digest
-        id: migrations-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-      - name: Get clickhouse-migrations manifest digest
-        id: clickhouse-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-      - name: Get metrics-worker manifest digest
-        id: worker-manifest
-        run: |
-          DIGEST=$(docker buildx imagetools inspect ${{ env.WORKER_IMAGE }}:${{ needs.prep.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
-          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-
-      - name: SBOM → Dependency-Track (app)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.APP_IMAGE }}@${{ steps.app-manifest.outputs.digest }}
-          project-name: ${{ env.APP_PROJECT }}
-          project-version: ${{ needs.prep.outputs.version }}
-          is-latest: ${{ needs.prep.outputs.is_semver }}
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-      - name: SBOM → Dependency-Track (migrations)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.MIGRATIONS_IMAGE }}@${{ steps.migrations-manifest.outputs.digest }}
-          project-name: ${{ env.MIGRATIONS_PROJECT }}
-          project-version: ${{ needs.prep.outputs.version }}
-          is-latest: ${{ needs.prep.outputs.is_semver }}
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-      - name: SBOM → Dependency-Track (clickhouse-migrations)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${{ steps.clickhouse-manifest.outputs.digest }}
-          project-name: ${{ env.CLICKHOUSE_MIGRATIONS_PROJECT }}
-          project-version: ${{ needs.prep.outputs.version }}
-          is-latest: ${{ needs.prep.outputs.is_semver }}
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-      - name: SBOM → Dependency-Track (metrics-worker)
-        uses: ./.github/actions/sbom-dependency-track
-        with:
-          image-ref: ${{ env.WORKER_IMAGE }}@${{ steps.worker-manifest.outputs.digest }}
-          project-name: ${{ env.WORKER_PROJECT }}
-          project-version: ${{ needs.prep.outputs.version }}
-          is-latest: ${{ needs.prep.outputs.is_semver }}
-          project-tags: oss,container,docker
-          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
-          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
-
-      - name: Sign images with Cosign (keyless)
-        env:
-          APP_DIGEST: ${{ steps.app-manifest.outputs.digest }}
-          MIGRATIONS_DIGEST: ${{ steps.migrations-manifest.outputs.digest }}
-          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
-          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
-        run: |
-          cosign sign --yes "${{ env.APP_IMAGE }}@${APP_DIGEST}"
-          cosign sign --yes "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}"
-          cosign sign --yes "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}"
-          cosign sign --yes "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"
-
-  verify-signatures:
-    runs-on: ubuntu-22.04
-    needs: merge
-    permissions:
-      contents: read
-    steps:
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
-      - name: Log in to container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ secrets.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - name: Verify signatures
-        env:
-          APP_DIGEST: ${{ needs.merge.outputs.app_digest }}
-          MIGRATIONS_DIGEST: ${{ needs.merge.outputs.migrations_digest }}
-          CLICKHOUSE_DIGEST: ${{ needs.merge.outputs.clickhouse_digest }}
-          WORKER_DIGEST: ${{ needs.merge.outputs.worker_digest }}
-        run: |
-          for REF in \
-            "${{ env.APP_IMAGE }}@${APP_DIGEST}" \
-            "${{ env.MIGRATIONS_IMAGE }}@${MIGRATIONS_DIGEST}" \
-            "${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${CLICKHOUSE_DIGEST}" \
-            "${{ env.WORKER_IMAGE }}@${WORKER_DIGEST}"; do
-            cosign verify "${REF}" \
-              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@refs/tags/.+" \
-              --certificate-oidc-issuer https://token.actions.githubusercontent.com
-          done
+  worker-images:
+    needs: [prep, test-gateway, test-worker]
+    uses: ./.github/workflows/worker-pipeline.yaml
+    with:
+      image-tag: ${{ needs.prep.outputs.version }}
+      push-latest: ${{ needs.prep.outputs.is_final == 'true' }}
+    secrets: inherit
 
   source-sbom:
     runs-on: ubuntu-22.04
@@ -347,7 +100,7 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           project-name: ${{ env.GATEWAY_PYTHON_PROJECT }}
           project-version: ${{ needs.prep.outputs.version }}
-          is-latest: ${{ needs.prep.outputs.is_semver }}
+          is-latest: ${{ needs.prep.outputs.is_final }}
           project-tags: oss,python,source
           dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
           dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
@@ -357,7 +110,7 @@ jobs:
           working-directory: ./ui
           project-name: ${{ env.UI_PROJECT }}
           project-version: ${{ needs.prep.outputs.version }}
-          is-latest: ${{ needs.prep.outputs.is_semver }}
+          is-latest: ${{ needs.prep.outputs.is_final }}
           project-tags: oss,npm,source
           dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
           dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
@@ -369,7 +122,7 @@ jobs:
           uv-version: ${{ env.UV_VERSION }}
           project-name: ${{ env.WORKER_PYTHON_PROJECT }}
           project-version: ${{ needs.prep.outputs.version }}
-          is-latest: ${{ needs.prep.outputs.is_semver }}
+          is-latest: ${{ needs.prep.outputs.is_final }}
           project-tags: oss,python,source
           dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
           dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,44 @@
+name: tests
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: Path of the component to test (gateway / metrics-worker).
+        required: true
+        type: string
+      run-pytest:
+        description: Whether to run the pytest suite (gateway only).
+        required: false
+        default: false
+        type: boolean
+
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.7.13"
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Setup uv
+        run: |
+          curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
+      - name: Run formatting validation
+        run: |
+          uv run ruff check
+      - name: Run format check
+        run: |
+          uv run ruff format --check
+      - name: Run tests
+        if: ${{ inputs.run-pytest }}
+        run: |
+          uv run pytest -v

--- a/.github/workflows/worker-pipeline.yaml
+++ b/.github/workflows/worker-pipeline.yaml
@@ -1,0 +1,214 @@
+name: worker-pipeline
+
+on:
+  workflow_call:
+    inputs:
+      image-tag:
+        description: Tag applied to the built images (e.g. "main" or the release version).
+        required: true
+        type: string
+      push-latest:
+        description: Also tag images as :latest and mark them as latest in Dependency-Track.
+        required: false
+        default: false
+        type: boolean
+
+env:
+  WORKER_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-metrics-worker
+  CLICKHOUSE_MIGRATIONS_IMAGE: ${{ secrets.IMAGE_PREFIX }}/radicalbit-ai-gateway-clickhouse-migrations
+  # Dependency-Track project names (registry-independent, stable across builds)
+  WORKER_PROJECT: metrics-worker
+  CLICKHOUSE_MIGRATIONS_PROJECT: radicalbit-ai-gateway-clickhouse-migrations
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            platform_short: amd64
+          - platform: linux/arm64
+            runner: ubuntu-22.04-arm
+            platform_short: arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            network=host
+            env.BUILDKIT_STEP_LOG_MAX_SIZE=50000000
+            env.BUILDKIT_STEP_LOG_MAX_SPEED=100000000
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and push metrics-worker image by digest
+        id: build-worker
+        uses: docker/build-push-action@v6
+        with:
+          context: ./metrics-worker
+          file: ./metrics-worker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.WORKER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Build and push clickhouse-migrations image by digest
+        id: build-clickhouse-migrations
+        uses: docker/build-push-action@v6
+        with:
+          context: ./clickhouse-migrations
+          file: ./clickhouse-migrations/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digests
+        run: |
+          mkdir -p /tmp/digests/worker /tmp/digests/clickhouse-migrations
+          touch "/tmp/digests/worker/${WORKER_DIGEST#sha256:}"
+          touch "/tmp/digests/clickhouse-migrations/${CLICKHOUSE_DIGEST#sha256:}"
+        env:
+          WORKER_DIGEST: ${{ steps.build-worker.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.build-clickhouse-migrations.outputs.digest }}
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-worker-${{ matrix.platform_short }}
+          path: /tmp/digests/**
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for keyless signing with the GitHub OIDC token
+    outputs:
+      worker_digest: ${{ steps.worker-manifest.outputs.digest }}
+      clickhouse_digest: ${{ steps.clickhouse-manifest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-worker-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Create and push metrics-worker manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+          PUSH_LATEST: ${{ inputs.push-latest }}
+        run: |
+          TAGS="-t ${WORKER_IMAGE}:${IMAGE_TAG}"
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
+            TAGS="$TAGS -t ${WORKER_IMAGE}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${WORKER_IMAGE}@sha256:%s ' $(ls /tmp/digests/worker/))
+      - name: Create and push clickhouse-migrations manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+          PUSH_LATEST: ${{ inputs.push-latest }}
+        run: |
+          TAGS="-t ${CLICKHOUSE_MIGRATIONS_IMAGE}:${IMAGE_TAG}"
+          if [[ "${PUSH_LATEST}" == "true" ]]; then
+            TAGS="$TAGS -t ${CLICKHOUSE_MIGRATIONS_IMAGE}:latest"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf '${CLICKHOUSE_MIGRATIONS_IMAGE}@sha256:%s ' $(ls /tmp/digests/clickhouse-migrations/))
+      - name: Inspect images
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          docker buildx imagetools inspect ${WORKER_IMAGE}:${IMAGE_TAG}
+          docker buildx imagetools inspect ${CLICKHOUSE_MIGRATIONS_IMAGE}:${IMAGE_TAG}
+      - name: Get metrics-worker manifest digest
+        id: worker-manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${WORKER_IMAGE}:${IMAGE_TAG} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+      - name: Get clickhouse-migrations manifest digest
+        id: clickhouse-manifest
+        env:
+          IMAGE_TAG: ${{ inputs.image-tag }}
+        run: |
+          DIGEST=$(docker buildx imagetools inspect ${CLICKHOUSE_MIGRATIONS_IMAGE}:${IMAGE_TAG} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: SBOM → Dependency-Track (metrics-worker)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.WORKER_IMAGE }}@${{ steps.worker-manifest.outputs.digest }}
+          project-name: ${{ env.WORKER_PROJECT }}
+          project-version: ${{ inputs.image-tag }}
+          is-latest: ${{ inputs.push-latest }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+      - name: SBOM → Dependency-Track (clickhouse-migrations)
+        uses: ./.github/actions/sbom-dependency-track
+        with:
+          image-ref: ${{ env.CLICKHOUSE_MIGRATIONS_IMAGE }}@${{ steps.clickhouse-manifest.outputs.digest }}
+          project-name: ${{ env.CLICKHOUSE_MIGRATIONS_PROJECT }}
+          project-version: ${{ inputs.image-tag }}
+          is-latest: ${{ inputs.push-latest }}
+          project-tags: oss,container,docker
+          dt-url: ${{ secrets.DEPENDENCYTRACK_URL }}
+          dt-api-key: ${{ secrets.DEPENDENCYTRACK_API_KEY }}
+
+      - name: Sign images with Cosign (keyless)
+        env:
+          WORKER_DIGEST: ${{ steps.worker-manifest.outputs.digest }}
+          CLICKHOUSE_DIGEST: ${{ steps.clickhouse-manifest.outputs.digest }}
+        run: |
+          cosign sign --yes "${WORKER_IMAGE}@${WORKER_DIGEST}"
+          cosign sign --yes "${CLICKHOUSE_MIGRATIONS_IMAGE}@${CLICKHOUSE_DIGEST}"
+
+  verify-signatures:
+    runs-on: ubuntu-22.04
+    needs: merge
+    permissions:
+      contents: read
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Verify signatures
+        env:
+          WORKER_DIGEST: ${{ needs.merge.outputs.worker_digest }}
+          CLICKHOUSE_DIGEST: ${{ needs.merge.outputs.clickhouse_digest }}
+          EXPECTED_REF: ${{ github.ref }}
+        run: |
+          for REF in \
+            "${WORKER_IMAGE}@${WORKER_DIGEST}" \
+            "${CLICKHOUSE_MIGRATIONS_IMAGE}@${CLICKHOUSE_DIGEST}"; do
+            cosign verify "${REF}" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/.+@${EXPECTED_REF}$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          done


### PR DESCRIPTION
## Summary

Three problems in the current setup:

1. **Pre-release tags overwrote `latest`.** `v0.1.0-rc` matched the unanchored
   semver regex (`^v[0-9]+\.[0-9]+\.[0-9]+`), so an RC moved `:latest` on all four
   Docker Hub images and flagged itself latest in Dependency-Track.
2. **CI runs failed on tag pushes.** `gateway-wf` / `metrics-worker-wf` triggered on
   `v*.*.*` tags, but their `cosign verify` policy only accepts `refs/heads/main`
   certificates — tag-triggered runs always went red at verification.
3. **~1200 lines of duplicated jobs.** Build / merge / sign / verify / SBOM existed
   three times (release + both CI workflows), diverging only in parameters.

### What changed

**New architecture — job logic lives in reusable workflows, triggers are thin callers:**

| File | Role |
|---|---|
| `tests.yaml` *(new)* | Reusable: ruff (+ pytest for gateway) |
| `gateway-pipeline.yaml` *(new)* | Reusable: build (amd64/arm64) → merge + sign → verify, for app + migrations |
| `worker-pipeline.yaml` *(new)* | Reusable: same, for metrics-worker + clickhouse-migrations |
| `gateway-workflow.yaml` | Thin trigger: PR → tests; main → tests + pipeline(`:main`) + source SBOM |
| `metrics-worker-workflow.yaml` | Thin trigger, same shape |
| `release.yaml` | prep → tests ×2 → publish-pypi + both pipelines + source SBOM |

**Behavior fixes:**

- `prep` now distinguishes `is_semver` (final **or** pre-release, anchored) from
  `is_final` (exact `vX.Y.Z`). Only final releases get `:latest` on Docker Hub and
  `isLatest=true` in Dependency-Track.
- CI workflows no longer trigger on tags — tags are handled exclusively by `release.yaml`.
- `release.yaml` runs the full test suites; failures block `publish-pypi` and all
  image publishing (previously tests never gated releases).
- `cosign verify` identity is now pinned to the run's own ref
  (`…@${GITHUB_REF}$`) instead of per-workflow regexps — correct for both
  `refs/heads/main` and `refs/tags/*` with no mode-specific policy to maintain.
- Interpolated values reach shell scripts via `env:` instead of `${{ }}` inline
  (script-injection hardening).

### Release behavior by tag

| Tag | PyPI | Docker Hub | Dependency-Track |
|---|---|---|---|
| `v0.1.0` | `0.1.0` | `:v0.1.0` + `:latest` | latest = true |
| `v0.1.0-rc` | `0.1.0rc0` (pre-release) | `:v0.1.0-rc` only | latest = false |
| other | — | `:<tag>` only | latest = false |

### Validation

- `actionlint` clean on all 6 workflow files (validates reusable-workflow calls,
  input types, expressions, shell blocks).
- Job graphs verified: both pipelines gate on both test jobs; publish paths
  unchanged (digest-pinned multi-arch, keyless cosign, OIDC trusted publishing).

## Linked Issue
Closes #123

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
