### PR TITLE
chore: gitignore secrets.yaml and add secrets-dummy.yaml template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@
 # Environments
 **/.env
 **/.secrets
+secrets.yaml
+**/secrets.yaml
 **/.venv
 **/env/
 **/venv/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,9 +88,14 @@ Configure your gateway SMTP settings:
 
 Open **[http://localhost:8025](http://localhost:8025)** in your browser to view all captured emails and HTML notifications.
 
-Add your LLM provider keys to `gateway/secrets.yaml`:
+Create your `secrets.yaml` by copying the template and adding your LLM provider keys:
+
+```bash
+cp secrets-dummy.yaml secrets.yaml
+```
 
 ```yaml
+# secrets.yaml
 OPENAI_API_KEY: sk-your-key-here
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ cd radicalbit-ai-gateway
 
 ### 2. Add your provider credentials
 
-Create a `secrets.yaml` file in the project root. These are the keys the gateway uses to call your models:
+Create `secrets.yaml` in the project root by copying `secrets-dummy.yaml`, then add your provider keys:
+
+```bash
+cp secrets-dummy.yaml secrets.yaml
+```
 
 ```yaml
 # secrets.yaml

--- a/secrets-dummy.yaml
+++ b/secrets-dummy.yaml
@@ -1,0 +1,5 @@
+# secrets-dummy.yaml - Template for LLM provider credentials
+# Copy this file to secrets.yaml and fill in your actual API keys:
+#   cp secrets-dummy.yaml secrets.yaml
+
+OPENAI_API_KEY: sk-dummy-key

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,1 +1,0 @@
-OPENAI_API_KEY: sk-123


### PR DESCRIPTION
## Summary
- Untracked `secrets.yaml` from Git to prevent accidental leaks of real API credentials.
- Added `secrets.yaml` and `**/secrets.yaml` to `.gitignore`.
- Created `secrets-dummy.yaml` as a clean template for developers to copy (`cp secrets-dummy.yaml secrets.yaml`).
- Updated `README.md` and `DEVELOPMENT.md` setup instructions accordingly.

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [x] Refactor/Chore
- [ ] Performance
- [x] Security

## Checklist
- [x] Tests pass (locally/CI)
- [x] Lint/build pass
- [x] No secrets committed
- [x] Docs updated (if needed)