### PR TITLE
feat: add exact caching support for transcription requests

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -714,6 +714,49 @@ class GatewayRoute:
         set_operation_category(OperationCategory.ROUTING)
         model_selected = self._select_and_prepare_transcription_model()
 
+        use_cache = self.gateway_cache and self.gateway_cache.cache_type in (
+            CacheType.EXACT,
+            CacheType.IN_MEMORY,
+        )
+        cache_key = ''
+        if use_cache:
+            set_operation_category(OperationCategory.CACHE)
+            cache_key = self.gateway_cache.generate_transcription_cache_key(
+                project_uuid=self.project_uuid,
+                route_name=route_name,
+                key_uuid=api_key_uuid,
+                audio_bytes=audio_bytes,
+                model_id=model_selected.model_id,
+                response_format=requested_response_format,
+                language=language,
+                prompt=prompt,
+                temperature=temperature,
+            )
+            raw_cached_response = await self.gateway_cache.get(cache_key)
+            if raw_cached_response:
+                logger.debug('Transcription cache hit. Key: %s', cache_key)
+                cached_body: Transcription | TranscriptionVerbose
+                if requested_response_format == 'verbose_json':
+                    cached_body = TranscriptionVerbose.model_validate_json(
+                        raw_cached_response
+                    )
+                else:
+                    cached_body = Transcription.model_validate_json(raw_cached_response)
+
+                self._emit_cache_events_and_metrics(
+                    request_uuid=request_uuid,
+                    api_key_uuid=api_key_uuid,
+                    group_uuid=group_uuid,
+                    api_key_name=api_key_name,
+                    group_name=group_name,
+                    route_name=route_name,
+                    model_id=model_selected.model_id,
+                    usage=None,
+                    cache_type=self.gateway_cache.cache_type,
+                )
+
+                return cached_body
+
         if self.budget_limiter:
             set_operation_category(OperationCategory.LIMITING)
             await self.budget_limiter.check_budget()
@@ -752,6 +795,13 @@ class GatewayRoute:
         )
 
         await self._count_transcription_usage(result.usage, model_selected)
+
+        if use_cache and cache_key:
+            await self.gateway_cache.set(
+                cache_key=cache_key,
+                response=result.model_dump_json(indent=None),
+                ttl=self.ttl,
+            )
 
         return result
 

--- a/gateway/radicalbit_ai_gateway/caching/gateway_cache.py
+++ b/gateway/radicalbit_ai_gateway/caching/gateway_cache.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 from langchain_core.messages import BaseMessage
@@ -87,3 +88,29 @@ class GatewayCache:
         **kwargs,
     ) -> str:
         return f'inputs:{json.dumps(input_texts, ensure_ascii=False)};extra_args:{json.dumps(kwargs)}'
+
+    def generate_transcription_cache_key(
+        self,
+        project_uuid: str,
+        route_name: str,
+        key_uuid: str,
+        audio_bytes: bytes,
+        **kwargs,
+    ) -> str:
+        request_signature = self._build_transcription_request_signature(
+            audio_bytes=audio_bytes,
+            **kwargs,
+        )
+        return self.cache_client.generate_cache_key(
+            project_uuid, route_name, request_signature, key_uuid
+        )
+
+    @staticmethod
+    def _build_transcription_request_signature(
+        audio_bytes: bytes,
+        **kwargs,
+    ) -> str:
+        # The audio itself is hashed separately (never embedded raw) — it's
+        # binary, not text, and would otherwise dominate the signature size.
+        audio_hash = hashlib.sha256(audio_bytes).hexdigest()
+        return f'audio_hash:{audio_hash};extra_args:{json.dumps(kwargs)}'

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from freezegun import freeze_time
 from langchain_core.messages import HumanMessage, SystemMessage
 from openai.types import CreateEmbeddingResponse
+from openai.types.audio.transcription import Transcription
+from openai.types.audio.transcription_verbose import TranscriptionVerbose
 from openai.types.chat.chat_completion import ChatCompletion
 import pook
 import pytest
@@ -1089,6 +1091,165 @@ async def test_invoke_transcription_success():
         project_uuid='',
         project_name='',
     )
