### PR TITLE
feat: add caching for list call

### DIFF
--- a/gateway/radicalbit_ai_gateway/caching/gateway_cache.py
+++ b/gateway/radicalbit_ai_gateway/caching/gateway_cache.py
@@ -89,6 +89,29 @@ class GatewayCache:
     ) -> str:
         return f'inputs:{json.dumps(input_texts, ensure_ascii=False)};extra_args:{json.dumps(kwargs)}'
 
+    def generate_mcp_list_cache_key(
+        self,
+        project_uuid: str,
+        route_name: str,
+        key_uuid: str,
+        method: str,
+        servers_signature: str,
+    ) -> str:
+        """Key a cached MCP list method (``tools/list`` and its siblings)."""
+        request_signature = self._build_mcp_list_request_signature(
+            method=method, servers_signature=servers_signature
+        )
+        return self.cache_client.generate_cache_key(
+            project_uuid, route_name, request_signature, key_uuid
+        )
+
+    @staticmethod
+    def _build_mcp_list_request_signature(
+        method: str,
+        servers_signature: str,
+    ) -> str:
+        return f'mcp_method:{method};mcp_servers:{servers_signature}'
+
     def generate_transcription_cache_key(
         self,
         project_uuid: str,

--- a/gateway/radicalbit_ai_gateway/mcp_proxy/list_cache.py
+++ b/gateway/radicalbit_ai_gateway/mcp_proxy/list_cache.py
@@ -1,0 +1,176 @@
+"""Route-level caching for the MCP list methods.
+
+``tools/list``, ``prompts/list`` and ``resources/list`` fan out to every
+upstream server on the route, and :class:`McpUpstreamClient` runs a full
+``initialize`` handshake per operation — so one list is N x (TCP + TLS +
+handshake), re-issued by agent clients on every reconnect. The three are also
+the only MCP methods that are safe to cache: everything else either carries
+caller-supplied arguments or is side-effecting by definition.
+
+This wraps the route's existing ``GatewayCache`` (the same ``caching:`` block
+the /v1 endpoints use, no new YAML) and owns the guards that decide when a
+route may not be cached at all — see :meth:`McpListCache.for_route`.
+"""
+
+import json
+import logging
+
+from radicalbit_ai_gateway.caching.gateway_cache import GatewayCache
+from radicalbit_ai_gateway.events.events_processor import emit_event
+from radicalbit_ai_gateway.metrics.define_metrics import cache_hit_counter
+from radicalbit_ai_gateway.models.caching import CacheType
+from radicalbit_ai_gateway.models.event_payload import CacheEventPayload
+from radicalbit_ai_gateway.models.event_type import EventType
+from radicalbit_ai_gateway.models.mcp_authorized_request import McpAuthorizedRequest
+from radicalbit_ai_gateway.models.mcp_server import AnyMcpServer, McpHttpServer
+from radicalbit_ai_gateway.utils.app_config import get_app_config
+
+logger = logging.getLogger(get_app_config().log_config.logger_name)
+
+CACHEABLE_CACHE_TYPES = frozenset({CacheType.EXACT, CacheType.IN_MEMORY})
+
+TOOLS_LIST = 'tools/list'
+PROMPTS_LIST = 'prompts/list'
+RESOURCES_LIST = 'resources/list'
+
+
+def servers_signature(servers: list[AnyMcpServer]) -> str:
+    """Identify the upstream set a cached list was produced from."""
+    parts = []
+    for server in sorted(servers, key=lambda s: s.alias):
+        if isinstance(server, McpHttpServer):
+            endpoint = server.url
+        else:
+            endpoint = json.dumps([server.command, *server.args, server.cwd or ''])
+        parts.append(f'{server.alias}|{server.transport}|{endpoint}')
+    return ';'.join(parts)
+
+
+class McpListCache:
+    """A route's cache for the three MCP list methods, or nothing at all."""
+
+    def __init__(
+        self,
+        gateway_cache: GatewayCache,
+        ttl: int | None,
+        authorized: McpAuthorizedRequest,
+        signature: str,
+    ):
+        self._cache = gateway_cache
+        self._ttl = ttl
+        self._authorized = authorized
+        self._signature = signature
+
+    @classmethod
+    def for_route(
+        cls,
+        gateway_cache: GatewayCache | None,
+        ttl: int | None,
+        authorized: McpAuthorizedRequest,
+    ) -> 'McpListCache | None':
+        """Build the cache for a route, or ``None`` when it must not cache.
+
+        Three reasons a route gets no cache:
+
+        - it declares no ``caching:`` block (``gateway_cache is None``);
+        - it declares a *semantic* cache, which cannot answer a query-less
+          lookup (see :data:`CACHEABLE_CACHE_TYPES`);
+        - one of its servers declares ``forward_headers``. That is a
+          correctness rule, not hygiene: the upstream fills a header from the
+          inbound request, so two callers with different credentials can
+          legitimately be shown different tool lists. Skipping those routes
+          entirely is provably safe and keeps credential material out of cache
+          keys.
+        """
+        servers = authorized.servers
+        if gateway_cache is None or not servers:
+            return None
+        if gateway_cache.cache_type not in CACHEABLE_CACHE_TYPES:
+            logger.debug(
+                'MCP list caching disabled on route %s: cache type %s is not cacheable',
+                authorized.route_name,
+                gateway_cache.cache_type.value,
+            )
+            return None
+        if any(
+            isinstance(server, McpHttpServer) and server.forward_headers
+            for server in servers
+        ):
+            logger.debug(
+                'MCP list caching disabled on route %s: an upstream declares '
+                'forward_headers, so its list may vary per caller',
+                authorized.route_name,
+            )
+            return None
+        return cls(
+            gateway_cache=gateway_cache,
+            ttl=ttl,
+            authorized=authorized,
+            signature=servers_signature(servers),
+        )
+
+    async def get(self, method: str) -> dict | None:
+        """Return the cached result for ``method``, or ``None`` on a miss."""
+        try:
+            raw = await self._cache.get(self._key(method))
+        except Exception:
+            logger.warning('MCP %s cache lookup failed', method, exc_info=True)
+            return None
+        if not raw:
+            return None
+        try:
+            cached = json.loads(raw)
+        except ValueError:
+            logger.warning('MCP %s cache entry is not valid JSON, ignoring', method)
+            return None
+        if not isinstance(cached, dict):
+            logger.warning('MCP %s cache entry is not a JSON object, ignoring', method)
+            return None
+        return cached
+
+    async def set(self, method: str, result: dict) -> None:
+        """Store ``result`` for ``method``. Never raises."""
+        try:
+            await self._cache.set(
+                cache_key=self._key(method),
+                response=json.dumps(result),
+                ttl=self._ttl,
+            )
+        except Exception:
+            logger.warning('MCP %s cache write failed', method, exc_info=True)
+
+    def record_hit(self, method: str) -> None:
+        """Report a hit to the events pipeline and the cache-hit metric."""
+        logger.debug(
+            'MCP %s served from cache on route %s',
+            method,
+            self._authorized.route_name,
+        )
+        key_details = self._authorized.key_details
+        emit_event(
+            CacheEventPayload(
+                value=1.0,
+                request_uuid=self._authorized.request_uuid,
+                event_type=EventType.CACHE_HIT,
+                route_name=self._authorized.route_name,
+                api_key_uuid=key_details.api_key_uuid,
+                api_key_name=key_details.api_key_name,
+                group_uuid=key_details.group_uuid,
+                group_name=key_details.group_name,
+                project_uuid=self._authorized.project_uuid,
+                project_name=self._authorized.project_name,
+                cost=0.0,
+                cache_type=str(self._cache.cache_type.value),
+                model_id='',
+            )
+        )
+        cache_hit_counter.add(1, {'route_name': self._authorized.route_name})
+
+    def _key(self, method: str) -> str:
+        return self._cache.generate_mcp_list_cache_key(
+            project_uuid=self._authorized.project_uuid,
+            route_name=self._authorized.route_name,
+            key_uuid=self._authorized.key_details.api_key_uuid,
+            method=method,
+            servers_signature=self._signature,
+        )

--- a/gateway/radicalbit_ai_gateway/mcp_proxy/list_cache.py
+++ b/gateway/radicalbit_ai_gateway/mcp_proxy/list_cache.py
@@ -33,6 +33,8 @@ TOOLS_LIST = 'tools/list'
 PROMPTS_LIST = 'prompts/list'
 RESOURCES_LIST = 'resources/list'
 
+DEFAULT_LIST_TTL_SECONDS = 300
+
 
 def servers_signature(servers: list[AnyMcpServer]) -> str:
     """Identify the upstream set a cached list was produced from."""
@@ -57,7 +59,7 @@ class McpListCache:
         signature: str,
     ):
         self._cache = gateway_cache
