### PR TITLE
fix: generator prompt and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,9 +475,14 @@ routes:
       window_size: 1 minute
       max_requests: 100
     token_limiting:
-      algorithm: fixed_window
-      window_size: 1 hour
-      max_tokens: 100000
+      input:
+        algorithm: fixed_window
+        window_size: 1 hour
+        max_token: 100000
+      output:
+        algorithm: fixed_window
+        window_size: 1 hour
+        max_token: 100000
     budget_limiting:
       window_size: 1 month
       max_budget: 50.0

--- a/README.md
+++ b/README.md
@@ -442,7 +442,8 @@ guardrails:
     where: input
     behavior: warn
     parameters:
-      pattern: '\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
+      values:
+        - '\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
 ```
 
 </details>

--- a/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
+++ b/gateway/radicalbit_ai_gateway/models/gateway_route_config.py
@@ -57,7 +57,7 @@ class GatewayRouteConfig(BaseModel):
     )
     budget_limiting: BudgetLimiting | None = Field(
         default=None,
-        description='Budget limiting configuration for the route, specifying input and output token limits.',
+        description='Shared budget limiting configuration for the route, covering input and output costs.',
     )
     duration_limiting: AudioDurationLimiting | None = Field(
         default=None,

--- a/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
+++ b/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
@@ -9,12 +9,14 @@ Never embed literal secrets or placeholder strings.
 ## Top-Level Structure
 
 ```
-chat_models:       # required — list of language models
-embedding_models:  # optional — required for semantic caching
-guardrails:        # optional — defined globally, referenced by name in routes
-routing:           # optional — advanced routing rules, referenced by name in routes
-cache:             # optional — required when any route uses caching
-routes:            # required — named route definitions (use kebab-case names)
+chat_models:          # optional — list of language models
+embedding_models:     # optional — required for semantic caching
+transcription_models: # optional — required for audio transcription routes
+guardrails:           # optional — defined globally, referenced by name in routes
+routing:              # optional — advanced routing rules, referenced by name in routes
+mcp_servers:          # optional — defined globally, referenced by alias in routes
+cache:                # optional — required when any route uses caching
+routes:               # required — named route definitions (use kebab-case names)
 ```
 
 ---
@@ -32,6 +34,8 @@ routes:            # required — named route definitions (use kebab-case names)
 | `params.temperature` | No | Float 0.0–1.0 |
 | `params.max_tokens` | No | Integer |
 | `retry_attempts` | No | Integer, default 3 |
+| `input_cost_per_million_tokens` | No | Float — auto-filled from the built-in price catalog when omitted |
+| `output_cost_per_million_tokens` | No | Float — auto-filled from the built-in price catalog when omitted |
 
 ### Provider / Model Format
 
@@ -54,6 +58,28 @@ Same field structure as `chat_models`. Required when any route uses semantic cac
 |----------|---------|
 | OpenAI | `openai/text-embedding-3-small`, `openai/text-embedding-3-large`, `openai/text-embedding-ada-002` |
 | Google | `google-genai/models/gemini-embedding-001` |
+
+---
+
+## `transcription_models`
+
+Same field structure as `chat_models`. Required when a route handles audio transcription.
+
+```yaml
+transcription_models:
+  - model_id: whisper
+    model: openai/whisper-1
+    credentials:
+      api_key: !secret OPENAI_API_KEY
+
+routes:
+  audio-route:
+    transcription_models:
+      - whisper
+```
+
+`model_id` values must be unique across `chat_models`, `embedding_models`, and
+`transcription_models` — the three namespaces are disjoint.
 
 ---
 
@@ -337,6 +363,47 @@ The embedding model must also be listed in the route's `embedding_models`.
 
 ---
 
+## `mcp_servers`
+
+Defined globally; referenced by alias in a route's `mcp_servers` list. Tools are exposed
+on the route as `{alias}__{tool}`, so an alias must not be empty, contain whitespace, or
+contain `__`. Aliases must be unique case-insensitively.
+
+Streamable HTTP transport:
+
+```yaml
+mcp_servers:
+  - alias: github
+    transport: streamable_http
+    url: https://api.githubcopilot.com/mcp/
+    timeout: 30
+    headers:
+      x-api-key: !secret GITHUB_MCP_TOKEN
+    forward_headers:
+      - authorization
+```
+
+Stdio transport:
+
+```yaml
+mcp_servers:
+  - alias: local-tools
+    transport: stdio
+    command: python
+    args:
+      - -m
+      - my_mcp_server
+    env:
+      API_TOKEN: !secret MY_TOOL_TOKEN
+    cwd: /opt/tools
+```
+
+`forward_headers` must not list transport or framing headers — `host`, `content-length`,
+`content-type`, `accept`, `connection`, `transfer-encoding`, `te`, `upgrade`,
+`mcp-session-id`, `mcp-protocol-version`, `x-rb-tags` are all rejected.
+
+---
+
 ## `cache`
 
 Required at top level when any route uses caching.
@@ -357,18 +424,28 @@ Route names must be **kebab-case**. Every model_id referenced must be declared a
 |-------|-------|
 | `chat_models` | List of `model_id` strings |
 | `embedding_models` | List of embedding `model_id` strings |
+| `transcription_models` | List of transcription `model_id` strings |
 | `guardrails` | List of guardrail names (must be defined globally) |
 | `routing` | Name of a top-level `routing` entry |
-| `fallback` | Fallback chains |
+| `mcp_servers` | List of aliases of top-level `mcp_servers` entries |
+| `fallback` | Fallback chains (route level only — there is no top-level `fallback`) |
 | `caching` | Caching config |
 | `rate_limiting` | Rate limiting config |
 | `token_limiting` | Token limiting config |
 | `budget_limiting` | Required when using `budget` routing rule |
+| `duration_limiting` | Audio-duration limiting; requires `transcription_models` on the route |
+
+Every route must reference at least one of `chat_models`, `embedding_models`, or
+`transcription_models`.
 
 ### `fallback`
 
-Every model_id in `target` and `fallbacks` **must also be listed** in the route's `chat_models`
-(or `embedding_models` for embedding fallbacks). Missing this causes a runtime error.
+Defined **inside a route** — there is no top-level `fallback` key.
+
+`type` is one of `chat` (default), `embedding`, or `transcription`. Every model_id in
+`target` and `fallbacks` **must also be listed** in the route's model list matching that
+type — `chat_models`, `embedding_models`, or `transcription_models`. Missing this causes
+a validation error.
 
 ```yaml
 routes:
