### PR TITLE
feat: transcription and tag

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@radicalbit/formbit": "2.1.0",
-    "@radicalbit/radicalbit-design-system": "2.19.5",
+    "@radicalbit/radicalbit-design-system": "2.19.6",
     "@reduxjs/toolkit": "^2.8.2",
     "@vitejs/plugin-react": "^4.2.1",
     "ace-builds": "^1.33.2",

--- a/ui/src/components/modals/add-routes-to-group/form-fields/project.jsx
+++ b/ui/src/components/modals/add-routes-to-group/form-fields/project.jsx
@@ -29,8 +29,10 @@ function Project() {
         allowClear
         disabled={isError}
         onChange={handleOnChange}
+        optionFilterProp="label"
         options={options}
         placeholder="Please select"
+        showSearch
         value={projectUuid}
       />
     </FormField>

--- a/ui/src/components/tags-filter/context.jsx
+++ b/ui/src/components/tags-filter/context.jsx
@@ -1,0 +1,36 @@
+import { parseTagsFromSearchParams } from '@State/tags-query-params-factory';
+import {
+  createContext, useContext, useMemo, useState,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export const EMPTY_ROW = { id: 'empty', key: undefined, values: [] };
+
+const buildRowsFromSearchParams = (searchParams) => {
+  const rows = parseTagsFromSearchParams(searchParams)
+    .map((tag, index) => ({ id: `${tag.key}-${index}`, key: tag.key, values: tag.values }));
+
+  if (rows.length === 0) {
+    return [EMPTY_ROW];
+  }
+
+  return rows;
+};
+
+const TagsFilterContext = createContext(null);
+
+export const useTagsFilterContext = () => useContext(TagsFilterContext);
+
+export function TagsFilterContextProvider({ children }) {
+  const [searchParams] = useSearchParams();
+
+  const [rows, setRows] = useState(() => buildRowsFromSearchParams(searchParams));
+
+  const value = useMemo(() => ({ rows, setRows }), [rows]);
+
+  return (
+    <TagsFilterContext.Provider value={value}>
+      {children}
+    </TagsFilterContext.Provider>
+  );
+}

--- a/ui/src/components/tags-filter/index.jsx
+++ b/ui/src/components/tags-filter/index.jsx
@@ -1,0 +1,179 @@
+import { useGetTagKeysByProjectQuery } from '@State/projects/api';
+import {
+  Button, Divider, Popover, Select, Skeleton, Void,
+} from '@radicalbit/radicalbit-design-system';
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { EMPTY_ROW, TagsFilterContextProvider, useTagsFilterContext } from './context';
+import TagRow from './tag-row';
+
+const POPOVER_MIN_WIDTH = 520;
+
+const OVERLAY_SELECTORS = '.c-popover, .ant-select-dropdown';
+
+const TRIGGER_WIDTH = 150;
+
+function TagsFilter() {
+  return (
+    <TagsFilterContextProvider>
+      <TagsFilterInner />
+    </TagsFilterContextProvider>
+  );
+}
+
+function TagsFilterInner() {
+  const [searchParams] = useSearchParams();
+  const projectUuid = searchParams.get('projectUuid');
+
+  const { rows } = useTagsFilterContext();
+  const activeCount = rows.filter(({ key, values }) => key && values.length > 0).length;
+  const label = activeCount > 0 ? `${activeCount} selected` : undefined;
+
+  const { handleOnTriggerClick, isOpen, wrapperRef } = usePopoverVisibility();
+  useResetRowsOnProjectChange();
+
+  if (!projectUuid) {
+    return (
+      <Select
+        disabled
+        minWidth={TRIGGER_WIDTH}
+        placeholder="Select a project first"
+      />
+    );
+  }
+
+  return (
+    <Popover
+      content={<PopoverContent />}
+      minWidth={POPOVER_MIN_WIDTH}
+      open={isOpen}
+      placement="bottomLeft"
+      trigger={[]}
+    >
+      <div ref={wrapperRef}>
+        <Select
+          minWidth={TRIGGER_WIDTH}
+          onClick={handleOnTriggerClick}
+          open={false}
+          placeholder="All tags"
+          value={label}
+        />
+      </div>
+    </Popover>
+  );
+}
+
+function PopoverContent() {
+  const [searchParams] = useSearchParams();
+  const projectUuid = searchParams.get('projectUuid');
+
+  const { data, isError, isLoading, isSuccess } = useGetTagKeysByProjectQuery({ projectUuid });
+
+  if (isLoading) {
+    return <Skeleton.Input active block />;
+  }
+
+  if (isError) {
+    return <Void description="Unable to load tags for this project" size="small" />;
+  }
+
+  if (!data?.tagKeys?.length) {
+    return <Void description="No tags found for this project" size="small" />;
+  }
+
+  if (!isSuccess) {
+    return false;
+  }
+
+  return <IsSuccess tagKeys={data.tagKeys} />;
+}
+
+function IsSuccess({ tagKeys }) {
+  const { rows, setRows } = useTagsFilterContext();
+
+  const nextRowId = useRef(0);
+
+  const usedKeys = rows.map((row) => row.key).filter(Boolean);
+  const isAddDisabled = usedKeys.length >= tagKeys.length;
+
+  const handleOnAddRow = () => {
+    nextRowId.current += 1;
+
+    setRows((prev) => [...prev, { id: `new-${nextRowId.current}`, key: undefined, values: [] }]);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {rows.map((row, index) => (
+        <TagRow key={row.id} index={index} rowId={row.id} tagKeys={tagKeys} />
+      ))}
+
+      <Divider />
+
+      <div className="flex flex-row">
+        <Button disabled={isAddDisabled} onClick={handleOnAddRow}>
+          + Add another tag
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const usePopoverVisibility = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handleOnDocumentClick = (event) => {
+      if (wrapperRef.current?.contains(event.target)) {
+        return;
+      }
+
+      const isInsideOverlay = Array.from(document.querySelectorAll(OVERLAY_SELECTORS))
+        .some((overlay) => overlay.contains(event.target));
+
+      if (isInsideOverlay) {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleOnDocumentClick, true);
+
+    return () => {
+      document.removeEventListener('mousedown', handleOnDocumentClick, true);
+    };
+  }, [isOpen]);
+
+  const handleOnTriggerClick = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  return { handleOnTriggerClick, isOpen, wrapperRef };
+};
+
+const useResetRowsOnProjectChange = () => {
+  const [searchParams] = useSearchParams();
+  const projectUuid = searchParams.get('projectUuid');
+
+  const { setRows } = useTagsFilterContext();
+
+  const previousProjectUuid = useRef(projectUuid);
+
+  useEffect(() => {
+    if (previousProjectUuid.current === projectUuid) {
+      return;
+    }
+
+    previousProjectUuid.current = projectUuid;
+
+    setRows([EMPTY_ROW]);
+  }, [projectUuid, setRows]);
+};
+
+export default TagsFilter;

--- a/ui/src/components/tags-filter/tag-row.jsx
+++ b/ui/src/components/tags-filter/tag-row.jsx
@@ -1,0 +1,123 @@
+import Lucide from '@Components/lucide';
+import { useGetTagValuesByProjectQuery } from '@State/projects/api';
+import { appendTagsToParams } from '@State/tags-query-params-factory';
+import { Button, FormField, Select } from '@radicalbit/radicalbit-design-system';
+import { CircleMinus } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
+import { useTagsFilterContext } from './context';
+
+const KEY_SELECT_WIDTH = 180;
+const VALUE_SELECT_WIDTH = 260;
+
+const writeRowsToSearchParams = (prev, rows) => {
+  prev.delete('tags');
+
+  appendTagsToParams(prev, rows);
+
+  return prev;
+};
+
+function TagRow({ index, rowId, tagKeys }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const projectUuid = searchParams.get('projectUuid');
+
+  const { rows, setRows } = useTagsFilterContext();
+
+  const row = rows.find((item) => item.id === rowId);
+
+  const { data, isError, isFetching } = useGetTagValuesByProjectQuery(
+    { projectUuid, tagKey: row.key },
+    { skip: !projectUuid || !row.key },
+  );
+
+  const valueOptions = (data?.tagValues ?? []).map((value) => ({ label: value, value }));
+
+  const usedKeys = rows.map((item) => item.key).filter(Boolean);
+  const keyOptions = tagKeys
+    .filter((tagKey) => tagKey === row.key || !usedKeys.includes(tagKey))
+    .map((tagKey) => ({ label: tagKey, value: tagKey }));
+
+  const handleOnKeyChange = (value) => {
+    setRows((prev) => {
+      const next = prev.map((item) => {
+        if (item.id !== rowId) {
+          return item;
+        }
+
+        return { ...item, key: value, values: [] };
+      });
+
+      setSearchParams((current) => writeRowsToSearchParams(current, next));
+
+      return next;
+    });
+  };
+
+  const handleOnValuesChange = (values) => {
+    setRows((prev) => {
+      const next = prev.map((item) => {
+        if (item.id !== rowId) {
+          return item;
+        }
+
+        return { ...item, values };
+      });
+
+      setSearchParams((current) => writeRowsToSearchParams(current, next));
+
+      return next;
+    });
+  };
+
+  const handleOnRemove = () => {
+    setRows((prev) => {
+      if (prev.length === 1) {
+        return prev;
+      }
+
+      const next = prev.filter((item) => item.id !== rowId);
+
+      setSearchParams((current) => writeRowsToSearchParams(current, next));
+
+      return next;
+    });
+  };
+
+  return (
+    <FormField label={`Tag ${index + 1}`}>
+      <div className="flex flex-row items-center gap-2">
+        <Select
+          onChange={handleOnKeyChange}
+          options={keyOptions}
+          placeholder="Select key"
+          style={{ width: KEY_SELECT_WIDTH }}
+          value={row.key || undefined}
+        />
+
+        <Select
+          allowClear
+          disabled={!row.key || isError}
+          loading={isFetching}
+          maxTagCount="responsive"
+          mode="multiple"
+          onChange={handleOnValuesChange}
+          options={valueOptions}
+          placeholder="Select values"
+          style={{ width: VALUE_SELECT_WIDTH }}
+          value={row.values}
+        />
+
+        <Button
+          disabled={rows.length === 1}
+          onClick={handleOnRemove}
+          prefix={<Lucide icon={CircleMinus} />}
+          shape="circle"
+          title="Remove"
+          type="ghost"
+        />
+      </div>
+    </FormField>
+  );
+}
+
+export default TagRow;

--- a/ui/src/container/pages/alerts/list/header/index.jsx
+++ b/ui/src/container/pages/alerts/list/header/index.jsx
@@ -9,8 +9,7 @@ import {
 import { Plus, SlidersHorizontal } from 'lucide-react';
 
 function AlertsListHeader() {
-  const { data = [] } = useGetAlertsQuery();
-  const count = data.length;
+  useGetAlertsQuery();
 
   return (
     <NewHeader

--- a/ui/src/container/pages/routes/detail/body/curl/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/index.jsx
@@ -5,7 +5,7 @@ import SomethingWentWrong from '@Components/error-page/something-went-wrong';
 import Lucide from '@Components/lucide';
 import { useGetProjectQuery } from '@State/projects/api';
 import { useGetRouteByNameWithRange } from '@State/routes/vertical-hooks';
-import { Input, Skeleton } from '@radicalbit/radicalbit-design-system';
+import { Board, Input, SectionTitle, Skeleton, Void } from '@radicalbit/radicalbit-design-system';
 import { Key } from 'lucide-react';
 import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -32,9 +32,12 @@ function Curl() {
   const projectUuid = searchParams.get('projectUuid');
 
   const { isLoading, isError, isSuccess } = useGetProjectQuery(projectUuid, { skip: !projectUuid });
-  const { isLoading: isRouteLoading,
+  const { data: route,
+    isLoading: isRouteLoading,
     isError: isRouteError,
     isSuccess: isRouteSuccess } = useGetRouteByNameWithRange(name);
+  const chatModels = route?.configuration?.chatModels;
+  const transcriptionModels = route?.configuration?.transcriptionModels;
 
   if (isLoading || isRouteLoading) {
     return <Skeleton.Input active block />;
@@ -42,6 +45,10 @@ function Curl() {
 
   if (isError || isRouteError) {
     return <SomethingWentWrong />;
+  }
+
+  if (!chatModels?.length && !transcriptionModels?.length) {
+    return <IsEmpty />;
   }
 
   if (!isSuccess || !isRouteSuccess) {
@@ -57,6 +64,21 @@ function Curl() {
   );
 }
 
+function IsEmpty() {
+  return (
+    <Board
+      main={(
+        <Void
+          description="This route has no models configured yet. cURL examples appear once you add a chat or transcription model."
+          size="small"
+          title="No cURL available"
+        />
+      )}
+      size="small"
+    />
+  );
+}
+
 function ChatCurl() {
   const { name } = useParams();
   const [apiKey, setApiKey] = useState('');
@@ -67,23 +89,37 @@ function ChatCurl() {
   const { data } = useGetProjectQuery(projectUuid, { skip: !projectUuid });
   const projectName = data?.name;
 
+  const { data: route } = useGetRouteByNameWithRange(name);
+  const chatModels = route?.configuration?.chatModels;
+
   const handleOnChangeApiKey = ({ target: { value } }) => { setApiKey(value); };
 
+  if (!chatModels?.length) {
+    return false;
+  }
+
   return (
-    <CodeBlock
-      actions={(
-        <Input
-          onChange={handleOnChangeApiKey}
-          placeholder="Paste your credential"
-          prefix={<Lucide icon={Key} />}
-          value={apiKey}
-        />
+    <Board
+      borderType="none"
+      header={<SectionTitle title="Chat model cURL" />}
+      main={(
+        <CodeBlock
+          actions={(
+            <Input
+              onChange={handleOnChangeApiKey}
+              placeholder="Paste your credential"
+              prefix={<Lucide icon={Key} />}
+              value={apiKey}
+            />
+          )}
+          code={CURL_COMMAND(projectName, name, apiKey)}
+          hasCopyToClipboard
+        >
+          <CodeBlockRawText text={CURL_COMMAND(projectName, name, apiKey)} />
+        </CodeBlock>
       )}
-      code={CURL_COMMAND(projectName, name, apiKey)}
-      hasCopyToClipboard
-    >
-      <CodeBlockRawText text={CURL_COMMAND(projectName, name, apiKey)} />
-    </CodeBlock>
+      size="small"
+    />
   );
 }
 
@@ -98,28 +134,36 @@ function TranscriptionCurl() {
   const projectName = data?.name;
 
   const { data: route } = useGetRouteByNameWithRange(name);
+  const transcriptionModels = route?.configuration?.transcriptionModels;
 
   const handleOnChangeApiKey = ({ target: { value } }) => { setApiKey(value); };
 
-  if (!route?.configuration?.transcriptionModels?.length) {
+  if (!transcriptionModels?.length) {
     return false;
   }
 
   return (
-    <CodeBlock
-      actions={(
-        <Input
-          onChange={handleOnChangeApiKey}
-          placeholder="Paste your credential"
-          prefix={<Lucide icon={Key} />}
-          value={apiKey}
-        />
+    <Board
+      borderType="none"
+      header={<SectionTitle title="Transcription model cURL" />}
+      main={(
+        <CodeBlock
+          actions={(
+            <Input
+              onChange={handleOnChangeApiKey}
+              placeholder="Paste your credential"
+              prefix={<Lucide icon={Key} />}
+              value={apiKey}
+            />
+          )}
+          code={CURL_COMMAND_TRANSCRIPTION(projectName, name, apiKey)}
+          hasCopyToClipboard
+        >
+          <CodeBlockRawText text={CURL_COMMAND_TRANSCRIPTION(projectName, name, apiKey)} />
+        </CodeBlock>
       )}
-      code={CURL_COMMAND_TRANSCRIPTION(projectName, name, apiKey)}
-      hasCopyToClipboard
-    >
-      <CodeBlockRawText text={CURL_COMMAND_TRANSCRIPTION(projectName, name, apiKey)} />
-    </CodeBlock>
+      size="small"
+    />
   );
 }
 

--- a/ui/src/container/pages/routes/list/body/project-filter.jsx
+++ b/ui/src/container/pages/routes/list/body/project-filter.jsx
@@ -48,8 +48,10 @@ function ProjectFilter() {
       allowClear
       disabled={isError}
       onChange={handleOnChange}
+      optionFilterProp="label"
       options={options}
       placeholder="Please select"
+      showSearch
       style={{ width: 400 }}
       value={projectUuid}
     />

--- a/ui/src/container/pages/routes/list/body/table/columns/limits.jsx
+++ b/ui/src/container/pages/routes/list/body/table/columns/limits.jsx
@@ -9,8 +9,9 @@ function Limits({ metrics, configuration }) {
   const rateLimitTriggered = metrics?.rateLimitTriggered;
   const tokenInputLimitTriggered = metrics?.tokenInputLimitTriggered;
   const tokenOutputLimitTriggered = metrics?.tokenOutputLimitTriggered;
+  const durationLimitTriggered = metrics?.durationLimitTriggered;
 
-  if (rateLimitTriggered === undefined && tokenInputLimitTriggered === undefined && tokenOutputLimitTriggered === undefined) {
+  if (rateLimitTriggered === undefined && tokenInputLimitTriggered === undefined && tokenOutputLimitTriggered === undefined && durationLimitTriggered === undefined) {
     return (
       <Button disabled shape="circle">
         <Lucide icon={SlidersHorizontal} />
@@ -18,7 +19,7 @@ function Limits({ metrics, configuration }) {
     );
   }
 
-  const hasTriggered = rateLimitTriggered > 0 || tokenInputLimitTriggered > 0 || tokenOutputLimitTriggered > 0;
+  const hasTriggered = rateLimitTriggered > 0 || tokenInputLimitTriggered > 0 || tokenOutputLimitTriggered > 0 || durationLimitTriggered > 0;
   const btnType = hasTriggered ? { type: 'primary' } : { type: 'primary-light' };
 
   return (
@@ -34,10 +35,12 @@ function PopoverContent({ configuration, metrics }) {
   const rateLimiting = configuration?.rateLimiting;
   const tokenLimitingInput = configuration?.tokenLimiting?.input;
   const tokenLimitingOutput = configuration?.tokenLimiting?.output;
+  const durationLimiting = configuration?.durationLimiting;
 
   const rate = numberFormatterInt(metrics.rateLimitTriggered) ?? '--';
   const tokenIn = numberFormatterInt(metrics.tokenInputLimitTriggered) ?? '--';
   const tokenOut = numberFormatterInt(metrics.tokenOutputLimitTriggered) ?? '--';
+  const duration = numberFormatterInt(metrics.durationLimitTriggered) ?? '--';
 
   const rateLimitingalgorithm = rateLimiting?.algorithm ?? '--';
   const rateLimitingwindowSize = rateLimiting?.windowSize ?? '--';
@@ -51,6 +54,10 @@ function PopoverContent({ configuration, metrics }) {
   const tokenLimitingOutputWindowSize = tokenLimitingOutput?.windowSize ?? '--';
   const tokenLimitingOutputMaxTokens = numberFormatterInt(tokenLimitingOutput?.maxTokens) ?? '--';
 
+  const durationLimitingAlgorithm = durationLimiting?.algorithm ?? '--';
+  const durationLimitingWindowSize = durationLimiting?.windowSize ?? '--';
+  const durationLimitingMaxDurationSeconds = numberFormatterInt(durationLimiting?.maxDurationSeconds) ?? '--';
+
   return (
     <div className="flex flex-col">
       <PopoverRow label="Rate:" value={rate} />
@@ -58,6 +65,8 @@ function PopoverContent({ configuration, metrics }) {
       <PopoverRow label="Token in:" value={tokenIn} />
 
       <PopoverRow label="Token out:" value={tokenOut} />
+
+      <PopoverRow label="Duration:" value={duration} />
 
       <Divider style={{ margin: '.5rem' }} />
 
@@ -88,6 +97,16 @@ function PopoverContent({ configuration, metrics }) {
       <PopoverRow label="Window size:" value={tokenLimitingOutputWindowSize} />
 
       <PopoverRow label="Max tokens:" value={tokenLimitingOutputMaxTokens} />
+
+      <Divider style={{ margin: '.5rem' }} />
+
+      <strong>Duration Limiting</strong>
+
+      <PopoverRow label="Algorithm:" value={durationLimitingAlgorithm} />
+
+      <PopoverRow label="Window size:" value={durationLimitingWindowSize} />
+
+      <PopoverRow label="Max duration (s):" value={durationLimitingMaxDurationSeconds} />
     </div>
   );
 }

--- a/ui/src/container/pages/tracing/list/body/dashboard/index.jsx
+++ b/ui/src/container/pages/tracing/list/body/dashboard/index.jsx
@@ -1,8 +1,24 @@
+import {
+  useGetSpanLatenciesWithRange,
+  useGetTraceLatenciesWithRange,
+  useGetTracesChartWithRange,
+} from '@State/tracing/vertical-hooks';
+import { Skeleton } from '@radicalbit/radicalbit-design-system';
 import SpanLatencies from './span-latencies';
 import TraceLatencies from './trace-latencies';
 import TracesChart from './traces-chart';
 
+const SKELETON_STYLE = { height: '20rem', width: '100%' };
+
 function Dashboard() {
+  const { isLoading: isLoadingChart } = useGetTracesChartWithRange();
+  const { isLoading: isLoadingTraceLatencies } = useGetTraceLatenciesWithRange();
+  const { isLoading: isLoadingSpanLatencies } = useGetSpanLatenciesWithRange({ grouped: true });
+
+  if (isLoadingChart || isLoadingTraceLatencies || isLoadingSpanLatencies) {
+    return <Skeleton.Node active style={SKELETON_STYLE} />;
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <TracesChart />

--- a/ui/src/container/pages/tracing/list/body/dashboard/span-latencies/index.jsx
+++ b/ui/src/container/pages/tracing/list/body/dashboard/span-latencies/index.jsx
@@ -39,7 +39,7 @@ function SpanLatencies() {
 
 function IsSuccess() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { data } = useGetSpanLatenciesWithRange({ grouped: true });
+  const { data, isFetching } = useGetSpanLatenciesWithRange({ grouped: true });
 
   const expandedCategories = useMemo(() => {
     const param = searchParams.get(EXPANDED_PARAM);
@@ -56,7 +56,8 @@ function IsSuccess() {
 
     return items.flatMap(({ category, spans = [], ...percentiles }) => {
       const spanCount = spans.length;
-      const headerRow = { name: category, spanCount, ...percentiles, header: true, key: `header:${category}` };
+      const headerPercentiles = isFetching ? {} : percentiles;
+      const headerRow = { name: category, spanCount, ...headerPercentiles, header: true, key: `header:${category}` };
 
       if (!expandedCategories.has(category)) {
         return [headerRow];
@@ -64,14 +65,14 @@ function IsSuccess() {
 
       const spanRows = (spans || []).map(({ spanName, ...spanPercentiles }) => ({
         name: spanName,
-        ...spanPercentiles,
+        ...(isFetching ? {} : spanPercentiles),
         header: false,
         key: `${category}:${spanName}`,
       }));
 
       return [headerRow, ...spanRows];
     });
-  }, [data?.data, expandedCategories]);
+  }, [data?.data, expandedCategories, isFetching]);
 
   const handleOnRow = (record) => {
     if (!record.header) {

--- a/ui/src/container/pages/tracing/list/body/dashboard/trace-latencies/index.jsx
+++ b/ui/src/container/pages/tracing/list/body/dashboard/trace-latencies/index.jsx
@@ -4,7 +4,7 @@ import { Board, DataTable, SectionTitle, Skeleton, Void } from '@radicalbit/radi
 import columns from './columns';
 
 function TraceLatencies() {
-  const { data, isError, isLoading, isSuccess } = useGetTraceLatenciesWithRange();
+  const { data, isError, isFetching, isLoading, isSuccess } = useGetTraceLatenciesWithRange();
 
   if (isLoading) {
     return (
@@ -29,13 +29,15 @@ function TraceLatencies() {
     return null;
   }
 
+  const dataSource = isFetching ? [{}] : [data];
+
   return (
     <Board
       header={<SectionTitle title="Trace latencies" />}
       main={(
         <DataTable
           columns={columns}
-          dataSource={[data]}
+          dataSource={dataSource}
           pagination={false}
           rowKey="trace-latencies"
         />

--- a/ui/src/container/pages/tracing/list/body/dashboard/traces-chart/index.jsx
+++ b/ui/src/container/pages/tracing/list/body/dashboard/traces-chart/index.jsx
@@ -1,7 +1,7 @@
 import SomethingWentWrong from '@Components/error-page/something-went-wrong';
 import useDarkModeChart, { updateTheme } from '@Hooks/use-chart-dark-mode';
 import { useGetTracesChartWithRange } from '@Src/store/state/tracing/vertical-hooks';
-import { Board, Skeleton, Void } from '@radicalbit/radicalbit-design-system';
+import { Board, Skeleton, Spinner, Void } from '@radicalbit/radicalbit-design-system';
 import ReactEChartsCore from 'echarts-for-react/lib/core';
 import { useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -13,7 +13,7 @@ const chartWidthAndHeight = {
 };
 
 function TracesChart() {
-  const { data, isError, isLoading, isSuccess } = useGetTracesChartWithRange();
+  const { data, isError, isFetching, isLoading, isSuccess } = useGetTracesChartWithRange();
   const chartData = data?.data || [];
 
   if (isLoading) {
@@ -22,6 +22,10 @@ function TracesChart() {
 
   if (isError) {
     return <IsError />;
+  }
+
+  if (isFetching) {
+    return <IsFetching />;
   }
 
   if (!chartData.length) {
@@ -40,6 +44,21 @@ function IsError() {
     <Board
       main={<SomethingWentWrong size="small" style={chartWidthAndHeight} />}
       size="xsmall"
+    />
+  );
+}
+
+function IsFetching() {
+  return (
+    <Board
+      main={(
+        <Void
+          actions={<Spinner spinning />}
+          description="Fetching the latest trace data. The chart will appear as soon as it is ready."
+          style={chartWidthAndHeight}
+          title="Loading traces by time"
+        />
+      )}
     />
   );
 }
@@ -104,10 +123,11 @@ const useGetChartKeyRef = () => {
   const from = searchParams.get('from') || null;
   const to = searchParams.get('to') || null;
   const routes = searchParams.get('routes') || null;
+  const tags = searchParams.getAll('tags').join('&') || null;
 
   useEffect(() => {
-    ref.current = [from, to, routes].filter(Boolean).join('-');
-  }, [from, routes, to]);
+    ref.current = [from, to, routes, tags].filter(Boolean).join('-');
+  }, [from, routes, tags, to]);
 
   return ref;
 };

--- a/ui/src/container/pages/tracing/list/body/index.jsx
+++ b/ui/src/container/pages/tracing/list/body/index.jsx
@@ -62,7 +62,7 @@ function ProjectSelected() {
   };
 
   return (
-    <div className="flex flex-col gap-4 py-4">
+    <>
       <Tabs
         activeKey={activeKey}
         items={items}
@@ -73,7 +73,7 @@ function ProjectSelected() {
       {activeKey === 'dashboard' && <Dashboard />}
 
       {activeKey === 'tracing' && <Tracing />}
-    </div>
+    </>
   );
 }
 

--- a/ui/src/container/pages/tracing/list/body/tracing/columns.jsx
+++ b/ui/src/container/pages/tracing/list/body/tracing/columns.jsx
@@ -11,6 +11,7 @@ import {
 import { Button, Tooltip } from '@radicalbit/radicalbit-design-system';
 import { TriangleAlert } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import TagsCell from './tags-cell';
 
 function AssociatedGroup({ groupName, groupUuid }) {
   const navigate = useNavigate();
@@ -41,6 +42,12 @@ const columns = [
         </div>
       </StatusTooltip>
     ),
+  },
+  {
+    title: 'Tags',
+    dataIndex: 'tags',
+    align: 'left',
+    render: (tags) => <TagsCell tags={tags} />,
   },
   {
     title: 'Group',

--- a/ui/src/container/pages/tracing/list/body/tracing/tags-cell.jsx
+++ b/ui/src/container/pages/tracing/list/body/tracing/tags-cell.jsx
@@ -15,8 +15,8 @@ function TagsCell({ tags }) {
   return (
     <div className="flex flex-col gap-2">
       {visibleTags.map((tag) => (
-        <i>
-          <Tag key={tag} size="large" type="primary-outlined">
+        <i key={tag}>
+          <Tag size="large" type="primary-outlined">
             <Truncate style={{ maxWidth: CELL_WIDTH }} tooltip={{ title: tag, placement: 'top' }}>{tag}</Truncate>
           </Tag>
         </i>
@@ -42,8 +42,8 @@ function HiddenTags({ count, tags }) {
       content={(
         <div className="flex flex-col gap-2">
           {tags.map((tag) => (
-            <i>
-              <Tag key={tag} size="large" type="primary-outlined">
+            <i key={tag}>
+              <Tag size="large" type="primary-outlined">
                 <Truncate style={{ maxWidth: CELL_WIDTH }} tooltip={{ title: tag, placement: 'top' }}>{tag}</Truncate>
               </Tag>
             </i>

--- a/ui/src/container/pages/tracing/list/body/tracing/tags-cell.jsx
+++ b/ui/src/container/pages/tracing/list/body/tracing/tags-cell.jsx
@@ -1,0 +1,61 @@
+import { Popover, Tag, Truncate } from '@radicalbit/radicalbit-design-system';
+
+const VISIBLE_TAGS = 3;
+
+const CELL_WIDTH = '150px';
+
+function TagsCell({ tags }) {
+  if (!tags?.length) {
+    return '--';
+  }
+
+  const visibleTags = tags.slice(0, VISIBLE_TAGS);
+  const hiddenCount = tags.length - visibleTags.length;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {visibleTags.map((tag) => (
+        <i>
+          <Tag key={tag} size="large" type="primary-outlined">
+            <Truncate style={{ maxWidth: CELL_WIDTH }} tooltip={{ title: tag, placement: 'top' }}>{tag}</Truncate>
+          </Tag>
+        </i>
+      ))}
+
+      <HiddenTags count={hiddenCount} tags={tags} />
+    </div>
+  );
+}
+
+function HiddenTags({ count, tags }) {
+  if (count <= 0) {
+    return false;
+  }
+
+  const handleOnClick = (e) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <Popover
+      arrow={false}
+      content={(
+        <div className="flex flex-col gap-2">
+          {tags.map((tag) => (
+            <i>
+              <Tag key={tag} size="large" type="primary-outlined">
+                <Truncate style={{ maxWidth: CELL_WIDTH }} tooltip={{ title: tag, placement: 'top' }}>{tag}</Truncate>
+              </Tag>
+            </i>
+          ))}
+        </div>
+      )}
+      placement="topRight"
+      title="Tags"
+    >
+      <Tag onClick={handleOnClick} rounded type="secondary">{`+${count}`}</Tag>
+    </Popover>
+  );
+}
+
+export default TagsCell;

--- a/ui/src/container/pages/tracing/list/header/index.jsx
+++ b/ui/src/container/pages/tracing/list/header/index.jsx
@@ -1,4 +1,5 @@
 import Lucide from '@Components/lucide';
+import TagsFilter from '@Components/tags-filter';
 import { TimeFilterCustomOnly } from '@Components/time-filter';
 import { FormField, NewHeader, SectionTitle, Select } from '@radicalbit/radicalbit-design-system';
 import { useGetRoutesWithRange } from '@Src/store/state/routes/vertical-hooks';
@@ -17,6 +18,10 @@ function TracingListHeader() {
           <div className="flex flex-row items-center gap-4">
             <FormField label="Project">
               <ProjectFilter />
+            </FormField>
+
+            <FormField label="Tags">
+              <TagsFilter />
             </FormField>
 
             <FormField label="Routes">
@@ -80,6 +85,7 @@ function RouteSelector() {
       onChange={handleChange}
       options={routeNames.map((name) => ({ label: name, value: name }))}
       placeholder="All routes"
+      showSearch
       style={{ width: 250 }}
       value={selectedRoutes}
     />

--- a/ui/src/container/pages/tracing/list/header/project-filter.jsx
+++ b/ui/src/container/pages/tracing/list/header/project-filter.jsx
@@ -19,6 +19,7 @@ function ProjectFilter() {
       setSearchParams((prev) => {
         prev.delete('projectUuid');
         prev.delete('routes');
+        prev.delete('tags');
         return prev;
       }, { replace: true });
     }
@@ -33,6 +34,7 @@ function ProjectFilter() {
       }
 
       prev.delete('routes');
+      prev.delete('tags');
 
       return prev;
     });
@@ -47,8 +49,10 @@ function ProjectFilter() {
       allowClear
       disabled={isError}
       onChange={handleOnChange}
+      optionFilterProp="label"
       options={options}
       placeholder="Please select"
+      showSearch
       style={{ width: 250 }}
       value={projectUuid}
     />

--- a/ui/src/container/pages/usage/list/body/consumptions/columns.jsx
+++ b/ui/src/container/pages/usage/list/body/consumptions/columns.jsx
@@ -1,3 +1,5 @@
+import { Popover } from '@radicalbit/radicalbit-design-system';
+
 const columns = [
   {
     title: '',
@@ -26,10 +28,58 @@ const columns = [
     key: 'semanticCache',
   },
   {
+    title: 'Transcription',
+    dataIndex: 'transcription',
+    key: 'transcription',
+    render: (value) => <TranscriptionCell value={value} />,
+  },
+  {
     title: 'Total',
     dataIndex: 'total',
     key: 'total',
   },
 ];
+
+function TranscriptionCell({ value }) {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return (
+    <Popover
+      content={<TranscriptionPopoverContent value={value} />}
+      minWidth="250"
+      title="Transcription"
+    >
+      <div className="underline decoration-dotted cursor-default w-fit">{value?.total}</div>
+    </Popover>
+  );
+}
+
+function TranscriptionPopoverContent({ value }) {
+  const duration = value?.duration;
+  const audio = value?.audio;
+  const text = value?.text;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <PopoverRow label="Duration:" value={duration} />
+
+      <PopoverRow label="Audio:" value={audio} />
+
+      <PopoverRow label="Text:" value={text} />
+    </div>
+  );
+}
+
+function PopoverRow({ label, value }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <div>{label}</div>
+
+      <div>{value}</div>
+    </div>
+  );
+}
 
 export default columns;

--- a/ui/src/container/pages/usage/list/body/consumptions/cost-table.jsx
+++ b/ui/src/container/pages/usage/list/body/consumptions/cost-table.jsx
@@ -28,6 +28,7 @@ const useGetDataSource = () => {
   const { data } = useGetCostsSummaryStreamWithRange({ routes, withSavedTokens: false });
   const chatModels = data?.chatModels;
   const embeddingModels = data?.embeddingModels;
+  const transcriptionModels = data?.transcriptionModels;
   const totals = data?.totals;
 
   return useMemo(() => [
@@ -37,6 +38,14 @@ const useGetDataSource = () => {
       judge: chatModels ? costFormatter({ cent: chatModels?.input?.judges }) : '--',
       embedding: embeddingModels ? costFormatter({ cent: embeddingModels?.input?.embedding }) : '--',
       semanticCache: embeddingModels ? costFormatter({ cent: embeddingModels?.input?.semanticCache }) : '--',
+      transcription: transcriptionModels
+        ? {
+          total: costFormatter({ cent: transcriptionModels?.input?.total }),
+          duration: costFormatter({ cent: transcriptionModels?.input?.duration }),
+          audio: costFormatter({ cent: transcriptionModels?.input?.audio }),
+          text: costFormatter({ cent: transcriptionModels?.input?.text }),
+        }
+        : '--',
       total: costFormatter({ cent: totals?.input }),
     },
     {
@@ -45,6 +54,7 @@ const useGetDataSource = () => {
       judge: chatModels ? costFormatter({ cent: chatModels?.cachedInput?.judges }) : '--',
       embedding: '--',
       semanticCache: '--',
+      transcription: '--',
       total: costFormatter({ cent: totals?.cachedInput }),
     },
     {
@@ -53,9 +63,10 @@ const useGetDataSource = () => {
       judge: chatModels ? costFormatter({ cent: chatModels?.output?.judges }) : '--',
       embedding: '--',
       semanticCache: '--',
+      transcription: transcriptionModels ? costFormatter({ cent: transcriptionModels?.output }) : '--',
       total: costFormatter({ cent: totals?.output }),
     },
-  ], [chatModels, embeddingModels, totals]);
+  ], [chatModels, embeddingModels, transcriptionModels, totals]);
 };
 
 export default CostTable;

--- a/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-inner/index.jsx
+++ b/ui/src/container/pages/usage/list/body/consumptions/costs-graph/costs-graph-inner/index.jsx
@@ -1,5 +1,6 @@
 import SomethingWentWrong from '@Components/error-page/something-went-wrong';
 import useDarkModeChart, { updateTheme } from '@Hooks/use-chart-dark-mode';
+import { parseTagsFromSearchParams } from '@State/tags-query-params-factory';
 import { useGetCostsChartStreamWithRange } from '@State/usage/vertical-hooks';
 import { Board, Segmented, Spinner, Void } from '@radicalbit/radicalbit-design-system';
 import ReactEChartsCore from 'echarts-for-react/lib/core';
@@ -214,13 +215,14 @@ const useRouteBreakdownTooltip = (chartRef) => {
   const { data } = useGetCostsChartStreamWithRange({ routes, groupBy });
   const granularity = data?.chart?.granularity;
   const routesKey = routes.join(',');
+  const tagsKey = searchParams.getAll('tags').join('&');
 
   useEffect(() => {
     routeBreakdownCacheRef.current = new Map();
 
     inFlightRef.current.forEach((req) => req.abort?.());
     inFlightRef.current.clear();
-  }, [groupBy, routesKey, granularity]);
+  }, [groupBy, routesKey, tagsKey, granularity]);
 
   const handleOnMouseOver = (params) => {
     const cacheKey = `${params.seriesName}:${params.name}`;
@@ -243,6 +245,7 @@ const useRouteBreakdownTooltip = (chartRef) => {
       timestamp: params.name,
       granularity,
       routes,
+      tags: parseTagsFromSearchParams(searchParams),
     });
 
     inFlightRef.current.set(cacheKey, req);

--- a/ui/src/container/pages/usage/list/body/consumptions/index.jsx
+++ b/ui/src/container/pages/usage/list/body/consumptions/index.jsx
@@ -1,4 +1,5 @@
 import Lucide from '@Components/lucide';
+import TagsFilter from '@Components/tags-filter';
 import TimeFilter from '@Components/time-filter';
 import { WIDE_MAIN_LAYOUT_CONFIGURATION } from '@Container/layout/layout-provider/layout-provider-configuration';
 import { useGetCostsSummaryStreamWithRange } from '@State/usage/vertical-hooks';
@@ -42,6 +43,10 @@ function Consumptions() {
       <div className="flex flex-row items-center gap-4">
         <FormField label="Project">
           <ProjectFilter />
+        </FormField>
+
+        <FormField label="Tags">
+          <TagsFilter />
         </FormField>
 
         <FormField label="Routes">

--- a/ui/src/container/pages/usage/list/body/consumptions/summary-header.jsx
+++ b/ui/src/container/pages/usage/list/body/consumptions/summary-header.jsx
@@ -14,6 +14,7 @@ function SummaryHeader() {
   const saved = costFormatter({ cent: data?.totals?.saved || 0 });
   const chatModelsTotal = data?.chatModels ? costFormatter({ cent: data?.chatModels?.total }) : '--';
   const embeddingModelsTotal = data?.embeddingModels ? costFormatter({ cent: data?.embeddingModels?.total }) : '--';
+  const transcriptionModelsTotal = data?.transcriptionModels ? costFormatter({ cent: data?.transcriptionModels?.total }) : '--';
 
   return (
     <div className="flex gap-16 items-start">
@@ -33,6 +34,8 @@ function SummaryHeader() {
       <SectionTitle reverse size="large" subtitle="Chat models" title={chatModelsTotal} />
 
       <SectionTitle reverse size="large" subtitle="Embedding models" title={embeddingModelsTotal} />
+
+      <SectionTitle reverse size="large" subtitle="Transcription models" title={transcriptionModelsTotal} />
     </div>
   );
 }

--- a/ui/src/container/pages/usage/list/body/limits/columns.jsx
+++ b/ui/src/container/pages/usage/list/body/limits/columns.jsx
@@ -57,6 +57,11 @@ const columns = [
     render: (progressBar, record) => <RateLimit progressBar={progressBar} routeName={record.routeName} />,
   },
   {
+    title: 'Duration limit',
+    dataIndex: 'progressBar',
+    render: (progressBar, record) => <DurationLimit progressBar={progressBar} routeName={record.routeName} />,
+  },
+  {
     title: '',
     dataIndex: 'margin-right',
     key: 'margin-right',
@@ -266,6 +271,60 @@ function RateLimit({ progressBar, routeName }) {
 function RateLimitPopoverContent({ rate, routeName }) {
   const window = formatWindowLength(rate.windowLength);
   const current = `${numberFormatterInt(rate.windowFilledSize)}/${numberFormatterInt(rate.windowSize)}`;
+
+  return (
+    <div className="flex flex-col">
+      <PopoverRow label="Route:" value={routeName} />
+
+      <PopoverRow label="Window:" value={window} />
+
+      <PopoverRow label="Current:" value={current} />
+    </div>
+  );
+}
+
+function DurationLimit({ progressBar, routeName }) {
+  const duration = progressBar?.duration;
+  const value = numberFormatterInt(duration?.windowFilledPercentage ?? DEFAULT_VALUE);
+  const status = duration?.windowStatus ?? DEFAULT_STATUS;
+  const type = STATUS_TO_TYPE[status];
+
+  if (!duration) {
+    return (
+      <div className="flex flex-row gap-2 items-center">
+        <BarChart
+          className="w-full"
+          type={type}
+          value={value}
+        />
+
+        <small className="min-w-20">--</small>
+      </div>
+    );
+  }
+
+  return (
+    <Popover
+      content={<DurationLimitPopoverContent duration={duration} routeName={routeName} />}
+      minWidth="250"
+      title={<strong>Duration limit</strong>}
+    >
+      <div className="flex flex-row gap-2 items-center">
+        <BarChart
+          className="w-full"
+          type={type}
+          value={value}
+        />
+
+        <small className="min-w-20">{`${value}%`}</small>
+      </div>
+    </Popover>
+  );
+}
+
+function DurationLimitPopoverContent({ duration, routeName }) {
+  const window = formatWindowLength(duration.windowLength);
+  const current = `${numberFormatterInt(duration.windowFilledSize)}/${numberFormatterInt(duration.windowSize)}`;
 
   return (
     <div className="flex flex-col">

--- a/ui/src/container/pages/usage/list/body/project-filter.jsx
+++ b/ui/src/container/pages/usage/list/body/project-filter.jsx
@@ -19,6 +19,7 @@ function ProjectFilter() {
       setSearchParams((prev) => {
         prev.delete('projectUuid');
         prev.delete('routes');
+        prev.delete('tags');
         return prev;
       }, { replace: true });
     }
@@ -33,6 +34,7 @@ function ProjectFilter() {
       }
 
       prev.delete('routes');
+      prev.delete('tags');
 
       return prev;
     });
@@ -47,8 +49,10 @@ function ProjectFilter() {
       allowClear
       disabled={isError}
       onChange={handleOnChange}
+      optionFilterProp="label"
       options={options}
       placeholder="Please select"
+      showSearch
       style={{ width: 400 }}
       value={projectUuid}
     />

--- a/ui/src/container/pages/usage/list/body/routes-filter.jsx
+++ b/ui/src/container/pages/usage/list/body/routes-filter.jsx
@@ -37,6 +37,7 @@ function RoutesFilter() {
       onChange={handleOnChange}
       options={options}
       placeholder="Please select"
+      showSearch
       style={{ width: 400 }}
       value={selectedRoutes}
     />

--- a/ui/src/store/state/projects/api.js
+++ b/ui/src/store/state/projects/api.js
@@ -40,6 +40,22 @@ export const projectsApiSlice = apiService.injectEndpoints({
       }),
     }),
 
+    getTagKeysByProject: builder.query({
+      providesTags: (result, error, { projectUuid }) => [{ type: API_TAGS.PROJECTS, id: `tag-keys-${projectUuid}` }],
+      query: ({ projectUuid }) => ({
+        url: `/projects/${projectUuid}/tags/keys`,
+        method: 'get',
+      }),
+    }),
+
+    getTagValuesByProject: builder.query({
+      providesTags: (result, error, { projectUuid, tagKey }) => [{ type: API_TAGS.PROJECTS, id: `tag-values-${projectUuid}-${tagKey}` }],
+      query: ({ projectUuid, tagKey }) => ({
+        url: `/projects/${projectUuid}/tags/keys/${encodeURIComponent(tagKey)}/values`,
+        method: 'get',
+      }),
+    }),
+
     createProject: builder.mutation({
       query: ({ data }) => ({
         url: '/projects',
@@ -230,6 +246,8 @@ export const {
   useGetProjectsQuery,
   useGetProjectQuery,
   useVerifyProjectQuery,
+  useGetTagKeysByProjectQuery,
+  useGetTagValuesByProjectQuery,
   useCreateProjectMutation,
   useDeleteProjectMutation,
   useGetConfigQuery,

--- a/ui/src/store/state/tags-query-params-factory.js
+++ b/ui/src/store/state/tags-query-params-factory.js
@@ -1,0 +1,58 @@
+const parseTagEntries = (entries) => {
+  const tags = [];
+
+  entries.forEach((entry) => {
+    const separatorIndex = entry.indexOf('=');
+
+    if (separatorIndex <= 0) {
+      return;
+    }
+
+    const key = entry.slice(0, separatorIndex);
+    const value = entry.slice(separatorIndex + 1);
+
+    if (!value) {
+      return;
+    }
+
+    const existing = tags.find((tag) => tag.key === key);
+
+    if (existing) {
+      existing.values.push(value);
+
+      return;
+    }
+
+    tags.push({ key, values: [value] });
+  });
+
+  return tags;
+};
+
+export const parseTagsFromSearchParams = (searchParams) => parseTagEntries(searchParams.getAll('tags'));
+
+export const parseTagsFromTagsKey = (tagsKey) => {
+  if (!tagsKey) {
+    return [];
+  }
+
+  return parseTagEntries(tagsKey.split('&'));
+};
+
+export const appendTagsToParams = (params, tags) => {
+  if (!tags || tags.length === 0) {
+    return params;
+  }
+
+  tags.forEach(({ key, values }) => {
+    if (!key || !values || values.length === 0) {
+      return;
+    }
+
+    values.forEach((value) => {
+      params.append('tags', `${key}=${value}`);
+    });
+  });
+
+  return params;
+};

--- a/ui/src/store/state/tracing/api.js
+++ b/ui/src/store/state/tracing/api.js
@@ -1,11 +1,12 @@
 import { API_TAGS, apiService } from '@Src/store/apis';
+import { appendTagsToParams } from '@State/tags-query-params-factory';
 import timeFiltersQueryParamFactory from '@State/time-filter-query-params-factory';
 
 export const tracingApiSlice = apiService.injectEndpoints({
   endpoints: (builder) => ({
     getTracesChart: builder.query({
       providesTags: () => [API_TAGS.TRACING],
-      query: ({ projectUuid, from, to, routes }) => {
+      query: ({ projectUuid, from, to, routes, tags }) => {
         const init = {};
 
         const params = timeFiltersQueryParamFactory({ from, to, init });
@@ -15,6 +16,8 @@ export const tracingApiSlice = apiService.injectEndpoints({
             params.append('routes', route);
           });
         }
+
+        appendTagsToParams(params, tags);
 
         return ({
           url: `/projects/${projectUuid}/traces/chart?${params.toString()}`,
@@ -25,7 +28,7 @@ export const tracingApiSlice = apiService.injectEndpoints({
 
     getTraceLatencies: builder.query({
       providesTags: () => [API_TAGS.TRACING],
-      query: ({ projectUuid, from, to, routes }) => {
+      query: ({ projectUuid, from, to, routes, tags }) => {
         const init = {};
 
         const params = timeFiltersQueryParamFactory({ from, to, init });
@@ -35,6 +38,8 @@ export const tracingApiSlice = apiService.injectEndpoints({
             params.append('routes', route);
           });
         }
+
+        appendTagsToParams(params, tags);
 
         return ({
           url: `/projects/${projectUuid}/traces/latencies?${params.toString()}`,
@@ -46,7 +51,7 @@ export const tracingApiSlice = apiService.injectEndpoints({
     getSpanLatencies: builder.query({
       providesTags: () => [API_TAGS.TRACING],
       query: ({
-        projectUuid, from, to, routes, includeOthers = false, grouped = false,
+        projectUuid, from, to, routes, tags, includeOthers = false, grouped = false,
       }) => {
         const init = {
           grouped,
@@ -60,6 +65,8 @@ export const tracingApiSlice = apiService.injectEndpoints({
             params.append('routes', route);
           });
         }
+
+        appendTagsToParams(params, tags);
 
         return ({
           url: `/projects/${projectUuid}/traces/spans/latencies?${params.toString()}`,
@@ -87,7 +94,7 @@ export const tracingApiSlice = apiService.injectEndpoints({
     getTraces: builder.query({
       providesTags: () => [API_TAGS.TRACING],
       query: ({
-        projectUuid, from, to, routes, page, limit,
+        projectUuid, from, to, routes, tags, page, limit,
       }) => {
         const init = {};
 
@@ -98,6 +105,8 @@ export const tracingApiSlice = apiService.injectEndpoints({
             params.append('routes', route);
           });
         }
+
+        appendTagsToParams(params, tags);
 
         if (page !== undefined) {
           params.append('_page', page);

--- a/ui/src/store/state/tracing/vertical-hooks.js
+++ b/ui/src/store/state/tracing/vertical-hooks.js
@@ -1,4 +1,5 @@
 import { tracesPageSize } from '@Src/constants';
+import { parseTagsFromTagsKey } from '@State/tags-query-params-factory';
 import {
   useGetSpanByIdQuery,
   useGetSpanLatenciesQuery,
@@ -7,6 +8,7 @@ import {
   useGetTracesChartQuery,
   useGetTracesQuery,
 } from '@State/tracing/api';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 const useQueryRangeParams = () => {
@@ -19,41 +21,44 @@ const useQueryRangeParams = () => {
   const routesParam = searchParams.get('routes');
   const routes = routesParam ? routesParam.split(',') : [];
 
+  const tagsKey = searchParams.getAll('tags').join('&');
+  const tags = useMemo(() => parseTagsFromTagsKey(tagsKey), [tagsKey]);
+
   return {
-    from, to, routes, projectUuid,
+    from, to, routes, tags, projectUuid,
   };
 };
 
 const useGetTracesChartWithRange = (options) => {
-  const { from, to, routes, projectUuid } = useQueryRangeParams();
+  const { from, to, routes, tags, projectUuid } = useQueryRangeParams();
 
   return useGetTracesChartQuery({
-    projectUuid, from, to, routes,
+    projectUuid, from, to, routes, tags,
   }, { skip: !projectUuid, ...options });
 };
 
 const useGetTraceLatenciesWithRange = (options) => {
-  const { from, to, routes, projectUuid } = useQueryRangeParams();
+  const { from, to, routes, tags, projectUuid } = useQueryRangeParams();
 
   return useGetTraceLatenciesQuery({
-    projectUuid, from, to, routes,
+    projectUuid, from, to, routes, tags,
   }, { skip: !projectUuid, ...options });
 };
 
 const useGetSpanLatenciesWithRange = ({ includeOthers, grouped }, options) => {
-  const { from, to, routes, projectUuid } = useQueryRangeParams();
+  const { from, to, routes, tags, projectUuid } = useQueryRangeParams();
 
   return useGetSpanLatenciesQuery({
-    projectUuid, from, to, routes, includeOthers, grouped,
+    projectUuid, from, to, routes, tags, includeOthers, grouped,
   }, { skip: !projectUuid, ...options });
 };
 
 const useGetTracesWithRange = (args, options) => {
-  const { from, to, routes, projectUuid } = useQueryRangeParams();
+  const { from, to, routes, tags, projectUuid } = useQueryRangeParams();
   const page = args?.page;
 
   return useGetTracesQuery({
-    projectUuid, from, to, routes, page, limit: tracesPageSize,
+    projectUuid, from, to, routes, tags, page, limit: tracesPageSize,
   }, { skip: !projectUuid, ...options });
 };
 

--- a/ui/src/store/state/usage/api.js
+++ b/ui/src/store/state/usage/api.js
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from '@Api/config';
 import { apiService } from '@Src/store/apis';
+import { appendTagsToParams } from '@State/tags-query-params-factory';
 import timeFiltersQueryParamFactory from '@State/time-filter-query-params-factory';
 
 export const usageApiSlice = apiService.injectEndpoints({
@@ -9,7 +10,7 @@ export const usageApiSlice = apiService.injectEndpoints({
       queryFn: () => ({ data: null }),
       async onCacheEntryAdded(
         {
-          projectUuid, routes, withSavedTokens, from, to, gte,
+          projectUuid, routes, tags, withSavedTokens, from, to, gte,
         },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
@@ -27,6 +28,8 @@ export const usageApiSlice = apiService.injectEndpoints({
           if (routes && routes.length > 0) {
             routes.forEach((route) => { params.append('routes', route); });
           }
+
+          appendTagsToParams(params, tags);
 
           const url = `${API_BASE_URL}/projects/${projectUuid}/routes/costs/summary/stream?${params.toString()}`;
           const eventSource = new EventSource(url, { withCredentials: true });
@@ -89,7 +92,9 @@ export const usageApiSlice = apiService.injectEndpoints({
       keepUnusedDataFor: 0,
       queryFn: () => ({ data: null }),
       async onCacheEntryAdded(
-        { projectUuid, routes, from, to, gte },
+        {
+          projectUuid, routes, tags, from, to, gte,
+        },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
         try {
@@ -102,6 +107,8 @@ export const usageApiSlice = apiService.injectEndpoints({
           if (routes && routes.length > 0) {
             routes.forEach((route) => { params.append('routes', route); });
           }
+
+          appendTagsToParams(params, tags);
 
           const url = `${API_BASE_URL}/projects/${projectUuid}/routes/tokens/stream?${params.toString()}`;
           const eventSource = new EventSource(url, { withCredentials: true });
@@ -125,7 +132,9 @@ export const usageApiSlice = apiService.injectEndpoints({
       keepUnusedDataFor: 0,
       queryFn: () => ({ data: null }),
       async onCacheEntryAdded(
-        { projectUuid, routes, from, to, gte },
+        {
+          projectUuid, routes, tags, from, to, gte,
+        },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
         try {
@@ -138,6 +147,8 @@ export const usageApiSlice = apiService.injectEndpoints({
           if (routes && routes.length > 0) {
             routes.forEach((route) => { params.append('routes', route); });
           }
+
+          appendTagsToParams(params, tags);
 
           const url = `${API_BASE_URL}/projects/${projectUuid}/routes/invocations/stream?${params.toString()}`;
           const eventSource = new EventSource(url, { withCredentials: true });
@@ -162,7 +173,7 @@ export const usageApiSlice = apiService.injectEndpoints({
       queryFn: () => ({ data: { loading: true, error: false, chart: null } }),
       async onCacheEntryAdded(
         {
-          projectUuid, routes, groupBy, from, to, gte,
+          projectUuid, routes, tags, groupBy, from, to, gte,
         },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
@@ -176,6 +187,8 @@ export const usageApiSlice = apiService.injectEndpoints({
           if (routes && routes.length > 0) {
             routes.forEach((route) => { params.append('routes', route); });
           }
+
+          appendTagsToParams(params, tags);
 
           const url = `${API_BASE_URL}/projects/${projectUuid}/routes/costs/stream?${params.toString()}`;
           const eventSource = new EventSource(url, { withCredentials: true });
@@ -207,7 +220,7 @@ export const usageApiSlice = apiService.injectEndpoints({
       queryFn: () => ({ data: null }),
       async onCacheEntryAdded(
         {
-          projectUuid, modelId, routes, from, to, gte,
+          projectUuid, modelId, routes, tags, from, to, gte,
         },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
@@ -219,6 +232,8 @@ export const usageApiSlice = apiService.injectEndpoints({
           if (routes && routes.length > 0) {
             routes.forEach((route) => { params.append('routes', route); });
           }
+
+          appendTagsToParams(params, tags);
 
           const url = `${API_BASE_URL}/projects/${projectUuid}/routes/costs/model/${encodeURIComponent(modelId)}/stream?${params.toString()}`;
           const eventSource = new EventSource(url, { withCredentials: true });
@@ -243,7 +258,7 @@ export const usageApiSlice = apiService.injectEndpoints({
       queryFn: () => ({ data: null }),
       async onCacheEntryAdded(
         {
-          projectUuid, groupUuid, routes, from, to, gte,
+          projectUuid, groupUuid, routes, tags, from, to, gte,
         },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
@@ -255,6 +270,8 @@ export const usageApiSlice = apiService.injectEndpoints({
           if (routes && routes.length > 0) {
             routes.forEach((route) => { params.append('routes', route); });
           }
+
+          appendTagsToParams(params, tags);
 
           const url = `${API_BASE_URL}/projects/${projectUuid}/routes/costs/group/${encodeURIComponent(groupUuid)}/stream?${params.toString()}`;
           const eventSource = new EventSource(url, { withCredentials: true });
@@ -279,7 +296,7 @@ export const usageApiSlice = apiService.injectEndpoints({
       queryFn: () => ({ data: null }),
       async onCacheEntryAdded(
         {
-          projectUuid, keyUuid, routes, from, to, gte,
+          projectUuid, keyUuid, routes, tags, from, to, gte,
         },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
@@ -291,6 +308,8 @@ export const usageApiSlice = apiService.injectEndpoints({
           if (routes && routes.length > 0) {
             routes.forEach((route) => { params.append('routes', route); });
           }
+
+          appendTagsToParams(params, tags);
 
           const url = `${API_BASE_URL}/projects/${projectUuid}/routes/costs/key/${encodeURIComponent(keyUuid)}/stream?${params.toString()}`;
           const eventSource = new EventSource(url, { withCredentials: true });
@@ -311,36 +330,48 @@ export const usageApiSlice = apiService.injectEndpoints({
     }),
 
     getCostsModelBreakdown: builder.query({
-      query: ({ projectUuid, entityId, timestamp, granularity, routes }) => {
+      query: ({
+        projectUuid, entityId, timestamp, granularity, routes, tags,
+      }) => {
         const params = new URLSearchParams({ timestamp, granularity });
 
         if (routes && routes.length > 0) {
           routes.forEach((route) => { params.append('routes', route); });
         }
+
+        appendTagsToParams(params, tags);
 
         return { url: `/projects/${projectUuid}/routes/costs/model/${encodeURIComponent(entityId)}/breakdown?${params.toString()}` };
       },
     }),
 
     getCostsGroupBreakdown: builder.query({
-      query: ({ projectUuid, entityId, timestamp, granularity, routes }) => {
+      query: ({
+        projectUuid, entityId, timestamp, granularity, routes, tags,
+      }) => {
         const params = new URLSearchParams({ timestamp, granularity });
 
         if (routes && routes.length > 0) {
           routes.forEach((route) => { params.append('routes', route); });
         }
+
+        appendTagsToParams(params, tags);
 
         return { url: `/projects/${projectUuid}/routes/costs/group/${encodeURIComponent(entityId)}/breakdown?${params.toString()}` };
       },
     }),
 
     getCostsKeyBreakdown: builder.query({
-      query: ({ projectUuid, entityId, timestamp, granularity, routes }) => {
+      query: ({
+        projectUuid, entityId, timestamp, granularity, routes, tags,
+      }) => {
         const params = new URLSearchParams({ timestamp, granularity });
 
         if (routes && routes.length > 0) {
           routes.forEach((route) => { params.append('routes', route); });
         }
+
+        appendTagsToParams(params, tags);
 
         return { url: `/projects/${projectUuid}/routes/costs/key/${encodeURIComponent(entityId)}/breakdown?${params.toString()}` };
       },

--- a/ui/src/store/state/usage/vertical-hooks.js
+++ b/ui/src/store/state/usage/vertical-hooks.js
@@ -1,4 +1,5 @@
 import { useGetRoutesQuery } from '@State/routes/api';
+import { parseTagsFromTagsKey } from '@State/tags-query-params-factory';
 import {
   useGetCostsByGroupStreamQuery,
   useGetCostsByKeyStreamQuery,
@@ -9,6 +10,7 @@ import {
   useGetLimitsStreamQuery,
   useGetTokensChartStreamQuery,
 } from '@State/usage/api';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 const useQueryRangeParams = () => {
@@ -18,7 +20,10 @@ const useQueryRangeParams = () => {
   const to = searchParams.get('to') || null;
   const projectUuid = searchParams.get('projectUuid') || null;
 
-  return { gte, from, to, projectUuid };
+  const tagsKey = searchParams.getAll('tags').join('&');
+  const tags = useMemo(() => parseTagsFromTagsKey(tagsKey), [tagsKey]);
+
+  return { gte, from, to, tags, projectUuid };
 };
 
 const useGetProjectRoutesWithRange = (options) => {
@@ -28,58 +33,58 @@ const useGetProjectRoutesWithRange = (options) => {
 };
 
 const useGetCostsSummaryStreamWithRange = ({ routes, withSavedTokens }, options) => {
-  const { gte, from, to, projectUuid } = useQueryRangeParams();
+  const { gte, from, to, tags, projectUuid } = useQueryRangeParams();
 
   return useGetCostsSummaryStreamQuery({
-    projectUuid, routes, withSavedTokens, gte, from, to,
+    projectUuid, routes, tags, withSavedTokens, gte, from, to,
   }, options);
 };
 
 const useGetTokensChartStreamWithRange = ({ routes }, options) => {
-  const { gte, from, to, projectUuid } = useQueryRangeParams();
+  const { gte, from, to, tags, projectUuid } = useQueryRangeParams();
 
   return useGetTokensChartStreamQuery({
-    projectUuid, routes, gte, from, to,
+    projectUuid, routes, tags, gte, from, to,
   }, options);
 };
 
 const useGetInvocationsChartStreamWithRange = ({ routes }, options) => {
-  const { gte, from, to, projectUuid } = useQueryRangeParams();
+  const { gte, from, to, tags, projectUuid } = useQueryRangeParams();
 
   return useGetInvocationsChartStreamQuery({
-    projectUuid, routes, gte, from, to,
+    projectUuid, routes, tags, gte, from, to,
   }, options);
 };
 
 const useGetCostsChartStreamWithRange = ({ routes, groupBy }, options) => {
-  const { gte, from, to, projectUuid } = useQueryRangeParams();
+  const { gte, from, to, tags, projectUuid } = useQueryRangeParams();
 
   return useGetCostsChartStreamQuery({
-    projectUuid, routes, groupBy, gte, from, to,
+    projectUuid, routes, tags, groupBy, gte, from, to,
   }, options);
 };
 
 const useGetCostsByModelStreamWithRange = ({ modelId, routes }, options) => {
-  const { gte, from, to, projectUuid } = useQueryRangeParams();
+  const { gte, from, to, tags, projectUuid } = useQueryRangeParams();
 
   return useGetCostsByModelStreamQuery({
-    projectUuid, modelId, routes, gte, from, to,
+    projectUuid, modelId, routes, tags, gte, from, to,
   }, options);
 };
 
 const useGetCostsByGroupStreamWithRange = ({ groupUuid, routes }, options) => {
-  const { gte, from, to, projectUuid } = useQueryRangeParams();
+  const { gte, from, to, tags, projectUuid } = useQueryRangeParams();
 
   return useGetCostsByGroupStreamQuery({
-    projectUuid, groupUuid, routes, gte, from, to,
+    projectUuid, groupUuid, routes, tags, gte, from, to,
   }, options);
 };
 
 const useGetCostsByKeyStreamWithRange = ({ keyUuid, routes }, options) => {
-  const { gte, from, to, projectUuid } = useQueryRangeParams();
+  const { gte, from, to, tags, projectUuid } = useQueryRangeParams();
 
   return useGetCostsByKeyStreamQuery({
-    projectUuid, keyUuid, routes, gte, from, to,
+    projectUuid, keyUuid, routes, tags, gte, from, to,
   }, options);
 };
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -575,10 +575,10 @@
     uuid "^10.0.0"
     yup "^1.4.0"
 
-"@radicalbit/radicalbit-design-system@2.19.5":
-  version "2.19.5"
-  resolved "https://registry.yarnpkg.com/@radicalbit/radicalbit-design-system/-/radicalbit-design-system-2.19.5.tgz#5099f2c7699b4b0a8f00ef0dee07a07c4335129d"
-  integrity sha512-jkkualwnXtf/lWjHpZ6ALJR/TQIHNfbltdxG1+tp4VcPs1BsZLGm/t+YPhLpEOSz8vSQhaCVeg2aozf2VOL2hA==
+"@radicalbit/radicalbit-design-system@2.19.6":
+  version "2.19.6"
+  resolved "https://registry.yarnpkg.com/@radicalbit/radicalbit-design-system/-/radicalbit-design-system-2.19.6.tgz#0ad9963caed9ef3a9de510b42008ebe318b8d73a"
+  integrity sha512-sZ1kQ1sISUeEYFS9RTt6QzuxQhVCCGzpu3B+uLBLLTcD4RzOjLZyGbb88CgS3kIS94nNqfrX2rpj8jiimKlwpg==
   dependencies:
     "@babel/polyfill" "7.12.1"
     "@fortawesome/fontawesome-svg-core" "6.7.2"


### PR DESCRIPTION
## Tag filtering and transcription support

Adds tag-based filtering across Tracing and Usage, plus surfaces transcription models in the routes and costs views.

### Tag filtering

A new tag filter lets you narrow Tracing and Usage down to specific key/value pairs. Rows are repeatable, keys are unique across rows, and values are multi-select — so you can express things like `env=prod` **and** `team=(payments|checkout)`.

Selections persist in the URL as `tags=key=value` params, so a filtered view is shareable and survives a reload. Tags are forwarded to the 4 tracing and 10 usage endpoints, and cleared when you switch project.

Backed by two new endpoints, `GET /projects/{uuid}/tags/keys` and `GET /projects/{uuid}/tags/keys/{key}/values`, which populate the key and value selects.

The traces table gains a Tags column showing up to 3 tags, with a `+N` popover listing the rest.

### Transcription

- **cURL examples** — the route detail page now shows a chat and a transcription snippet, each rendered only when the route actually has models of that kind, with an empty state when it has neither.
- **Costs** — a Transcription cost column with a duration/audio/text breakdown popover, and a Transcription models card in the costs summary header.
- **Duration limiting** — surfaced as a Duration row and a Duration Limiting section in the route list popover, plus a Duration limit column in the usage limits table.

### Also

- Project and route selects are now searchable.
- Two small fixes on the side: an unused variable that was failing lint, and a misplaced React `key` in the new tags cell.
- Bumps `@radicalbit/radicalbit-design-system` to 2.19.6.