+
+
+@patch('radicalbit_ai_gateway.ai_gateway.emit_event', autospec=True)
+@pytest.mark.asyncio
+async def test_invoke_transcription_cache_miss_then_hit_skips_reinvocation(
+    mock_emit_event,
+):
+    cost_service = MagicMock(spec_set=CostService)
+    whisper_model = Model(
+        model_id='whisper-1',
+        model='openai/whisper-1',
+        credentials=Credentials(api_key='sk-test'),
+    )
+    route_cfg = _make_transcription_route_config()
+    gateway_cache = GatewayCache(CacheToolsInMemory())
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=[whisper_model],
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=gateway_cache,
+        cost_service=cost_service,
+    )
+    ai_gateway.budget_limiter = MagicMock(
+        check_budget=AsyncMock(), count_duration=AsyncMock()
+    )
+
+    fake_result = Transcription(
+        text='Ciao, questo è un test.', usage={'type': 'duration', 'seconds': 9}
+    )
+    ai_gateway.transcription_invoker.transcribe = AsyncMock(return_value=fake_result)
+
+    kwargs = {
+        'request_uuid': str(REQUEST_UUID),
+        'api_key_uuid': str(API_KEY_UUID),
+        'group_uuid': str(GROUP_UUID),
+        'api_key_name': 'rb-key',
+        'group_name': 'test-group',
+        'route_name': 'rb-gateway',
+        'audio_bytes': b'fake-audio',
+        'filename': 'test.wav',
+        'content_type': 'audio/wav',
+    }
+
+    first_result = await ai_gateway.invoke_transcription(**kwargs)
+    assert first_result == fake_result
+    ai_gateway.transcription_invoker.transcribe.assert_awaited_once()
+    ai_gateway.budget_limiter.check_budget.assert_awaited_once()
+
+    second_result = await ai_gateway.invoke_transcription(**kwargs)
+    assert second_result == fake_result
+    # Still called once each — the second call must be served from cache,
+    # never reaching the invoker or the budget limiter.
+    ai_gateway.transcription_invoker.transcribe.assert_awaited_once()
+    ai_gateway.budget_limiter.check_budget.assert_awaited_once()
+
+
+@patch('radicalbit_ai_gateway.ai_gateway.emit_event', autospec=True)
+@pytest.mark.asyncio
+async def test_invoke_transcription_cache_hit_verbose_json_roundtrips(
+    mock_emit_event,
+):
+    cost_service = MagicMock(spec_set=CostService)
+    whisper_model = Model(
+        model_id='whisper-1',
+        model='openai/whisper-1',
+        credentials=Credentials(api_key='sk-test'),
+    )
+    route_cfg = _make_transcription_route_config()
+    gateway_cache = GatewayCache(CacheToolsInMemory())
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=[whisper_model],
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=gateway_cache,
+        cost_service=cost_service,
+    )
+
+    fake_result = TranscriptionVerbose(
+        task='transcribe',
+        language='italian',
+        duration=8.25,
+        text='Ciao, questo è un test.',
+        segments=[],
+        usage={'type': 'duration', 'seconds': 9},
+    )
+    ai_gateway.transcription_invoker.transcribe = AsyncMock(return_value=fake_result)
+
+    kwargs = {
+        'request_uuid': str(REQUEST_UUID),
+        'api_key_uuid': str(API_KEY_UUID),
+        'group_uuid': str(GROUP_UUID),
+        'api_key_name': 'rb-key',
+        'group_name': 'test-group',
+        'route_name': 'rb-gateway',
+        'audio_bytes': b'fake-audio',
+        'filename': 'test.wav',
+        'content_type': 'audio/wav',
+        'requested_response_format': 'verbose_json',
+    }
+
+    await ai_gateway.invoke_transcription(**kwargs)
+    second_result = await ai_gateway.invoke_transcription(**kwargs)
+
+    ai_gateway.transcription_invoker.transcribe.assert_awaited_once()
+    assert isinstance(second_result, TranscriptionVerbose)
+    assert second_result.language == 'italian'
+    assert second_result.segments == []
+
+
+@patch('radicalbit_ai_gateway.ai_gateway.emit_event', autospec=True)
+@pytest.mark.asyncio
+async def test_invoke_transcription_cache_miss_when_audio_bytes_differ(
+    mock_emit_event,
+):
+    cost_service = MagicMock(spec_set=CostService)
+    whisper_model = Model(
+        model_id='whisper-1',
+        model='openai/whisper-1',
+        credentials=Credentials(api_key='sk-test'),
+    )
+    route_cfg = _make_transcription_route_config()
+    gateway_cache = GatewayCache(CacheToolsInMemory())
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=[],
+        embedding_models=None,
+        transcription_models=[whisper_model],
+        guardrail_engine=MagicMock(spec_set=GuardrailEngine),
+        gateway_cache=gateway_cache,
+        cost_service=cost_service,
+    )
+
+    fake_result = Transcription(
+        text='Ciao, questo è un test.', usage={'type': 'duration', 'seconds': 9}
+    )
+    ai_gateway.transcription_invoker.transcribe = AsyncMock(return_value=fake_result)
+
+    common_kwargs = {
+        'request_uuid': str(REQUEST_UUID),
+        'api_key_uuid': str(API_KEY_UUID),
+        'group_uuid': str(GROUP_UUID),
+        'api_key_name': 'rb-key',
+        'group_name': 'test-group',
+        'route_name': 'rb-gateway',
+        'filename': 'test.wav',
+        'content_type': 'audio/wav',
+    }
+
+    await ai_gateway.invoke_transcription(audio_bytes=b'audio-one', **common_kwargs)
+    await ai_gateway.invoke_transcription(audio_bytes=b'audio-two', **common_kwargs)
+
+    assert ai_gateway.transcription_invoker.transcribe.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/gateway/tests/caching/test_gateway_cache.py
+++ b/gateway/tests/caching/test_gateway_cache.py
@@ -376,3 +376,106 @@ def test_embedding_hash_name_in_memory():
     assert cache_key.startswith(
         f'response:aigateway:cache:{PROJECT_UUID}:rb-gateway:fake-uuid:'
     )