@@ -404,7 +481,7 @@ caching:
   ttl: 600
   embedding_model_id: text-embedding-3-small
   similarity_threshold: 0.85
-  distance_metric: cosine     # or euclidean
+  distance_metric: cosine
   dim: 1536
 ```
 
@@ -440,6 +517,24 @@ budget_limiting:
   max_budget: 10.0
 ```
 
+### `duration_limiting`
+
+Caps audio seconds (WAV only). Requires `transcription_models` on the same route.
+
+```yaml
+duration_limiting:
+  algorithm: fixed_window
+  window_size: "1 hour"
+  max_duration_seconds: 3600
+```
+
+Each limiting block sets exactly **one** of `max_requests`, `max_token`, `max_budget`,
+or `max_duration_seconds` — setting more than one is a validation error.
+
+`window_size` units: `second`, `minute`, `hour`, `day`, `week`, `month` (singular or
+plural). With `algorithm: aligned_fixed_window` the window must divide evenly into one
+day: 1/5/10/15/30 minutes, 1/2/3/4/6/8/12 hours, or 1 day.
+
 ---
 
 ## Rules
@@ -459,11 +554,16 @@ budget_limiting:
 - Caching requires `type: exact` or `type: semantic` — `type` is mandatory.
 - Semantic caching requires `embedding_models` on the route and `cache` at top level.
 - `token_length` and `context_length` routing conditions use `gte`, `lte`, or `between` — never a bare `threshold`.
-- Fallback can be defined at the top level or inside a route — both are valid.
+- Fallback is defined **inside a route only** — there is no top-level `fallback` key, and the top-level config rejects unknown keys.
 - Fallback `target` and all `fallbacks` must be listed in the route's `chat_models` (or `embedding_models` for embedding type).
 - `budget_limiting` at route level is required when using the `budget` routing rule.
+- Each limiting block sets exactly one of `max_requests`, `max_token`, `max_budget`, `max_duration_seconds`.
+- `duration_limiting` requires `transcription_models` on the route; `token_limiting` requires chat or embedding models.
+- Only these top-level keys exist: `chat_models`, `embedding_models`, `transcription_models`, `guardrails`, `routing`, `mcp_servers`, `cache`, `routes`. Any other top-level key is rejected.
+- Every route must reference at least one of `chat_models`, `embedding_models`, or `transcription_models`.
+- MCP servers are defined globally and referenced by alias in routes; aliases must not contain whitespace or `__`.
 - Route names should be kebab-case and descriptive (e.g., `customer-service`, `internal-qa`).