-        self._ttl = ttl
+        self._ttl = ttl if ttl and ttl > 0 else DEFAULT_LIST_TTL_SECONDS
         self._authorized = authorized
         self._signature = signature
 

--- a/gateway/radicalbit_ai_gateway/mcp_proxy/list_cache.py
+++ b/gateway/radicalbit_ai_gateway/mcp_proxy/list_cache.py
@@ -12,6 +12,7 @@ the /v1 endpoints use, no new YAML) and owns the guards that decide when a
 route may not be cached at all — see :meth:`McpListCache.for_route`.
 """
 
+import hashlib
 import json
 import logging
 
@@ -35,17 +36,46 @@ RESOURCES_LIST = 'resources/list'
 
 DEFAULT_LIST_TTL_SECONDS = 300
 
+# The result key each list method carries its payload under, and so also the
+# set of methods that may be cached at all.
+LIST_RESULT_KEY = {
+    TOOLS_LIST: 'tools',
+    PROMPTS_LIST: 'prompts',
+    RESOURCES_LIST: 'resources',
+}
+
 
 def servers_signature(servers: list[AnyMcpServer]) -> str:
-    """Identify the upstream set a cached list was produced from."""
+    """Identify the upstream set a cached list was produced from.
+
+    Every field that can change *which* items an upstream exposes belongs
+    here: its endpoint, and the credentials the gateway presents to it. The
+    static ``headers`` (HTTP) and ``env`` (stdio) are what carry those
+    credentials, so rotating a secret to a token with a different scope or
+    tenant — same alias, same url — has to miss rather than keep serving the
+    previous token's tools for the rest of the TTL. Their values are hashed,
+    never spelled out, so no secret reaches a cache key or a log line.
+    """
     parts = []
     for server in sorted(servers, key=lambda s: s.alias):
         if isinstance(server, McpHttpServer):
             endpoint = server.url
+            credentials = server.headers
         else:
             endpoint = json.dumps([server.command, *server.args, server.cwd or ''])
-        parts.append(f'{server.alias}|{server.transport}|{endpoint}')
+            credentials = server.env
+        parts.append(
+            f'{server.alias}|{server.transport}|{endpoint}|{_digest(credentials)}'
+        )
     return ';'.join(parts)
+
+
+def _digest(values: dict[str, str] | None) -> str:
+    """Hash a credential-bearing mapping for inclusion in the signature."""
+    if not values:
+        return ''
+    canonical = json.dumps(values, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode('utf-8')).hexdigest()
 
 
 class McpListCache:
@@ -112,7 +142,18 @@ class McpListCache:
         )
 
     async def get(self, method: str) -> dict | None:
-        """Return the cached result for ``method``, or ``None`` on a miss."""
+        """Return the cached result for ``method``, or ``None`` on a miss.
+
+        Never returns a half-trusted entry: what comes back here is handed to
+        the client verbatim as the JSON-RPC result, so an entry that does not
+        carry this method's own result list — ``{}``, or one written by a
+        gateway version that shaped it differently — is a miss rather than a
+        schema violation the client's SDK rejects.
+        """
+        key = LIST_RESULT_KEY.get(method)
+        if key is None:
+            logger.warning('MCP %s is not a cacheable method, not looking up', method)
+            return None
         try:
             raw = await self._cache.get(self._key(method))
         except Exception:
@@ -125,8 +166,10 @@ class McpListCache:
         except ValueError:
             logger.warning('MCP %s cache entry is not valid JSON, ignoring', method)
             return None
-        if not isinstance(cached, dict):
-            logger.warning('MCP %s cache entry is not a JSON object, ignoring', method)
+        if not isinstance(cached, dict) or not isinstance(cached.get(key), list):
+            logger.warning(
+                "MCP %s cache entry does not carry a '%s' list, ignoring", method, key
+            )
             return None
         return cached
 

--- a/gateway/radicalbit_ai_gateway/routes/mcp_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/mcp_route.py
@@ -3,6 +3,7 @@ from fastapi.responses import JSONResponse
 from traceloop.sdk.decorators import workflow
 
 from radicalbit_ai_gateway.ai_gateway import GatewayRoute
+from radicalbit_ai_gateway.mcp_proxy.list_cache import McpListCache
 from radicalbit_ai_gateway.services.mcp_service import McpService
 from radicalbit_ai_gateway.utils.dependencies import (
     get_gateway_routes,
@@ -62,7 +63,13 @@ class McpRoute:
                     project_name=authorized.project_name,
                 )
 
-            result = await mcp_service.dispatch(request, authorized)
+            list_cache = McpListCache.for_route(
+                gateway_cache=route.gateway_cache if route else None,
+                ttl=route.ttl if route else None,
+                authorized=authorized,
+            )
+
+            result = await mcp_service.dispatch(request, authorized, list_cache)
             if result.payload is None:
                 return Response(status_code=result.status_code)
             return JSONResponse(result.payload, status_code=result.status_code)

--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -16,6 +16,12 @@ from radicalbit_ai_gateway.mcp_proxy.errors import (
     JSON_RPC_UPSTREAM_ERROR,
     McpUpstreamError,
 )
+from radicalbit_ai_gateway.mcp_proxy.list_cache import (
+    PROMPTS_LIST,
+    RESOURCES_LIST,
+    TOOLS_LIST,
+    McpListCache,
+)
 from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
 from radicalbit_ai_gateway.middleware.request_event_context import RequestEventContext
 from radicalbit_ai_gateway.models.mcp_authorized_request import McpAuthorizedRequest
@@ -265,9 +271,18 @@ class McpService:
         )
 
     async def dispatch(
-        self, request: Request, authorized: McpAuthorizedRequest
+        self,
+        request: Request,
+        authorized: McpAuthorizedRequest,
+        list_cache: McpListCache | None = None,
     ) -> McpDispatchResult:
-        """Dispatch the JSON-RPC message on an already-authorized request."""
+        """Dispatch the JSON-RPC message on an already-authorized request.
+
+        ``list_cache`` is the route's cache for the three list methods, or
+        ``None`` when the route declares no caching or must not be cached. Like
+        the limiters, it is resolved by the caller and only carried here — see
+        :meth:`McpListCache.for_route`.
+        """
         self._validate_protocol_version(request)
 
         try:
@@ -284,7 +299,9 @@ class McpService:
             )
 
         set_operation_category(OperationCategory.INVOCATION)
-        result = await self._dispatch(body, authorized.servers, request.headers)
+        result = await self._dispatch(
+            body, authorized.servers, request.headers, list_cache
+        )
         self._record_degradation()
         return self._record_error_outcome(request, result)
 
@@ -332,6 +349,54 @@ class McpService:
             span.set_attribute('rb.gateway.mcp_result_count', count)
 
     @staticmethod
+    def _record_cache_hit(count: int) -> None:
+        """Record a list method served from cache on its own span.
+
+        Deliberately not routed through :meth:`_record_fanout`: no upstream was
+        contacted, so ``mcp_upstream_total``/``mcp_upstream_failed`` would be
+        fiction. ``mcp_result_count`` is still set, so a list's size stays
+        comparable across hits and misses; a span without
+        ``mcp_cache_hit`` is a miss.
+        """
+        span = get_current_span()
+        if span and span.is_recording():
+            span.set_attribute('rb.gateway.mcp_cache_hit', True)
+            span.set_attribute('rb.gateway.mcp_result_count', count)
+
+    async def _cached_list(
+        self,
+        list_cache: McpListCache | None,
+        method: str,
+        key: str,
+    ) -> dict | None:
+        """Return the cached result for a list method, or ``None`` to fan out."""
+        if list_cache is None:
+            return None
+        cached = await list_cache.get(method)
+        if cached is None:
+            return None
+        self._record_cache_hit(len(cached.get(key) or ()))
+        list_cache.record_hit(method)
+        return cached
+
+    @staticmethod
+    async def _store_list(
+        list_cache: McpListCache | None,
+        method: str,
+        result: dict,
+        failed: list[str],
+    ) -> None:
+        """Cache a list method's result, unless the fan-out was degraded.
+
+        A partial result must never be written: one transient upstream outage
+        would otherwise pin a truncated list for the whole TTL, and the client
+        silently loses the tools of a server that is healthy again.
+        """
+        if list_cache is None or failed:
+            return
+        await list_cache.set(method, result)
+
+    @staticmethod
     def _record_degradation() -> None:
         """Hoist a fan-out's failed upstreams onto the root span.
 