+
+
+def test_transcription_hash_name_redis(fake_redis_client):
+    redis_cache = RedisCache(fake_redis_client)
+    gateway_cache = GatewayCache(cache_client=redis_cache)
+
+    cache_key = gateway_cache.generate_transcription_cache_key(
+        project_uuid=PROJECT_UUID,
+        route_name='rb-gateway',
+        key_uuid='fake-uuid',
+        audio_bytes=b'fake-audio-bytes',
+        model_id='whisper-1',
+        response_format='json',
+        language=None,
+        prompt=None,
+        temperature=None,
+    )
+    assert cache_key.startswith(
+        f'response:aigateway:cache:{PROJECT_UUID}:rb-gateway:fake-uuid:'
+    )
+
+
+def test_transcription_hash_name_in_memory():
+    in_memory_cache = CacheToolsInMemory()
+    gateway_cache = GatewayCache(cache_client=in_memory_cache)
+
+    cache_key = gateway_cache.generate_transcription_cache_key(
+        project_uuid=PROJECT_UUID,
+        route_name='rb-gateway',
+        key_uuid='fake-uuid',
+        audio_bytes=b'fake-audio-bytes',
+        model_id='whisper-1',
+        response_format='json',
+        language=None,
+        prompt=None,
+        temperature=None,
+    )
+    assert cache_key.startswith(
+        f'response:aigateway:cache:{PROJECT_UUID}:rb-gateway:fake-uuid:'
+    )
+
+
+def test_transcription_hash_name_is_deterministic():
+    gateway_cache = GatewayCache(cache_client=CacheToolsInMemory())
+
+    kwargs = {
+        'project_uuid': PROJECT_UUID,
+        'route_name': 'rb-gateway',
+        'key_uuid': 'fake-uuid',
+        'audio_bytes': b'fake-audio-bytes',
+        'model_id': 'whisper-1',
+        'response_format': 'json',
+        'language': None,
+        'prompt': None,
+        'temperature': None,
+    }
+    assert gateway_cache.generate_transcription_cache_key(
+        **kwargs
+    ) == gateway_cache.generate_transcription_cache_key(**kwargs)
+
+
+def test_transcription_hash_name_differs_by_audio_bytes():
+    gateway_cache = GatewayCache(cache_client=CacheToolsInMemory())
+
+    common_kwargs = {
+        'project_uuid': PROJECT_UUID,
+        'route_name': 'rb-gateway',
+        'key_uuid': 'fake-uuid',
+        'model_id': 'whisper-1',
+        'response_format': 'json',
+        'language': None,
+        'prompt': None,
+        'temperature': None,
+    }
+    key_1 = gateway_cache.generate_transcription_cache_key(
+        audio_bytes=b'audio-one', **common_kwargs
+    )
+    key_2 = gateway_cache.generate_transcription_cache_key(
+        audio_bytes=b'audio-two', **common_kwargs
+    )
+    assert key_1 != key_2
+
+
+def test_transcription_hash_name_differs_by_params():
+    gateway_cache = GatewayCache(cache_client=CacheToolsInMemory())
+
+    common_kwargs = {
+        'project_uuid': PROJECT_UUID,
+        'route_name': 'rb-gateway',
+        'key_uuid': 'fake-uuid',
+        'audio_bytes': b'fake-audio-bytes',
+        'model_id': 'whisper-1',
+        'language': None,
+        'prompt': None,
+        'temperature': None,
+    }
+    key_json = gateway_cache.generate_transcription_cache_key(
+        response_format='json', **common_kwargs
+    )
+    key_verbose = gateway_cache.generate_transcription_cache_key(
+        response_format='verbose_json', **common_kwargs
+    )
+    assert key_json != key_verbose


