### PR TITLE
feat: expose AUDIO_DURATION_LIMIT events for the route events endpoint

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/event_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/event_dao.py
@@ -494,6 +494,7 @@ class EventDAO:
             'RATE_LIMIT',
             'TOKEN_INPUT_LIMIT',
             'TOKEN_OUTPUT_LIMIT',
+            'AUDIO_DURATION_LIMIT',
             'CACHE_HIT',
         ]
         row_number_col = (

--- a/gateway/radicalbit_ai_gateway/models/event_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/event_dto.py
@@ -72,6 +72,12 @@ class TokenOutputLimitEventDetailDTO(BaseEventDetailDTO):
     event_type: Literal['TOKEN_OUTPUT_LIMIT']
 
 
+class DurationLimitEventDetailDTO(BaseEventDetailDTO):
+    """DTO for AUDIO_DURATION_LIMIT event type."""
+
+    event_type: Literal['AUDIO_DURATION_LIMIT']
+
+
 class CacheHitEventDetailDTO(BaseEventDetailDTO):
     """DTO for CACHE_HIT event type."""
 
@@ -437,6 +443,9 @@ class LastNEvents(BaseModel):
     token_output_limit: list[TokenOutputLimitEventDetailDTO] | None = Field(
         default_factory=list
     )
+    duration_limit: list[DurationLimitEventDetailDTO] | None = Field(
+        default_factory=list
+    )
     cache_triggered: list[CacheHitEventDetailDTO] | None = Field(default_factory=list)
 
     @staticmethod
@@ -446,6 +455,7 @@ class LastNEvents(BaseModel):
         rate_limit: list[RateLimitEventDetailDTO],
         token_input_limit: list[TokenInputLimitEventDetailDTO],
         token_output_limit: list[TokenOutputLimitEventDetailDTO],
+        duration_limit: list[DurationLimitEventDetailDTO],
         cache_triggered: list[CacheHitEventDetailDTO],
         route_config: GatewayRouteConfig,
     ) -> 'LastNEvents':
@@ -458,6 +468,9 @@ class LastNEvents(BaseModel):
             else None,
             token_output_limit=token_output_limit
             if route_config.token_limiting is not None
+            else None,
+            duration_limit=duration_limit
+            if route_config.duration_limiting is not None
             else None,
             cache_triggered=cache_triggered
             if route_config.caching is not None

--- a/gateway/radicalbit_ai_gateway/services/event_service.py
+++ b/gateway/radicalbit_ai_gateway/services/event_service.py
@@ -21,6 +21,7 @@ from radicalbit_ai_gateway.models.event_dto import (
     CostChartDataDTO,
     CostChartDataSeriesDTO,
     CostDataDTO,
+    DurationLimitEventDetailDTO,
     EventsDTO,
     FallbackEventDetailDTO,
     GuardrailEventDetailDTO,
@@ -377,6 +378,7 @@ class EventService:
         rate_limit: list[RateLimitEventDetailDTO] = []
         token_input_limit: list[TokenInputLimitEventDetailDTO] = []
         token_output_limit: list[TokenOutputLimitEventDetailDTO] = []
+        duration_limit: list[DurationLimitEventDetailDTO] = []
         cache_triggered: list[CacheHitEventDetailDTO] = []
 
         route_config = config.routes[route_name]
@@ -467,6 +469,17 @@ class EventService:
                             event_type='TOKEN_OUTPUT_LIMIT',
                         )
                     )