-- All `model_id` values must be globally unique across `chat_models` and `embedding_models`.
+- All `model_id` values must be globally unique across `chat_models`, `embedding_models`, and `transcription_models`.
 
 ---
 

--- a/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
+++ b/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
@@ -435,11 +435,13 @@ token_limiting:
 
 ```yaml
 budget_limiting:
-  input:
-    algorithm: fixed_window
-    window_size: "1 day"
-    max_budget: 10.0
+  algorithm: fixed_window
+  window_size: "1 day"
+  max_budget: 10.0
 ```
+
+`budget_limiting` is a single shared limit across input and output costs. Never
+nest it under `input` or `output`.
 
 ---
 

--- a/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
+++ b/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
@@ -481,7 +481,7 @@ caching:
   ttl: 600
   embedding_model_id: text-embedding-3-small
   similarity_threshold: 0.85
-  distance_metric: cosine
+  distance_metric: cosine     # or euclidean, inner_product
   dim: 1536
 ```
 

--- a/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
+++ b/gateway/radicalbit_ai_gateway/services/prompts/config_generator_system_prompt.md
@@ -440,9 +440,6 @@ budget_limiting:
   max_budget: 10.0
 ```
 
-`budget_limiting` is a single shared limit across input and output costs. Never
-nest it under `input` or `output`.
-
 ---
 
 ## Rules


### PR DESCRIPTION
## Summary

Configuration documentation described YAML shapes the Pydantic models do not accept.
Because `Limiting` and `TokenLimiting` do not set `extra='forbid'` (unlike
`GatewayConfig`, which does), the wrong shapes validated without error and **silently
dropped the feature** — configs copied from the README, or emitted by the LLM config
generator, produced routes whose limiting and guardrails quietly did nothing.

## Defects fixed

- **README `token_limiting`** — documented as a flat block, but it requires `input:` /
  `output:` children. The documented form yielded `TokenLimiting(input=None,
  output=None)`, built no limiters at all, and left the route unlimited with no error.
- **Generator prompt `budget_limiting`** — documented nested under `input:` when it is a
  flat block. That form produced a `BudgetLimiting` with every `max_*` as `None`, which
  is truthy, so `_create_item` still ran and raised `ValueError('max_budget must be set
  for budget limiting')` at limiter construction.
- **README `email_detection` guardrail** — used `parameters.pattern`, a field
  `CheckParameter` does not have; it requires `values: list[str]`.
- **Generator prompt Rules** — claimed `fallback` may be declared at the top level, which
  `GatewayConfig`'s `extra='forbid'` rejects outright.

## Gaps filled

Validating every fenced YAML block against `GatewayConfig` surfaced real fields the
generator prompt never mentioned — `transcription_models`, `mcp_servers`, and
`duration_limiting` — meaning the generator could never produce a transcription or
MCP-enabled route. Also added: `fallback.type: transcription`, `model_id` uniqueness
across the three disjoint namespaces, the one-`max_*`-per-block rule, the accepted
`window_size` units, the `aligned_fixed_window` allowed sizes, and the explicit list of
the eight valid top-level keys. Every added snippet is taken from the model definitions
rather than inferred, and was validated against `GatewayConfig` before inclusion.

## Code changes

One, metadata only: the `budget_limiting` field `description=` in
`models/gateway_route_config.py`, which claimed the block carries input and output token
limits. `BudgetLimiting` subclasses `Limiting` directly and is a single flat block
covering total cost; only `token_limiting` has the input/output split. It surfaces in the
generated JSON schema. No field added, removed, renamed, or retyped; no endpoint, DTO,
DAO, table, route, or migration touched.

## Testing

- Every complete YAML config in both files validates against `GatewayConfig`, including
  the newly added transcription example. The README guardrail block now passes where it
  previously failed.
- The new cost, `duration_limiting`, and MCP snippets were each checked against the real
  models; `aligned_fixed_window` was confirmed to accept `30 minutes` and reject
  `1 week`, matching the documented constraint.
- `pytest -k "config_generator or gateway_config or limiting or guardrail"` — 252 passed.

## Notes for reviewers

- One Rules line still omits `transcription` in the constraint on `fallback.target` and
  `fallbacks`, while the `fallback` section above it now covers all three types. Worth a
  one-line follow-up.
- Root cause is the missing `extra='forbid'` on `Limiting` and `TokenLimiting`. Adding it
  would turn this class of mistake into a startup error instead of a silent no-op — out
  of scope here, but the reason these bugs survived.



## Linked Issue
Closes #123

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