### PR DESCRIPTION
# PR Summary: AG-902

Adds exact-cache support for `POST /v1/audio/transcriptions` (non-streaming
only): identical audio + params can now be served from cache instead of
re-calling OpenAI. Extends the existing generic hash-based exact-cache
mechanism already used for chat/embeddings — no new cache infrastructure,
no schema change to the request or response. Rebased onto `main` including
AG-931 (project-scoped cache keys), so transcription caching is isolated
per project from day one.

---

## DTO Changes

None. `Transcription` / `TranscriptionVerbose` (the existing response
models) are unchanged — a cache hit replays the exact same JSON that would
have been returned by the model, just skipping the upstream call.

---

## Affected Endpoints

### `POST /v1/audio/transcriptions` (MODIFIED — behavior only, no request/response schema change)

No change to the request or response shape. New behavior: if the route has
caching enabled (`type: exact`) and an identical request (same audio bytes +
`model`/`response_format`/`language`/`prompt`/`temperature`) was served
recently, the cached response is returned directly — no upstream call, no
budget-limiter check, only a `CACHE_HIT` event is recorded (no cost-savings
sub-event, deliberately out of scope for this ticket).

**Example config:**
```yaml
cache:
  redis_host: valkey-cache
  redis_port: 6379

transcription_models:
  - model_id: gpt4o-transcribe
    model: openai/gpt-4o-transcribe
    credentials:
      api_key: !secret OPENAI_API_KEY

routes:
  transcribe-route:
    transcription_models:
      - gpt4o-transcribe
    caching:
      type: exact
      ttl: 300
```

- Cache key is scoped by `project_uuid` + `route_name` + `key_uuid` +
  a signature hash of (audio bytes + model_id + response_format + language +
  prompt + temperature) — same project-isolation guarantee AG-931 added for
  chat/embedding caching.
- Works with both `RedisCache` (project `cache:` block configured) and the
  in-memory fallback (`CacheToolsInMemory`, used when no `cache:` block is
  present) — same as the existing chat/embedding cache behavior.
- Semantic caching remains out of scope for audio input (no audio-native
  embedding pipeline exists in the gateway).

---

## Other Changes

- `caching/gateway_cache.py` — new `GatewayCache.generate_transcription_cache_key()`
  + `_build_transcription_request_signature()`: audio bytes are hashed
  separately (sha256) before being folded into the signature, since raw
  binary can't be embedded in the existing text-based signature builder
  used by chat/embedding.
- `ai_gateway.py` — `invoke_transcription()` gains a cache check
  (`get`) before the upstream call and a cache write (`set`) after a
  successful invocation, mirroring the existing embedding-cache flow
  exactly (cache hit skips both the model invocation and the budget
  limiter check).
- Test coverage added in `tests/caching/test_gateway_cache.py` (key
  generation: deterministic, differs by audio bytes, differs by params,
  project-scoped) and `tests/ai_gateway_test.py` (cache miss → hit skips
  re-invocation, verbose_json round-trips through the cache, cache miss
  when audio bytes differ).
- Manually verified via Docker: cache hit ~75x faster than a real call with
  byte-identical response; cross-project isolation confirmed (same audio +
  same route name on two different projects sharing one Redis — second
  project gets a genuine cache miss, no leaked response).