+                case 'AUDIO_DURATION_LIMIT':
+                    duration_limit.append(
+                        DurationLimitEventDetailDTO(
+                            timestamp=event.timestamp,
+                            api_key_uuid=event.api_key_uuid,
+                            route_name=event.route_name,
+                            api_key_name=resolved_name,
+                            api_key_active=event.api_key_active,
+                            event_type='AUDIO_DURATION_LIMIT',
+                        )
+                    )
                 case 'CACHE_HIT':
                     cache_triggered.append(
                         CacheHitEventDetailDTO(
@@ -488,6 +501,7 @@ class EventService:
             rate_limit=rate_limit,
             token_input_limit=token_input_limit,
             token_output_limit=token_output_limit,
+            duration_limit=duration_limit,
             cache_triggered=cache_triggered,
             route_config=route_config,
         )

--- a/gateway/tests/services/event_service_test.py
+++ b/gateway/tests/services/event_service_test.py
@@ -39,6 +39,7 @@ from radicalbit_ai_gateway.db.models.event import (
 from radicalbit_ai_gateway.limiter.window_config import WindowStats
 from radicalbit_ai_gateway.models.auth_dto import KeyOut
 from radicalbit_ai_gateway.models.caching import SemanticCaching
+from radicalbit_ai_gateway.models.credentials import Credentials
 from radicalbit_ai_gateway.models.event_dto import (
     Cache,
     CacheHitEventDetailDTO,
@@ -50,6 +51,7 @@ from radicalbit_ai_gateway.models.event_dto import (
     CostChartDataDTO,
     CostChartDataSeriesDTO,
     CostDataDTO,
+    DurationLimitEventDetailDTO,
     EmbeddingInputBreakdownDTO,
     EmbeddingModelsCostDTO,
     Errors,
@@ -71,7 +73,10 @@ from radicalbit_ai_gateway.models.event_dto import (
 )
 from radicalbit_ai_gateway.models.event_type import EventType
 from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
+from radicalbit_ai_gateway.models.gateway_route_config import GatewayRouteConfig
 from radicalbit_ai_gateway.models.gateway_route_out import GatewayRouteOut
+from radicalbit_ai_gateway.models.limiting import AudioDurationLimiting
+from radicalbit_ai_gateway.models.model import Model
 from radicalbit_ai_gateway.services.event_service import EventService
 from radicalbit_ai_gateway.services.group_service import GroupService
 from radicalbit_ai_gateway.services.key_service import KeyService
@@ -514,6 +519,7 @@ class EventServiceTest(unittest.TestCase):
             ],
             token_input_limit=[],
             token_output_limit=[],
+            duration_limit=None,
             cache_triggered=[
                 CacheHitEventDetailDTO(
                     timestamp=datetime.datetime(
@@ -528,6 +534,65 @@ class EventServiceTest(unittest.TestCase):
             ],
         )
         assert res == expected
+
+    def test_get_latest_n_per_event_type_duration_limit(self):
+        """AUDIO_DURATION_LIMIT events populate duration_limit when the route
+        has duration_limiting configured.
+        """
+        transcription_model = Model(
+            model_id='whisper',
+            model='openai/whisper-1',
+            credentials=Credentials(api_key='sk-123'),
+        )
+        route = GatewayRouteConfig(
+            route_name='route-duration',
+            transcription_models=['whisper'],
+            duration_limiting=AudioDurationLimiting(
+                max_duration_seconds=10, window_size='1 minute'
+            ),
+        )
+        config = GatewayConfig(
+            transcription_models=[transcription_model],
+            routes={'route-duration': route},
+        )
+
+        api_key_uuid = uuid.UUID('00000000-0000-0000-0000-000000000000')
+        mocked_events = [
+            db_mock.get_event_detail(
+                timestamp=datetime.datetime(
+                    2025, 10, 13, 12, 58, 36, 931873, tzinfo=datetime.timezone.utc
+                ),
+                route_name='route-duration',
+                event_type='AUDIO_DURATION_LIMIT',
+            ),
+        ]
+        self.event_dao.get_latest_n_per_event_type = MagicMock(
+            return_value=mocked_events
+        )
+        self.key_service.get_names_by_uuids = MagicMock(
+            return_value={api_key_uuid: 'fake-name'}
+        )
+
+        res = self.event_service.get_latest_n_per_event_type(
+            self.TEST_PROJECT_UUID,
+            config,
+            'route-duration',
+            10,
+            None,
+            None,
+        )
+
+        assert res.duration_limit == [
+            DurationLimitEventDetailDTO(
+                timestamp=datetime.datetime(
+                    2025, 10, 13, 12, 58, 36, 931873, tzinfo=datetime.timezone.utc
+                ),
+                api_key_uuid=api_key_uuid,
+                route_name='route-duration',
+                api_key_name='fake-name',
+                event_type='AUDIO_DURATION_LIMIT',
+            )
+        ]
 
     def test_get_chart_data_multiple_groups(self):
         base_time = datetime.datetime(


### PR DESCRIPTION
# PR Summary: feat/AG-933-duration-limiting-ui (BE only)

Surfaces individual `AUDIO_DURATION_LIMIT` events in the per-event-type
listing endpoint, closing a gap where the aggregate trigger count
(`EventsDTO.duration_limit_triggered`, added in a prior PR) existed but the
underlying per-event detail — needed for a route-level "recent duration
limit events" table, mirroring what already exists for rate/token limiting
— was never queried or exposed. FE work building on this (a new UI section
consuming `durationLimit`) will be done separately by the FE team; not part
of this PR.

---

## DTO Changes

### `LastNEvents` (MODIFIED)

**Changes:**
```diff
  rate_limit: RateLimitEventDetailDTO[] | null
  token_input_limit: TokenInputLimitEventDetailDTO[] | null
  token_output_limit: TokenOutputLimitEventDetailDTO[] | null
+ duration_limit: DurationLimitEventDetailDTO[] | null
  cache_triggered: CacheHitEventDetailDTO[] | null
```

| Field | Type | Description |
|-------|------|--------------|
| `fallbacks` | object[] or null | Recent `FALLBACK` events |
| `guardrails` | object[] or null | Recent `GUARDRAIL` events |
| `rate_limit` | object[] or null | Recent `RATE_LIMIT` events |
| `token_input_limit` | object[] or null | Recent `TOKEN_INPUT_LIMIT` events |
| `token_output_limit` | object[] or null | Recent `TOKEN_OUTPUT_LIMIT` events |
| `duration_limit` **NEW** | object[] or null | Recent `AUDIO_DURATION_LIMIT` events |
| `cache_triggered` | object[] or null | Recent `CACHE_HIT` events |

`duration_limit` is `null` (not an empty array) when the route has no
`duration_limiting` configured — same enablement convention already used by
every other field on this DTO (`rate_limit` is `null` without
`rate_limiting`, etc.), so the FE can distinguish "not configured" from
"configured but never triggered".

### `DurationLimitEventDetailDTO` (NEW)

| Field | Type | Description |
|-------|------|--------------|
| `timestamp` | datetime | When the event occurred |
| `apiKeyUuid` | string | UUID of the API key that triggered it |
| `routeName` | string | Route the event occurred on |
| `apiKeyName` | string | Resolved key name (or `"Deleted Key (xxxxxxxx)"` if the key no longer exists) |
| `apiKeyActive` | boolean | Whether the key still exists/resolves |
| `eventType` | string | Always `"AUDIO_DURATION_LIMIT"` |

Structurally identical to the existing `RateLimitEventDetailDTO` /
`TokenInputLimitEventDetailDTO` / `TokenOutputLimitEventDetailDTO` — no
extra fields beyond the shared base, since a duration-limit trigger doesn't
carry any additional context (unlike, say, a guardrail event's
name/type/where/behavior).

**Example response:**
```json
{
  "durationLimit": [
    {
      "timestamp": "2026-08-28T14:08:38.230895Z",
      "apiKeyUuid": "4ba448dd-f63d-4f1c-8a9e-99df18125276",
      "routeName": "fe-test-route",
      "apiKeyName": "fe-limit-demo-key",
      "apiKeyActive": true,
      "eventType": "AUDIO_DURATION_LIMIT"
    }
  ]
}
```

**Used by:** `GET /public/api/v1/projects/{project_uuid}/routes/{route_name}/events`

---

## Affected Endpoints

### `GET /public/api/v1/projects/{project_uuid}/routes/{route_name}/events` (MODIFIED — response gains a field, no parameter changes)

**Example request:**
```
GET /public/api/v1/projects/4343c95d-c703-49fb-946d-653accae7f23/routes/fe-test-route/events
```

No parameter changes — same `n`/`from`/`to`/`tags` query params as before.
The response's `LastNEvents` object gains `durationLimit` alongside the
existing fields.

---

## Other Changes

- `db/dao/event_dao.py` — `EventDAO.get_latest_n_per_event_type()`'s
  hardcoded `event_types` list gains `'AUDIO_DURATION_LIMIT'`. Without this,
  `AUDIO_DURATION_LIMIT` rows were excluded from the underlying ClickHouse
  query entirely — no amount of DTO wiring downstream would have surfaced
  them, since they never left the DAO layer.
- `services/event_service.py` — new `case 'AUDIO_DURATION_LIMIT':` branch in
  `get_latest_n_per_event_type()`'s per-event dispatch, appending
  `DurationLimitEventDetailDTO` instances the same way the existing
  `RATE_LIMIT`/`TOKEN_INPUT_LIMIT`/`TOKEN_OUTPUT_LIMIT` branches do; threaded
  into the `LastNEvents.create_dto()` call.
- Test coverage: `tests/services/event_service_test.py` — existing
  `test_get_latest_n_per_event_type` updated for the new `duration_limit`
  field (asserts `null` when the route has no `duration_limiting`
  configured), plus a new dedicated
  `test_get_latest_n_per_event_type_duration_limit` covering the populated
  case (route with `duration_limiting` configured, an `AUDIO_DURATION_LIMIT`
  event present, asserting it round-trips into `DurationLimitEventDetailDTO`
  correctly).
- Manually verified via Docker: `GET .../events` on a route with
  `duration_limiting` configured and real triggered events returns
  `durationLimit` populated with the actual event history (timestamps, key
  names), matching the shape/count of the route's aggregate
  `metrics.durationLimitTriggered` counter.