@@ -350,6 +415,7 @@ class McpService:
         body: dict,
         servers: list[AnyMcpServer],
         client_headers: Mapping[str, str] | None,
+        list_cache: McpListCache | None = None,
     ) -> McpDispatchResult:
         """Dispatch one JSON-RPC message; returns its HTTP-level outcome.
 
@@ -407,15 +473,15 @@ class McpService:
             elif method == 'ping':
                 result = {}
             elif method == 'tools/list':
-                result = await self._tools_list(servers, client_headers)
+                result = await self._tools_list(servers, client_headers, list_cache)
             elif method == 'tools/call':
                 result = await self._tools_call(params or {}, servers, client_headers)
             elif method == 'prompts/list':
-                result = await self._prompts_list(servers, client_headers)
+                result = await self._prompts_list(servers, client_headers, list_cache)
             elif method == 'prompts/get':
                 result = await self._prompts_get(params or {}, servers, client_headers)
             elif method == 'resources/list':
-                result = await self._resources_list(servers, client_headers)
+                result = await self._resources_list(servers, client_headers, list_cache)
             elif method == 'resources/read':
                 result = await self._resources_read(
                     params or {}, servers, client_headers
@@ -466,15 +532,22 @@ class McpService:
         self,
         servers: list[AnyMcpServer],
         client_headers: Mapping[str, str] | None,
+        list_cache: McpListCache | None = None,
     ) -> dict:
         """Fan out to the route's upstreams and merge their tools.
 
         Each tool name is prefixed ``'{alias}__{tool}'``; all other fields
         pass through verbatim. A failing upstream yields a partial list
         (logged), unless every upstream failed.
+
+        Served from ``list_cache`` when the route declares caching; a degraded
+        fan-out is never written back.
         """
         if not servers:
             return {'tools': []}
+        cached = await self._cached_list(list_cache, TOOLS_LIST, 'tools')
+        if cached is not None:
+            return cached
         results = await asyncio.gather(
             *(
                 self._upstream_client.list_tools(s, client_headers=client_headers)
@@ -503,7 +576,9 @@ class McpService:
                 'tools/list: partial result, upstream MCP servers failed: %s',
                 ', '.join(failed),
             )
-        return {'tools': tools}
+        result = {'tools': tools}
+        await self._store_list(list_cache, TOOLS_LIST, result, failed)
+        return result
 
     @task(name='mcp_tools_call')
     async def _tools_call(
@@ -544,15 +619,19 @@ class McpService:
         self,
         servers: list[AnyMcpServer],
         client_headers: Mapping[str, str] | None,
+        list_cache: McpListCache | None = None,
     ) -> dict:
         """Fan out to the route's upstreams and merge their prompts.
 
         Same shape as :meth:`_tools_list`: each prompt name is prefixed
         ``'{alias}__{name}'``; a failing upstream yields a partial list
-        (logged), unless every upstream failed.
+        (logged), unless every upstream failed. Cached like it, too.
         """
         if not servers:
             return {'prompts': []}
+        cached = await self._cached_list(list_cache, PROMPTS_LIST, 'prompts')
+        if cached is not None:
+            return cached
         results = await asyncio.gather(
             *(
                 self._upstream_client.list_prompts(s, client_headers=client_headers)
@@ -580,7 +659,9 @@ class McpService:
                 'prompts/list: partial result, upstream MCP servers failed: %s',
                 ', '.join(failed),
             )
-        return {'prompts': prompts}
+        result = {'prompts': prompts}
+        await self._store_list(list_cache, PROMPTS_LIST, result, failed)
+        return result
 
     @task(name='mcp_prompts_get')
     async def _prompts_get(
@@ -619,15 +700,20 @@ class McpService:
         self,
         servers: list[AnyMcpServer],
         client_headers: Mapping[str, str] | None,
+        list_cache: McpListCache | None = None,
     ) -> dict:
         """Fan out to the route's upstreams and merge their resources.
 
         Each resource ``uri`` is wrapped via :func:`encode_resource_uri` so
         ``resources/read`` can route it back to the right upstream; a failing
         upstream yields a partial list (logged), unless every upstream failed.
