### PR TITLE
feat: readme and description for pypy

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -1,0 +1,17 @@
+# Radicalbit AI Gateway
+
+A configurable LLM proxy with guardrails, rate limiting, routing, cost tracking
+and observability. Everything is managed through a UI — and an AI assistant
+that generates the configuration from plain English.
+
+## About this package
+
+This Python package is distributed for development and plugin development.
+For a complete run of the gateway, the recommended way is the Docker image.
+
+For the quickstart, configuration, and deployment refer to the repository
+README and documentation:
+
+- [README & quickstart](https://github.com/radicalbit/radicalbit-ai-gateway#readme)
+- [Documentation](https://docs.ai-gateway.radicalbit.ai/)
+- [Releases](https://github.com/radicalbit/radicalbit-ai-gateway/releases)

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "radicalbit-ai-gateway"
 dynamic = ["version"]
-description = "Add your description here"
+description = "Extensible LLM gateway with guardrails, rate limiting, routing, cost tracking and observability. This package is distributed for development and plugin development."
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
@@ -51,6 +51,12 @@ dependencies = [
     "python-multipart>=0.0.20",
     "mcp>=1.13,<2",
 ]
+
+[project.urls]
+Homepage = "https://github.com/radicalbit/radicalbit-ai-gateway"
+Repository = "https://github.com/radicalbit/radicalbit-ai-gateway"
+Documentation = "https://docs.ai-gateway.radicalbit.ai/"
+Changelog = "https://github.com/radicalbit/radicalbit-ai-gateway/releases"
 
 [project.scripts]
 radicalbit-ai-gateway = "radicalbit_ai_gateway.cli:app"


### PR DESCRIPTION
## Summary

## Add PyPI package description and readme

### Why

The `radicalbit-ai-gateway` package is published to PyPI, but its page was effectively empty:

- `description` was the scaffold placeholder (`"Add your description here"`) and was published as-is
- `readme = "README.md"` pointed to a file that did not exist, so the published sdist/wheel carried **no long description at all**

The package is not the recommended way to run the gateway — users run the Docker image (Compose locally, Kubernetes in production) — but it is the artifact used for development and plugin development (plugins depend on it and register entry points under `radicalbit_ai_gateway.plugins`). The PyPI page needed to say exactly that, so nobody `pip install`s it expecting a turnkey gateway.

### What changed

**`gateway/pyproject.toml`**

- Real `description` summary, using stable feature categories (guardrails, rate limiting, routing, cost tracking, observability) that don't need updating as concrete features are added or removed
- New `[project.urls]` table (Homepage, Repository, Documentation, Changelog) → these render as sidebar links on the PyPI project page

**`gateway/README.md` (new)**

- Fixes the dangling `readme` reference; this file becomes the PyPI long description
- Deliberately a minimal stub: one-paragraph intro, an "About this package" note (development and plugin development; Docker image recommended to run the gateway), and links to the repository README, documentation, and releases
- Intentionally **not** a copy of the repo README: it would drift out of sync, and its relative image paths cannot render on PyPI. The repo README remains the single source of truth for quickstart and deployment; this stub only points to it
- No images, no provider list, no quickstart commands — nothing that can diverge

The package name is unchanged: the package *is* the gateway backend (full server + CLI), and plugins install on top of it. This follows the established pattern of Apache Airflow / Apache Superset / MLflow — full product on PyPI with a readme that steers runtime users to the Docker image.

### Verification

- `uv build` in `gateway/`
- Inspected the sdist `PKG-INFO`: `Summary` is the new one-liner, the readme body is present as the long description, and all 4 `Project-URL` entries are emitted

### Notes

No CI changes: the existing release workflow (`uv build` + `uv publish` on semver tags) picks this up with the next release.
