### PR TITLE
fix: release now triggers on github release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,10 @@
 name: release
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 concurrency:
-  group: docker-tag-${{ github.ref_name }}
+  group: docker-tag-${{ github.event.release.tag_name }}
   cancel-in-progress: true
 
 env:
@@ -26,10 +25,12 @@ jobs:
     steps:
       - name: Set version/tag
         id: check
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
-          echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
-          echo "is_semver=$(if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_OUTPUT
-          echo "is_final=$(if [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then echo 'true'; else echo 'false'; fi)" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "is_semver=$(if [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then echo 'true'; else echo 'false'; fi)" >> "$GITHUB_OUTPUT"
+          echo "is_final=$(if [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then echo 'true'; else echo 'false'; fi)" >> "$GITHUB_OUTPUT"
 
   test-gateway:
     uses: ./.github/workflows/tests.yaml


### PR DESCRIPTION
## Summary

## Change release trigger from tag push to GitHub release

### What changes

The release pipeline (`.github/workflows/release.yaml`) no longer starts when a
tag is pushed. It now runs when a **GitHub release is published**, with the tag
created directly in the release form.

### Why

Releasing from the GitHub release page makes the release an explicit, deliberate
act: the tag, release notes, and pipeline all originate from one place. A tag
pushed without a release no longer triggers any CI.

### Details

| Before | After |
|---|---|
| Trigger: `push: tags: ['*']` | Trigger: `release: types: [published]` |
| Version from `GITHUB_REF_NAME` | Version from `github.event.release.tag_name` |
| Concurrency: `docker-tag-${{ github.ref_name }}` | Concurrency: `docker-tag-${{ github.event.release.tag_name }}` |

- The `prep` job still validates the tag with the same semver regexes and
  exposes `version` / `is_semver` / `is_final` to downstream jobs, so the rest
  of the pipeline (tests, PyPI, images, SBOMs) is unchanged.
- Pre-release tags (e.g. `v0.1.0-rc.2`) behave as before: full pipeline runs,
  images tagged with the RC version, `:latest` and "latest" SBOM markers are
  not touched.
- Main-branch CI (`gateway-wf`, `metrics-worker-wf`) is unaffected.

### How to release now

1. Create a release on GitHub, typing the new tag (e.g. `v1.2.3`) in the
   release form — or select an existing tag.
2. Publish the release. The pipeline runs against that tag.

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