+        Cached like :meth:`_tools_list`.
         """
         if not servers:
             return {'resources': []}
+        cached = await self._cached_list(list_cache, RESOURCES_LIST, 'resources')
+        if cached is not None:
+            return cached
         results = await asyncio.gather(
             *(
                 self._upstream_client.list_resources(s, client_headers=client_headers)
@@ -657,7 +743,9 @@ class McpService:
                 'resources/list: partial result, upstream MCP servers failed: %s',
                 ', '.join(failed),
             )
-        return {'resources': resources}
+        result = {'resources': resources}
+        await self._store_list(list_cache, RESOURCES_LIST, result, failed)
+        return result
 
     @task(name='mcp_resources_read')
     async def _resources_read(

--- a/gateway/radicalbit_ai_gateway/services/mcp_service.py
+++ b/gateway/radicalbit_ai_gateway/services/mcp_service.py
@@ -375,6 +375,7 @@ class McpService:
         cached = await list_cache.get(method)
         if cached is None:
             return None
+        set_operation_category(OperationCategory.CACHE)
         self._record_cache_hit(len(cached.get(key) or ()))
         list_cache.record_hit(method)
         return cached

--- a/gateway/tests/mcp/test_list_cache.py
+++ b/gateway/tests/mcp/test_list_cache.py
@@ -7,6 +7,7 @@ from radicalbit_ai_gateway.caching.in_memory_cache import CacheToolsInMemory
 from radicalbit_ai_gateway.caching.redis_cache import RedisCache
 from radicalbit_ai_gateway.caching.semantic_caching import SemanticCache
 from radicalbit_ai_gateway.mcp_proxy.list_cache import (
+    DEFAULT_LIST_TTL_SECONDS,
     PROMPTS_LIST,
     RESOURCES_LIST,
     TOOLS_LIST,
@@ -172,6 +173,14 @@ async def test_the_ttl_from_the_caching_block_is_passed_through():
     cache = _cache(gateway_cache=GatewayCache(client), ttl=30)
     await cache.set(TOOLS_LIST, {'tools': []})
     assert client.set.await_args.args[2] == 30
+
+
+@pytest.mark.parametrize('ttl', [None, 0])
+async def test_a_list_entry_always_expires(ttl):
+    client = MagicMock(spec_set=CacheToolsInMemory)
+    cache = _cache(gateway_cache=GatewayCache(client), ttl=ttl)
+    await cache.set(TOOLS_LIST, {'tools': []})
+    assert client.set.await_args.args[2] == DEFAULT_LIST_TTL_SECONDS
 
 
 @pytest.mark.parametrize('stored', ['{not json', '["a", "list"]', '"a string"'])

--- a/gateway/tests/mcp/test_list_cache.py
+++ b/gateway/tests/mcp/test_list_cache.py
@@ -12,6 +12,7 @@ from radicalbit_ai_gateway.mcp_proxy.list_cache import (
     RESOURCES_LIST,
     TOOLS_LIST,
     McpListCache,
+    servers_signature,
 )
 from radicalbit_ai_gateway.models.auth_dto import KeyDetails
 from radicalbit_ai_gateway.models.event_type import EventType
@@ -160,6 +161,66 @@ def test_a_stdio_server_is_identified_by_its_command_line():
     )
 
 
+def test_rotating_a_static_header_invalidates_the_entry():
+    """The credential selects which tools the upstream exposes, so it is identity.
+
+    Same alias, same url, a token for a different scope or tenant: the
+    previous token's tools must not keep being served.
+    """
+    one = McpHttpServer(
+        alias='github',
+        url='https://github.example.com/mcp/',
+        headers={'authorization': 'Bearer tenant-a'},
+    )
+    other = McpHttpServer(
+        alias='github',
+        url='https://github.example.com/mcp/',
+        headers={'authorization': 'Bearer tenant-b'},
+    )
+    assert _cache(servers=[one])._key(TOOLS_LIST) != _cache(servers=[other])._key(
+        TOOLS_LIST
+    )
+    # and adding a credential where there was none is also a change of identity
+    assert _cache(servers=[one])._key(TOOLS_LIST) != _cache(servers=[GITHUB])._key(
+        TOOLS_LIST
+    )
+
+
+def test_changing_a_stdio_env_invalidates_the_entry():
+    one = McpStdioServer(alias='local', command='python', env={'TOKEN': 'a'})
+    other = McpStdioServer(alias='local', command='python', env={'TOKEN': 'b'})
+    assert _cache(servers=[one])._key(TOOLS_LIST) != _cache(servers=[other])._key(
+        TOOLS_LIST
+    )
+
+
+def test_reordering_the_same_headers_still_hits():
+    """The signature must key on the credential set, not on dict insertion order."""
+    one = McpHttpServer(
+        alias='github',
+        url='https://github.example.com/mcp/',
+        headers={'authorization': 'Bearer t', 'x-tenant': 'a'},
+    )
+    other = McpHttpServer(
+        alias='github',
+        url='https://github.example.com/mcp/',
+        headers={'x-tenant': 'a', 'authorization': 'Bearer t'},
+    )
+    assert _cache(servers=[one])._key(TOOLS_LIST) == _cache(servers=[other])._key(
+        TOOLS_LIST
+    )
+
+
+def test_a_credential_never_reaches_the_signature_in_the_clear():
+    secret = 'Bearer super-secret'
+    server = McpHttpServer(
+        alias='github',
+        url='https://github.example.com/mcp/',
+        headers={'authorization': secret},
+    )
+    assert secret not in servers_signature([server])
+
+
 async def test_a_stored_result_round_trips():
     cache = _cache()
     result = {'tools': [{'name': 'github__get_issue', 'description': 'a tool'}]}
@@ -183,7 +244,18 @@ async def test_a_list_entry_always_expires(ttl):
     assert client.set.await_args.args[2] == DEFAULT_LIST_TTL_SECONDS
 
 
-@pytest.mark.parametrize('stored', ['{not json', '["a", "list"]', '"a string"'])
+@pytest.mark.parametrize(
+    'stored',
+    [
+        '{not json',
+        '["a", "list"]',
+        '"a string"',
+        '{}',
+        '{"tools_v2": []}',
+        '{"tools": {"get_issue": {}}}',
+        '{"tools": null}',
+    ],
+)
 async def test_an_unusable_entry_is_a_miss_not_an_error(stored):
     client = MagicMock(spec_set=CacheToolsInMemory)
     client.get.return_value = stored
@@ -241,3 +313,10 @@ def test_an_exact_cache_reports_its_own_type():
         _cache(gateway_cache=exact).record_hit(RESOURCES_LIST)
 
     assert mock_emit.call_args.args[0].cache_type == 'exact'
+
+
+@pytest.mark.parametrize('method', ['tools/call', 'initialize'])
+async def test_a_method_that_is_not_a_list_is_never_served(method):
+    client = MagicMock(spec_set=CacheToolsInMemory)
+    assert await _cache(gateway_cache=GatewayCache(client)).get(method) is None
+    client.get.assert_not_awaited()

--- a/gateway/tests/mcp/test_list_cache.py
+++ b/gateway/tests/mcp/test_list_cache.py
@@ -1,0 +1,234 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from radicalbit_ai_gateway.caching.gateway_cache import GatewayCache
+from radicalbit_ai_gateway.caching.in_memory_cache import CacheToolsInMemory
+from radicalbit_ai_gateway.caching.redis_cache import RedisCache
+from radicalbit_ai_gateway.caching.semantic_caching import SemanticCache
+from radicalbit_ai_gateway.mcp_proxy.list_cache import (
+    PROMPTS_LIST,
+    RESOURCES_LIST,
+    TOOLS_LIST,
+    McpListCache,
+)
+from radicalbit_ai_gateway.models.auth_dto import KeyDetails
+from radicalbit_ai_gateway.models.event_type import EventType
+from radicalbit_ai_gateway.models.mcp_authorized_request import McpAuthorizedRequest
+from radicalbit_ai_gateway.models.mcp_server import McpHttpServer, McpStdioServer
+
+GITHUB = McpHttpServer(alias='github', url='https://github.example.com/mcp/')
+JIRA = McpHttpServer(alias='jira', url='https://jira.example.com/mcp/')
+SERVERS = [GITHUB, JIRA]
+
+PROJECT = 'project-uuid'
+ROUTE = 'my-route'
+KEY = 'key-uuid'
+
+LIST_CACHE = 'radicalbit_ai_gateway.mcp_proxy.list_cache'
+
+
+def _in_memory_cache() -> GatewayCache:
+    return GatewayCache(CacheToolsInMemory())
+
+
+def _authorized(
+    servers: list = SERVERS,
+    key_uuid: str = KEY,
+    route_name: str = ROUTE,
+    project_uuid: str = PROJECT,
+) -> McpAuthorizedRequest:
+    return McpAuthorizedRequest(
+        request_uuid='request-uuid',
+        project_name='my-project',
+        project_uuid=project_uuid,
+        route_name=route_name,
+        route_key=f'my-project/{route_name}',
+        key_details=KeyDetails(
+            api_key_uuid=key_uuid,
+            api_key_name='my-key',
+            group_uuid='group-uuid',
+            group_name='team-a',
+            hashed_api_key='hashed',
+        ),
+        servers=servers,
+    )
+
+
+def _for_route(
+    gateway_cache: GatewayCache | None = None,
+    servers: list = SERVERS,
+    ttl: int | None = None,
+    key_uuid: str = KEY,
+    route_name: str = ROUTE,
+    project_uuid: str = PROJECT,
+) -> McpListCache | None:
+    return McpListCache.for_route(
+        gateway_cache=gateway_cache
+        if gateway_cache is not None
+        else _in_memory_cache(),
+        ttl=ttl,
+        authorized=_authorized(
+            servers=servers,
+            key_uuid=key_uuid,
+            route_name=route_name,
+            project_uuid=project_uuid,
+        ),
+    )
+
+
+def _cache(**kwargs) -> McpListCache:
+    """Return the cache a cacheable route gets, narrowed out of the optional."""
+    cache = _for_route(**kwargs)
+    assert cache is not None, 'expected this route to be cacheable'
+    return cache
+
+
+def test_a_route_without_caching_gets_no_cache():
+    assert McpListCache.for_route(None, None, _authorized()) is None
+
+
+def test_a_route_without_servers_gets_no_cache():
+    assert _for_route(servers=[]) is None
+
+
+def test_the_semantic_cache_is_excluded():
+    """A list method has no query text to embed, so similarity search is moot."""
+    semantic = GatewayCache(MagicMock(spec_set=SemanticCache))
+    assert _for_route(gateway_cache=semantic) is None
+
+
+def test_forward_headers_disables_caching_for_the_whole_route():
+    """The list may legitimately differ per caller, so no entry is shareable."""
+    per_caller = McpHttpServer(
+        alias='github',
+        url='https://github.example.com/mcp/',
+        forward_headers=['authorization'],
+    )
+    assert _for_route(servers=[per_caller, JIRA]) is None
+    assert _for_route(servers=[JIRA, per_caller]) is None
+
+
+def test_stdio_servers_never_carry_forward_headers():
+    stdio = McpStdioServer(alias='local', command='python', args=['-m', 'server'])
+    assert _for_route(servers=[stdio]) is not None
+
+
+def test_each_list_method_has_its_own_key():
+    keys = {_cache()._key(m) for m in (TOOLS_LIST, PROMPTS_LIST, RESOURCES_LIST)}
+    assert len(keys) == 3
+
+
+@pytest.mark.parametrize(
+    'other',
+    [
+        {'key_uuid': 'another-key'},
+        {'route_name': 'other-route'},
+        {'project_uuid': 'other-project'},
+    ],
+)
+def test_entries_are_scoped_like_every_other_cached_response(other):
+    assert _cache()._key(TOOLS_LIST) != _cache(**other)._key(TOOLS_LIST)
+
+
+def test_reordering_the_same_servers_still_hits():
+    assert _cache(servers=[GITHUB, JIRA])._key(TOOLS_LIST) == _cache(
+        servers=[JIRA, GITHUB]
+    )._key(TOOLS_LIST)
+
+
+def test_repointing_an_alias_invalidates_the_entry():
+    """Same alias, different upstream: the old server's tools must not survive."""
+    moved = McpHttpServer(alias='github', url='https://elsewhere.example.com/mcp/')
+    assert _cache(servers=[GITHUB])._key(TOOLS_LIST) != _cache(servers=[moved])._key(
+        TOOLS_LIST
+    )
+
+
+def test_adding_a_server_invalidates_the_entry():
+    assert _cache(servers=[GITHUB])._key(TOOLS_LIST) != _cache(servers=SERVERS)._key(
+        TOOLS_LIST
+    )
+
+
+def test_a_stdio_server_is_identified_by_its_command_line():
+    base = McpStdioServer(alias='local', command='python', args=['-m', 'a'])
+    other_args = McpStdioServer(alias='local', command='python', args=['-m', 'b'])
+    assert _cache(servers=[base])._key(TOOLS_LIST) != _cache(servers=[other_args])._key(
+        TOOLS_LIST
+    )
+
+
+async def test_a_stored_result_round_trips():
+    cache = _cache()
+    result = {'tools': [{'name': 'github__get_issue', 'description': 'a tool'}]}
+    await cache.set(TOOLS_LIST, result)
+    assert await cache.get(TOOLS_LIST) == result
+    assert await cache.get(PROMPTS_LIST) is None
+
+
+async def test_the_ttl_from_the_caching_block_is_passed_through():
+    client = MagicMock(spec_set=CacheToolsInMemory)
+    cache = _cache(gateway_cache=GatewayCache(client), ttl=30)
+    await cache.set(TOOLS_LIST, {'tools': []})
+    assert client.set.await_args.args[2] == 30
+
+
+@pytest.mark.parametrize('stored', ['{not json', '["a", "list"]', '"a string"'])
+async def test_an_unusable_entry_is_a_miss_not_an_error(stored):
+    client = MagicMock(spec_set=CacheToolsInMemory)
+    client.get.return_value = stored
+    cache = _cache(gateway_cache=GatewayCache(client))
+    assert await cache.get(TOOLS_LIST) is None
+
+
+# ---------------------------------------------------------------------------
+# Reporting a hit
+# ---------------------------------------------------------------------------
+
+
+def test_a_hit_emits_a_cache_hit_event_under_the_callers_identity():
+    """The same event /v1 emits, so MCP hits reach the usage view and alerts."""
+    with (
+        patch(f'{LIST_CACHE}.emit_event') as mock_emit,
+        patch(f'{LIST_CACHE}.cache_hit_counter') as mock_counter,
+    ):
+        _cache().record_hit(TOOLS_LIST)
+
+    event = mock_emit.call_args.args[0]
+    assert event.event_type is EventType.CACHE_HIT
+    assert event.value == 1.0
+    assert event.route_name == ROUTE
+    assert event.project_uuid == PROJECT
+    assert event.api_key_uuid == KEY
+    assert event.api_key_name == 'my-key'
+    assert event.group_uuid == 'group-uuid'
+    assert event.request_uuid == 'request-uuid'
+    # in-memory stands in for redis when the project has no cache: block
+    assert event.cache_type == 'in-memory'
+    mock_counter.add.assert_called_once_with(1, {'route_name': ROUTE})
+
+
+def test_the_event_claims_no_model_and_no_saving():
+    """A list method invokes no model, so it prices nothing."""
+    with (
+        patch(f'{LIST_CACHE}.emit_event') as mock_emit,
+        patch(f'{LIST_CACHE}.cache_hit_counter'),
+    ):
+        _cache().record_hit(PROMPTS_LIST)
+
+    event = mock_emit.call_args.args[0]
+    assert event.model_id == ''
+    # nothing is claimed against the cache-savings columns either
+    assert event.cost == 0.0
+
+
+def test_an_exact_cache_reports_its_own_type():
+    exact = GatewayCache(MagicMock(spec_set=RedisCache))
+    with (
+        patch(f'{LIST_CACHE}.emit_event') as mock_emit,
+        patch(f'{LIST_CACHE}.cache_hit_counter'),
+    ):
+        _cache(gateway_cache=exact).record_hit(RESOURCES_LIST)
+
+    assert mock_emit.call_args.args[0].cache_type == 'exact'

