### PR TITLE
ci: add gitleaks and ruff lint/format workflows

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,30 @@
+name: gitleaks
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+        run: |
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Run Gitleaks
+        run: |
+          gitleaks detect --verbose --redact

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,42 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "*"
+
+env:
+  PYTHON_VERSION: "3.11"
+  UV_VERSION: "0.7.13"
+
+jobs:
+  ruff:
+    name: ruff (lint & format)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup uv
+        run: |
+          curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
+
+      # Identical to .pre-commit-config.yaml (ruff-check):
+      # args: [--config=gateway/pyproject.toml]
+      - name: Ruff Linter Check (gateway)
+        run: |
+          uv run --project gateway ruff check --config=gateway/pyproject.toml gateway
+
+      # Identical to .pre-commit-config.yaml (ruff-format):
+      # args: [--config=gateway/pyproject.toml] with --check for CI
+      - name: Ruff Formatter Check (gateway)
+        run: |
+          uv run --project gateway ruff format --config=gateway/pyproject.toml --check gateway

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,13 @@
+# Gitleaks ignore list for historical false positives / mock test data
+087a99a78968b904b29fdc3e9b21a886d6d38bc9:README.md:curl-auth-header:104
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/.secret-keys.json:generic-api-key:2
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:185
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:199
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:371
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:385
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:465
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:629
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:762
+d8b5b58ad44026d75bf743ef746be807d2a7f08c:ui/src/store/state/routes/mock.js:generic-api-key:863
+1963244be085f4f48c689c9621a67b022c433dc2:gateway/tests/common/db_mock.py:generic-api-key:41
+1963244be085f4f48c689c9621a67b022c433dc2:gateway/tests/common/db_mock.py:generic-api-key:42

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: >
   )$
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.29.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks
 
@@ -24,7 +24,7 @@ repos:
       # Gateway
       - id: ruff-check
         name: ruff-check (gateway)
-        args: [--config=gateway/pyproject.toml, --fix, --extend-select=I]
+        args: [--config=gateway/pyproject.toml, --fix]
         files: ^((gateway)/.+)?[^/]+\.(py)$
       - id: ruff-format
         name: ruff-format (gateway)

--- a/gateway/radicalbit_ai_gateway/utils/dependencies.py
+++ b/gateway/radicalbit_ai_gateway/utils/dependencies.py
@@ -20,7 +20,6 @@ async def get_gateway_routes(request: Request) -> dict:
 
 
 async def get_request_uuid(request: Request) -> str:
-
     request_uuid = getattr(request.state, 'request_uuid', None)
     if request_uuid is None:
         logger.warning(

--- a/gateway/tests/common/mocked_gateway_config_openai.py
+++ b/gateway/tests/common/mocked_gateway_config_openai.py
@@ -130,7 +130,6 @@ def _openai_route_guardrail_names() -> list[str]:
 
 
 def get_gateway_openai_with_guardrails() -> GatewayConfig:
-
     chat_models = [
         make_chat_model(
             'openai-o4-mini', 'openai/gpt-4o-mini', temperature=0.9, max_tokens=150
@@ -158,7 +157,6 @@ def get_gateway_openai_with_guardrails() -> GatewayConfig:
 
 
 def get_gateway_openai_cached() -> GatewayConfig:
-
     chat_models = [
         make_chat_model(
             'openai-o4-mini', 'openai/gpt-4o-mini', temperature=0.9, max_tokens=150
@@ -183,7 +181,6 @@ def get_gateway_openai_cached() -> GatewayConfig:
 
 
 def get_gateway_embedded_cached() -> GatewayConfig:
-
     chat_models = [
         make_chat_model(
             'openai-o4-mini', 'openai/gpt-4o-mini', temperature=0.9, max_tokens=150
@@ -207,7 +204,6 @@ def get_gateway_embedded_cached() -> GatewayConfig:
 
 
 def get_gateway_embedded_limiting() -> GatewayConfig:
-
     chat_models = [
         make_chat_model(
             'openai-o4-mini', 'openai/gpt-4o-mini', temperature=0.9, max_tokens=150
@@ -246,7 +242,6 @@ def get_gateway_embedded_limiting() -> GatewayConfig:
 
 
 def get_gateway_ollama_no_api_key() -> GatewayConfig:
-
     chat_models = [
         Model(
             model_id='qwen',
@@ -278,7 +273,6 @@ def _make_model(model_id: str, model: str) -> Model:
 
 
 def get_gateway_routing_keyword() -> GatewayConfig:
-
     chat_models = [
         _make_model('billing_model', 'openai/gpt-4o'),
         _make_model('tech_support_model', 'openai/gpt-4o-mini'),
@@ -311,7 +305,6 @@ def get_gateway_routing_keyword() -> GatewayConfig:
 
 
 def get_gateway_routing_context_length() -> GatewayConfig:
-
     chat_models = [
         _make_model('gpt-4o', 'openai/gpt-4o'),
         _make_model('gpt-4o-mini', 'openai/gpt-4o-mini'),
@@ -340,7 +333,6 @@ def get_gateway_routing_context_length() -> GatewayConfig:
 
 
 def get_gateway_routing_time() -> GatewayConfig:
-
     chat_models = [
         _make_model('weekday_model', 'openai/gpt-4o'),
         _make_model('night_model', 'openai/gpt-4o-mini'),
@@ -371,7 +363,6 @@ def get_gateway_routing_time() -> GatewayConfig:
 
 
 def get_gateway_routing_token_length() -> GatewayConfig:
-
     chat_models = [
         _make_model('gpt-4o', 'openai/gpt-4o'),
         _make_model('gpt-4o-mini', 'openai/gpt-4o-mini'),
@@ -400,7 +391,6 @@ def get_gateway_routing_token_length() -> GatewayConfig:
 
 
 def get_gateway_routing_text_classification() -> GatewayConfig:
-
     chat_models = [
         _make_model('billing_model', 'openai/gpt-4o'),
         _make_model('tech_support_model', 'openai/gpt-4o-mini'),


### PR DESCRIPTION
## Summary
- Added `gitleaks.yaml` workflow to run secret detection on all PRs and pushes to `main`.
- Added `.gitleaksignore` to whitelist historical mock test data and false positives.
- Added `lint.yaml` workflow to strictly enforce Ruff linter (`ruff check`) and formatter (`ruff format --check`) on gateway code.
- Updated `.pre-commit-config.yaml` to Gitleaks `v8.30.1` and aligned hook parameters with CI.
- Applied minor formatting fixes generated by `ruff format`.


## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [x] Refactor/Chore
- [ ] Performance
- [x] Security

## Checklist
- [x] Tests pass (locally/CI)
- [x] Lint/build pass
- [x] No secrets committed
- [ ] Docs updated (if needed)