--- a/gateway/tests/mcp/test_mcp_service.py
+++ b/gateway/tests/mcp/test_mcp_service.py
@@ -1162,28 +1162,9 @@ async def test_a_cache_hit_emits_a_cache_hit_event(emitted_cache_hits):
 
     event = emitted_cache_hits.call_args.args[0]
     assert event.event_type is EventType.CACHE_HIT
-    assert event.target == 'tools/list'
     assert event.route_name == 'my-route'
     assert event.api_key_uuid == 'key-uuid'
     assert emitted_cache_hits.call_count == 1
-
-
-async def test_each_cached_method_emits_its_own_event(emitted_cache_hits):
-    client = MagicMock(spec_set=McpUpstreamClient)
-    client.list_prompts = AsyncMock(return_value=types.ListPromptsResult(prompts=[]))
-    client.list_resources = AsyncMock(
-        return_value=types.ListResourcesResult(resources=[])
-    )
-    service, cache = _service(client), _list_cache()
-
-    for method in ('prompts/list', 'resources/list'):
-        await service._dispatch(_request(method), SERVERS, None, cache)
-        await service._dispatch(_request(method), SERVERS, None, cache)
-
-    assert [c.args[0].target for c in emitted_cache_hits.call_args_list] == [
-        'prompts/list',
-        'resources/list',
-    ]
 
 
 async def test_a_degraded_fanout_emits_no_hit_because_it_was_never_cached(

--- a/gateway/tests/mcp/test_mcp_service.py
+++ b/gateway/tests/mcp/test_mcp_service.py
@@ -3,8 +3,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from mcp import types
 import pytest
 
+from radicalbit_ai_gateway.caching.gateway_cache import GatewayCache
+from radicalbit_ai_gateway.caching.in_memory_cache import CacheToolsInMemory
 from radicalbit_ai_gateway.mcp_proxy.errors import McpUpstreamError
+from radicalbit_ai_gateway.mcp_proxy.list_cache import McpListCache
 from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
+from radicalbit_ai_gateway.models.auth_dto import KeyDetails
+from radicalbit_ai_gateway.models.event_type import EventType
+from radicalbit_ai_gateway.models.mcp_authorized_request import McpAuthorizedRequest
 from radicalbit_ai_gateway.models.mcp_server import McpHttpServer
 from radicalbit_ai_gateway.services.mcp_service import (
     LATEST_PROTOCOL_VERSION,
@@ -967,3 +973,234 @@ async def test_fanout_is_not_recorded_on_a_non_recording_span():
         await _service(client)._dispatch(_request('tools/list'), SERVERS, None)
 
     span.set_attribute.assert_not_called()
+
+
+LIST_CACHE = 'radicalbit_ai_gateway.mcp_proxy.list_cache'
+
+
+@pytest.fixture(autouse=True)
+def emitted_cache_hits():
+    """Keep CACHE_HIT events out of the real buffer; assert on the mock instead.
+
+    Autouse so no unit test reaches the Celery event buffer, and named so the
+    tests that care about the event can request it.
+    """
+    with (
+        patch(f'{LIST_CACHE}.emit_event') as mock_emit,
+        patch(f'{LIST_CACHE}.cache_hit_counter'),
+    ):
+        yield mock_emit
+
+
+def _list_cache(servers=SERVERS) -> McpListCache:
+    """Build a real in-memory cache, wired as the endpoint wires it.
+
+    for_route returns None for a route that must not be cached; these tests all
+    use cacheable routes, so the assert both narrows the type and fails loudly
+    if a guard ever starts firing on one of them.
+    """
+    cache = McpListCache.for_route(
+        gateway_cache=GatewayCache(CacheToolsInMemory()),
+        ttl=None,
+        authorized=McpAuthorizedRequest(
+            request_uuid='request-uuid',
+            project_name='my-project',
+            project_uuid='project-uuid',
+            route_name='my-route',
+            route_key='my-project/my-route',
+            key_details=KeyDetails(
+                api_key_uuid='key-uuid',
+                api_key_name='my-key',
+                group_uuid='group-uuid',
+                group_name='team-a',
+                hashed_api_key='hashed',
+            ),
+            servers=servers,
+        ),
+    )
+    assert cache is not None, 'expected these servers to be cacheable'
+    return cache
+
+
+async def test_a_second_tools_list_is_served_from_cache():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(
+        side_effect=[
+            types.ListToolsResult(tools=[_tool('get_issue')]),
+            types.ListToolsResult(tools=[_tool('search')]),
+        ]
+    )
+    service, cache = _service(client), _list_cache()
+
+    first = await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+    second = await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+
+    assert second.payload['result'] == first.payload['result']
+    assert [t['name'] for t in second.payload['result']['tools']] == [
+        'github__get_issue',
+        'jira__search',
+    ]
+    # one fan-out for the two requests, not one per server per request
+    assert client.list_tools.await_count == len(SERVERS)
+
+
+async def test_prompts_list_and_resources_list_are_cached_too():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_prompts = AsyncMock(
+        return_value=types.ListPromptsResult(prompts=[_prompt('summarize')])
+    )
+    client.list_resources = AsyncMock(
+        return_value=types.ListResourcesResult(
+            resources=[_resource('https://a.example/1')]
+        )
+    )
+    service, cache = _service(client), _list_cache()
+
+    for method in ('prompts/list', 'resources/list'):
+        first = await service._dispatch(_request(method), SERVERS, None, cache)
+        second = await service._dispatch(_request(method), SERVERS, None, cache)
+        assert second.payload['result'] == first.payload['result']
+
+    assert client.list_prompts.await_count == len(SERVERS)
+    assert client.list_resources.await_count == len(SERVERS)
+    # the wrapped uri survives the round trip through the cache
+    assert all(
+        uri.startswith('mcp-resource:')
+        for uri in [r['uri'] for r in second.payload['result']['resources']]
+    )
+
+
+async def test_one_cached_method_never_answers_another():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+    client.list_prompts = AsyncMock(
+        return_value=types.ListPromptsResult(prompts=[_prompt('summarize')])
+    )
+    service, cache = _service(client), _list_cache()
+
+    await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+    result = await service._dispatch(_request('prompts/list'), SERVERS, None, cache)
+
+    assert [p['name'] for p in result.payload['result']['prompts']] == [
+        'github__summarize',
+        'jira__summarize',
+    ]
+
+
+async def test_a_partial_fanout_is_never_cached():
+    """A transient outage must not pin a truncated list for the whole TTL."""
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(
+        side_effect=[
+            McpUpstreamError('github', 'boom'),
+            types.ListToolsResult(tools=[_tool('search')]),
+            types.ListToolsResult(tools=[_tool('get_issue')]),
+            types.ListToolsResult(tools=[_tool('search')]),
+        ]
+    )
+    service, cache = _service(client), _list_cache()
+
+    degraded = await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+    recovered = await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+
+    assert [t['name'] for t in degraded.payload['result']['tools']] == ['jira__search']
+    assert [t['name'] for t in recovered.payload['result']['tools']] == [
+        'github__get_issue',
+        'jira__search',
+    ]
+    assert client.list_tools.await_count == 2 * len(SERVERS)
+
+
+async def test_a_fully_failed_fanout_is_never_cached():
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(
+        side_effect=[
+            McpUpstreamError('github', 'boom'),
+            McpUpstreamError('jira', 'boom'),
+            types.ListToolsResult(tools=[_tool('get_issue')]),
+            types.ListToolsResult(tools=[_tool('search')]),
+        ]
+    )
+    service, cache = _service(client), _list_cache()
+
+    failed = await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+    recovered = await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+
+    assert failed.payload['error']['code'] == -32000
+    assert len(recovered.payload['result']['tools']) == 2
+
+
+async def test_a_cache_hit_is_marked_on_the_span():
+    """A hit contacted no upstream, so it records no fan-out counts."""
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(
+        return_value=types.ListToolsResult(tools=[_tool('get_issue')])
+    )
+    service, cache = _service(client), _list_cache()
+    await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+    span = _recording_span()
+
+    with patch(f'{MCP_SERVICE}.get_current_span', return_value=span):
+        await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+
+    assert _span_attrs(span) == {
+        'rb.gateway.mcp_cache_hit': True,
+        'rb.gateway.mcp_result_count': 2,
+    }
+
+
+async def test_a_cache_hit_emits_a_cache_hit_event(emitted_cache_hits):
+    """A hit reaches the usage view and alert rules, not just the trace."""
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+    service, cache = _service(client), _list_cache()
+
+    await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+    assert emitted_cache_hits.call_count == 0  # the miss that populated it
+
+    await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+
+    event = emitted_cache_hits.call_args.args[0]
+    assert event.event_type is EventType.CACHE_HIT
+    assert event.target == 'tools/list'
+    assert event.route_name == 'my-route'
+    assert event.api_key_uuid == 'key-uuid'
+    assert emitted_cache_hits.call_count == 1
+
+
+async def test_each_cached_method_emits_its_own_event(emitted_cache_hits):
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_prompts = AsyncMock(return_value=types.ListPromptsResult(prompts=[]))
+    client.list_resources = AsyncMock(
+        return_value=types.ListResourcesResult(resources=[])
+    )
+    service, cache = _service(client), _list_cache()
+
+    for method in ('prompts/list', 'resources/list'):
+        await service._dispatch(_request(method), SERVERS, None, cache)
+        await service._dispatch(_request(method), SERVERS, None, cache)
+
+    assert [c.args[0].target for c in emitted_cache_hits.call_args_list] == [
+        'prompts/list',
+        'resources/list',
+    ]
+
+
+async def test_a_degraded_fanout_emits_no_hit_because_it_was_never_cached(
+    emitted_cache_hits,
+):
+    client = MagicMock(spec_set=McpUpstreamClient)
+    client.list_tools = AsyncMock(
+        side_effect=[
+            McpUpstreamError('github', 'boom'),
+            types.ListToolsResult(tools=[_tool('search')]),
+            McpUpstreamError('github', 'boom'),
+            types.ListToolsResult(tools=[_tool('search')]),
+        ]
+    )
+    service, cache = _service(client), _list_cache()
+
+    await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+    await service._dispatch(_request('tools/list'), SERVERS, None, cache)
+
+    emitted_cache_hits.assert_not_called()

--- a/gateway/tests/mcp/test_span_attributes.py
+++ b/gateway/tests/mcp/test_span_attributes.py
@@ -30,6 +30,8 @@ from starlette.testclient import TestClient
 from traceloop.sdk import Traceloop
 from traceloop.sdk.tracing.tracing import TracerWrapper
 
+from radicalbit_ai_gateway.caching.gateway_cache import GatewayCache
+from radicalbit_ai_gateway.caching.in_memory_cache import CacheToolsInMemory
 from radicalbit_ai_gateway.mcp_proxy.errors import McpUpstreamError
 from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
 from radicalbit_ai_gateway.middleware.request_event_middleware import (
@@ -151,6 +153,29 @@ def client(exporter, upstream) -> TestClient:
     return TestClient(app)
 
 
+@pytest.fixture
+def cached_client(client) -> Iterator[TestClient]:
+    """Return the same app, with the route declaring a ``caching:`` block.
+
+    The base fixture leaves ``app.state.routes`` empty, which the endpoint
+    reads as "no route-level features", so no list cache is built at all.
+    """
+    client.app.state.routes = {
+        'proj/my-route': SimpleNamespace(
+            request_rate_limiter=None,
+            gateway_cache=GatewayCache(CacheToolsInMemory()),
+            ttl=60,
+        )
+    }
+    # A hit reports itself to the events pipeline; that is asserted in
+    # test_list_cache.py and only noise here.
+    with (
+        patch('radicalbit_ai_gateway.mcp_proxy.list_cache.emit_event'),
+        patch('radicalbit_ai_gateway.mcp_proxy.list_cache.cache_hit_counter'),
+    ):
+        yield client
+
+
 def _post(client: TestClient, method: str, params: dict | None = None):
     body = {'jsonrpc': '2.0', 'id': 1, 'method': method}
     if params is not None:
@@ -164,6 +189,10 @@ def _span(exporter, name: str):
         f'no {name} span emitted, got {[s.name for s in exporter.get_finished_spans()]}'
     )
     return matches[-1]
+
+
+def _category(span) -> str | None:
+    return (span.attributes or {}).get(f'{ASSOC}rb.gateway.operation_category')
 
 
 def _mcp_attrs(span) -> dict:
@@ -413,3 +442,55 @@ def test_an_auth_failure_still_reports_the_route_it_targeted(client):
     assert payload.route_name == 'my-route'
     assert payload.project_name == 'proj'
     assert payload.status is RequestStatus.HANDLED_ERROR
+
+
+LIST_SPAN = 'mcp_tools_list.task'
+
+
+def test_a_list_served_from_cache_is_categorised_as_cache(
+    cached_client, exporter, upstream
+):
+    """A hit contacted no upstream, so it must not be bucketed as one.
+
+    Asserted on the emitted span rather than on a call to
+    set_operation_category, because where it lands is the whole point:
+    get_category_latencies groups every span by this attribute, and the task
+    span inherits the INVOCATION that dispatch set before it knew the method.
+    """
+    upstream.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+
+    assert _post(cached_client, 'tools/list').status_code == 200
+    assert _category(_span(exporter, LIST_SPAN)) == 'invocation'
+
+    assert _post(cached_client, 'tools/list').status_code == 200
+    assert _category(_span(exporter, LIST_SPAN)) == 'cache'
+    # and the second request really was a hit, not a second fan-out
+    assert upstream.list_tools.await_count == 2
+
+
+def test_the_root_span_of_a_cache_hit_stays_the_endpoint_bucket(
+    cached_client, exporter, upstream
+):
+    """ensure_endpoint_category owns the root span; the phases are per-span."""
+    upstream.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+
+    assert _post(cached_client, 'tools/list').status_code == 200
+    assert _post(cached_client, 'tools/list').status_code == 200
+
+    assert _category(_span(exporter, ROOT_SPAN)) == 'endpoint'
+
+
+def test_a_cache_hit_does_not_recategorise_the_next_requests_fanout(
+    cached_client, exporter, upstream
+):
+    """The correction is attached inside a task, so prove it unwinds with it."""
+    upstream.list_tools = AsyncMock(return_value=types.ListToolsResult(tools=[]))
+    upstream.list_prompts = AsyncMock(return_value=types.ListPromptsResult(prompts=[]))
+
+    assert _post(cached_client, 'tools/list').status_code == 200
+    assert _post(cached_client, 'tools/list').status_code == 200
+    assert _category(_span(exporter, LIST_SPAN)) == 'cache'
+
+    # a different list method on the same route: a miss, and its own category
+    assert _post(cached_client, 'prompts/list').status_code == 200
+    assert _category(_span(exporter, 'mcp_prompts_list.task')) == 'invocation'

--- a/gateway/tests/routes/test_mcp_route.py
+++ b/gateway/tests/routes/test_mcp_route.py
@@ -9,9 +9,12 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from starlette.testclient import TestClient
 
+from radicalbit_ai_gateway.caching.gateway_cache import GatewayCache
+from radicalbit_ai_gateway.caching.in_memory_cache import CacheToolsInMemory
 from radicalbit_ai_gateway.limiting.rate_limiter import RequestRateLimiter
 from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
 from radicalbit_ai_gateway.models.auth_dto import KeyDetails
+from radicalbit_ai_gateway.models.event_type import EventType
 from radicalbit_ai_gateway.models.gateway_config import GatewayConfig
 from radicalbit_ai_gateway.models.limiting import RateLimiting
 from radicalbit_ai_gateway.models.project_entry import ProjectEntry
@@ -87,6 +90,8 @@ def _make_client(
     key_bound: bool = True,
     with_project: bool = True,
     rate_limiter=None,
+    gateway_cache=None,
+    ttl: int | None = None,
     request_uuid: str | None = REQUEST_UUID,
 ) -> tuple[TestClient, MagicMock]:
     app = FastAPI(title='AI Gateway', debug=True)
@@ -109,7 +114,9 @@ def _make_client(
     # Mirrors what the route factory registers: the built GatewayRoute carrying
     # the route's live feature instances, keyed '{project}/{route}'.
     app.state.routes = {
-        'proj/my-route': SimpleNamespace(request_rate_limiter=rate_limiter)
+        'proj/my-route': SimpleNamespace(
+            request_rate_limiter=rate_limiter, gateway_cache=gateway_cache, ttl=ttl
+        )
     }
     app.state.token_validator = SimpleNamespace(
         validate_token=AsyncMock(return_value=KEY_DETAILS)
@@ -589,3 +596,87 @@ def test_a_missing_route_registry_is_a_503_like_the_v1_endpoints():
     client, _ = _make_client()
     del client.app.state.routes
     assert client.post(PATH, json=_ping(), headers=AUTH).status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Route-level features: caching of the list methods
+# ---------------------------------------------------------------------------
+
+
+def _tools_list(request_id=1) -> dict:
+    return {'jsonrpc': '2.0', 'id': request_id, 'method': 'tools/list'}
+
+
+def _echoing_upstream() -> MagicMock:
+    upstream = MagicMock(spec_set=McpUpstreamClient)
+    upstream.list_tools = AsyncMock(
+        return_value=types.ListToolsResult(
+            tools=[
+                types.Tool(
+                    name='echo', inputSchema={'type': 'object', 'properties': {}}
+                )
+            ]
+        )
+    )
+    return upstream
+
+
+LIST_CACHE = 'radicalbit_ai_gateway.mcp_proxy.list_cache'
+
+
+@patch(f'{LIST_CACHE}.cache_hit_counter', autospec=True)
+@patch(f'{LIST_CACHE}.emit_event', autospec=True)
+def test_a_route_with_caching_serves_repeated_lists_without_the_upstreams(
+    mock_emit_event, mock_counter
+):
+    """The caching: block the /v1 endpoints already honour, with no new YAML."""
+    upstream = _echoing_upstream()
+    client, _ = _make_client(
+        upstream, gateway_cache=GatewayCache(CacheToolsInMemory()), ttl=60
+    )
+
+    first = client.post(PATH, json=_tools_list(1), headers=AUTH)
+    second = client.post(PATH, json=_tools_list(2), headers=AUTH)
+
+    assert first.status_code == second.status_code == 200
+    assert second.json()['result'] == first.json()['result']
+    assert [t['name'] for t in second.json()['result']['tools']] == ['github__echo']
+    upstream.list_tools.assert_awaited_once()
+
+    # the hit is reported under the identity the request authenticated with
+    event = mock_emit_event.call_args.args[0]
+    assert event.event_type is EventType.CACHE_HIT
+    assert event.route_name == 'my-route'
+    assert event.project_name == 'proj'
+    assert event.api_key_uuid == KEY_DETAILS.api_key_uuid
+    assert event.group_name == KEY_DETAILS.group_name
+    assert event.request_uuid == REQUEST_UUID
+    mock_counter.add.assert_called_once_with(1, {'route_name': 'my-route'})
+
+
+def test_a_route_without_caching_fans_out_every_time():
+    upstream = _echoing_upstream()
+    client, _ = _make_client(upstream)
+
+    assert client.post(PATH, json=_tools_list(1), headers=AUTH).status_code == 200
+    assert client.post(PATH, json=_tools_list(2), headers=AUTH).status_code == 200
+
+    assert upstream.list_tools.await_count == 2
+
+
+def test_only_the_list_methods_are_cached():
+    """tools/call is side-effecting: it must reach the upstream every time."""
+    upstream = _echoing_upstream()
+    upstream.call_tool = AsyncMock(return_value=types.CallToolResult(content=[]))
+    client, _ = _make_client(upstream, gateway_cache=GatewayCache(CacheToolsInMemory()))
+    call = {
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'tools/call',
+        'params': {'name': 'github__echo', 'arguments': {'text': 'hi'}},
+    }
+
+    assert client.post(PATH, json=call, headers=AUTH).status_code == 200
+    assert client.post(PATH, json={**call, 'id': 2}, headers=AUTH).status_code == 200
+
+    assert upstream.call_tool.await_count == 2


### PR DESCRIPTION
## Summary

Caches the three MCP **list** methods — `tools/list`, `prompts/list`, `resources/list` — so a
route with an enabled `caching:` block answers repeated list calls from Redis instead of
re-running the upstream fan-out. Each list call otherwise opens `N × (TCP + TLS + initialize
handshake)`, one per configured upstream, and agent SDKs re-issue `tools/list` on every
reconnect.

Reuses the route's existing `GatewayCache` — the same `caching:` block the `/v1` endpoints
already honour — so there is **no new YAML**. Route-level features are applied by the
endpoint, not the service, matching the pattern established for MCP rate limiting.

**No request or response schema changes.** The MCP JSON-RPC contract is unchanged: a cached
`tools/list` returns byte-identical results to a fresh fan-out. The only client-visible
difference is latency.

---

## DTO Changes

**None over the wire.** No Pydantic model in `radicalbit_ai_gateway/models/` was added or
modified, and no serialized response shape changed.

One internal class is introduced:

### `McpListCache` (NEW — internal, never serialized)

Lives in `mcp_proxy/list_cache.py`. Built by the endpoint and passed into `dispatch()`, the
same way the limiters are. Returns `None` from `for_route()` when a route must not cache,
which is what makes "not cacheable" a single decision rather than a check scattered across
three methods.

| Member | Description |
|--------|-------------|
| `for_route(gateway_cache, ttl, authorized)` | Builds the cache, or `None` when the route must not cache |
| `get(method)` | Cached result, or `None` on a miss. Never raises |
| `set(method, result)` | Stores a result. Never raises |
| `record_hit(method)` | Emits the `CACHE_HIT` event and increments `cache_hit_counter` |

---

## Configuration

No new keys — but the existing `caching:` block now governs MCP as well as `/v1`. Operators
should know this, because turning caching on for a route's chat completions now also turns it
on for that route's tool lists.

```yaml
cache:
  redis_host: valkey-cache  
  redis_port: 6379

routes:
  demo:
    mcp_servers:
      - weather
    caching:
      type: exact
      ttl: 300
```

| Setting | Effect on MCP list caching |
|---------|----------------------------|
| `caching:` absent | No caching. `for_route()` returns `None` |
| `caching.type: exact` | Cached in Redis |
| `caching.type: semantic` | **Not cached.** A list method has no query text to embed, so similarity search cannot answer it |
| `cache:` absent, `caching:` present | Falls back to the per-process in-memory LRU — single-replica only, and shared with the route's chat entries |
| `caching.ttl` unset or `0` | **Defaults to 300s** (`DEFAULT_LIST_TTL_SECONDS`), not to no-expiry |
| Any upstream declares `forward_headers` | **Whole route is not cached** — see below |

### Two behaviours worth flagging in review

**`ttl` unset does not mean "no expiry" here.** `Caching.ttl` defaults to `None`, which the
cache clients read as no expiry at all. That is defensible for a chat completion, whose key
contains the whole prompt — a stale entry is only ever reachable by an identical request. A
list key carries no upstream state, nothing can invalidate it (no cache client exposes a
`delete`, and the gateway does not subscribe to `notifications/tools/list_changed`), so an
unbounded entry would pin the upstream's first answer indefinitely. The list cache therefore
substitutes a bounded default.

**`forward_headers` disables caching for the entire route.** When an upstream fills a header
from the inbound request, two callers with different credentials can legitimately be shown
different tool lists, so no entry is shareable. Skipping such routes wholesale is provably
safe and keeps credential material out of cache keys. Note this means a route mixing a
`forward_headers` upstream with a statically-authenticated one gets **no** list caching.

---

## Affected Endpoints

### `POST /{project_name}/{route_name}/mcp` (MODIFIED — behaviour only)

**Changes:**
```diff
  (no change to path, query params, headers, request body, or response body)
+ repeated tools/list | prompts/list | resources/list may be served from cache
```

**Example request** (unchanged):
```
POST /my-project/demo/mcp
Authorization: Bearer sk-rb-...
Content-Type: application/json

{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
```

**Example response** (identical on a hit and a miss):
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "tools": [
      {
        "name": "weather__get_forecast",
        "description": "Get the forecast for a city",
        "inputSchema": {
          "type": "object",
          "properties": {"city": {"type": "string"}},
          "required": ["city"]
        }
      }
    ]
  }
}
```

| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `project_name` | string | yes | Project name (path) |
| `route_name` | string | yes | Route name (path) |
| `Authorization` | string | yes | `Bearer {gateway_api_key}` (header) |
| `mcp-protocol-version` | string | no | One of: `2025-06-18`, `2025-11-25` (header) |

**Methods affected:** only `tools/list`, `prompts/list`, `resources/list`. `initialize`,
`ping`, `tools/call`, `prompts/get` and `resources/read` are untouched — calls are
side-effecting by definition and are never cached.

**A degraded fan-out is never written back.** If any upstream fails, the partial list is
returned to the client but not stored; one transient outage would otherwise pin a truncated
tool list for the whole TTL, silently hiding a healthy server's tools.

---

## Cache Key Composition

`GatewayCache.generate_mcp_list_cache_key` (NEW) builds the key from:

| Component | Why it is in the key |
|-----------|---------------------|
| `project_uuid` | Route names are unique only within a project |
| `route_name` | Different routes expose different upstream sets |
| `key_uuid` | Currently scopes entries per API key |
| `method` | `tools/list` must never answer `prompts/list` |
| `servers_signature` | Alias, transport, endpoint (or stdio command line) **and a SHA-256 of the static `headers` / `env`** |

The credential digest is what makes a secret rotation invalidate the entry: same alias, same
URL, a token for a different scope or tenant produces a different key, so the previous
credential's tool list is not served for the rest of the TTL. Values are hashed, never
interpolated, so no secret reaches a cache key or a log line.

---

## Telemetry

| Signal | Where | Value on a cache hit |
|--------|-------|---------------------|
| `rb.gateway.mcp_cache_hit` | `mcp_{tools,prompts,resources}_list.task` span | `true` (absent = miss) |
| `rb.gateway.mcp_result_count` | same span | list length, so size is comparable across hits and misses |
| `rb.gateway.operation_category` | same span | `cache` instead of `invocation` |
| `mcp_upstream_total` / `mcp_upstream_failed` | same span | **not set** — no upstream was contacted, so the counts would be fiction |
| `CACHE_HIT` event | events pipeline → usage view, alert rules | one per hit, under the caller's identity, `cost: 0.0` |
| `cache_hit_counter` | metrics | `+1`, tagged `route_name` |

The category is corrected on the list task's own span rather than the root span:
`ensure_endpoint_category` deliberately resets the root workflow span to `endpoint` in a
`finally`, and `OtelTracesDAO.get_category_latencies` groups **every** span by category, not
just root ones — so the phase categories are per-child-span by design.

---

## Other Changes

- `mcp_proxy/list_cache.py` **(NEW)** — `McpListCache`, `servers_signature`, the cacheability
  guards, `DEFAULT_LIST_TTL_SECONDS`, and `LIST_RESULT_KEY`
- `caching/gateway_cache.py` — adds `generate_mcp_list_cache_key` alongside the existing
  chat / embedding / transcription key builders
- `routes/mcp_route.py` — builds the cache after authorization and hands it to `dispatch()`;
  after authorization, so an unknown route or unbound key never consumes cache work
- `services/mcp_service.py` — `dispatch()` takes an optional `list_cache`; adds `_cached_list`,
  `_store_list` and `_record_cache_hit`; the three list methods consult and populate the cache
- `tests/mcp/test_list_cache.py` **(NEW)** — 33 cases: cacheability guards, key scoping and
  invalidation, credential rotation, TTL fallback, malformed-entry handling, hit reporting
- `tests/mcp/test_mcp_service.py` — end-to-end hit/miss, per-method isolation, degraded and
  fully-failed fan-outs never cached, span attributes, event emission
- `tests/mcp/test_span_attributes.py` — root/task span category assertions against a real
  in-memory exporter
- `tests/routes/test_mcp_route.py` — endpoint wiring, and that `tools/call` is never cached


## Linked Issue
Closes AG-928

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor/Chore
- [ ] Performance
- [ ] Security

## Checklist
- [ ] Tests pass (locally/CI)
- [ ] Lint/build pass
- [ ] No secrets committed
- [ ] Docs updated (if needed)
