### PR TITLE
feat(routes): duration limiting on detail tabs, cURL parameters modal

### DIFF
--- a/ui/src/components/modals/route-analytics/columns/limits.jsx
+++ b/ui/src/components/modals/route-analytics/columns/limits.jsx
@@ -9,8 +9,9 @@ function Limits({ metrics, configuration }) {
   const rateLimitTriggered = metrics?.rateLimitTriggered;
   const tokenInputLimitTriggered = metrics?.tokenInputLimitTriggered;
   const tokenOutputLimitTriggered = metrics?.tokenOutputLimitTriggered;
+  const durationLimitTriggered = metrics?.durationLimitTriggered;
 
-  if (rateLimitTriggered === undefined && tokenInputLimitTriggered === undefined && tokenOutputLimitTriggered === undefined) {
+  if (rateLimitTriggered === undefined && tokenInputLimitTriggered === undefined && tokenOutputLimitTriggered === undefined && durationLimitTriggered === undefined) {
     return (
       <Button disabled shape="circle">
         <Lucide icon={SlidersHorizontal} />
@@ -18,7 +19,7 @@ function Limits({ metrics, configuration }) {
     );
   }
 
-  const hasTriggered = rateLimitTriggered > 0 || tokenInputLimitTriggered > 0 || tokenOutputLimitTriggered > 0;
+  const hasTriggered = rateLimitTriggered > 0 || tokenInputLimitTriggered > 0 || tokenOutputLimitTriggered > 0 || durationLimitTriggered > 0;
   const btnType = hasTriggered ? { type: 'primary' } : { type: 'primary-light' };
 
   return (
@@ -34,10 +35,15 @@ function PopoverContent({ configuration, metrics }) {
   const rateLimiting = configuration?.rateLimiting;
   const tokenLimitingInput = configuration?.tokenLimiting?.input;
   const tokenLimitingOutput = configuration?.tokenLimiting?.output;
+  const durationLimiting = configuration?.durationLimiting;
+
+  const supportsTokenLimiting = !!configuration?.chatModels?.length || !!configuration?.embeddingModels?.length;
+  const supportsDurationLimiting = !!configuration?.transcriptionModels?.length;
 
   const rate = numberFormatterInt(metrics.rateLimitTriggered) ?? '--';
   const tokenIn = numberFormatterInt(metrics.tokenInputLimitTriggered) ?? '--';
   const tokenOut = numberFormatterInt(metrics.tokenOutputLimitTriggered) ?? '--';
+  const duration = numberFormatterInt(metrics.durationLimitTriggered) ?? '--';
 
   const rateLimitingalgorithm = rateLimiting?.algorithm ?? '--';
   const rateLimitingwindowSize = rateLimiting?.windowSize ?? '--';
@@ -51,24 +57,24 @@ function PopoverContent({ configuration, metrics }) {
   const tokenLimitingOutputWindowSize = tokenLimitingOutput?.windowSize ?? '--';
   const tokenLimitingOutputMaxTokens = numberFormatterInt(tokenLimitingOutput?.maxTokens) ?? '--';
 
-  return (
-    <div className="flex flex-col">
-      <PopoverRow label="Rate:" value={rate} />
+  const durationLimitingAlgorithm = durationLimiting?.algorithm ?? '--';
+  const durationLimitingWindowSize = durationLimiting?.windowSize ?? '--';
+  const durationLimitingMaxDurationSeconds = numberFormatterInt(durationLimiting?.maxDurationSeconds) ?? '--';
 
+  const tokenTriggerRows = supportsTokenLimiting ? (
+    <>
       <PopoverRow label="Token in:" value={tokenIn} />
 
       <PopoverRow label="Token out:" value={tokenOut} />
+    </>
+  ) : false;
 
-      <Divider style={{ margin: '.5rem' }} />
+  const durationTriggerRow = supportsDurationLimiting
+    ? <PopoverRow label="Duration:" value={duration} />
+    : false;
 
-      <strong>Rate Limiting</strong>
-
-      <PopoverRow label="Algorithm:" value={rateLimitingalgorithm} />
-
-      <PopoverRow label="Window size:" value={rateLimitingwindowSize} />
-
-      <PopoverRow label="Max requests:" value={rateLimitingmaxRequests} />
-
+  const tokenLimitingSections = supportsTokenLimiting ? (
+    <>
       <Divider style={{ margin: '.5rem' }} />
 
       <strong>Token Limiting Input</strong>
@@ -88,6 +94,44 @@ function PopoverContent({ configuration, metrics }) {
       <PopoverRow label="Window size:" value={tokenLimitingOutputWindowSize} />
 
       <PopoverRow label="Max tokens:" value={tokenLimitingOutputMaxTokens} />
+    </>
+  ) : false;
+
+  const durationLimitingSection = supportsDurationLimiting ? (
+    <>
+      <Divider style={{ margin: '.5rem' }} />
+
+      <strong>Duration Limiting</strong>
+
+      <PopoverRow label="Algorithm:" value={durationLimitingAlgorithm} />
+
+      <PopoverRow label="Window size:" value={durationLimitingWindowSize} />
+
+      <PopoverRow label="Max duration (s):" value={durationLimitingMaxDurationSeconds} />
+    </>
+  ) : false;
+
+  return (
+    <div className="flex flex-col">
+      <PopoverRow label="Rate:" value={rate} />
+
+      {tokenTriggerRows}
+
+      {durationTriggerRow}
+
+      <Divider style={{ margin: '.5rem' }} />
+
+      <strong>Rate Limiting</strong>
+
+      <PopoverRow label="Algorithm:" value={rateLimitingalgorithm} />
+
+      <PopoverRow label="Window size:" value={rateLimitingwindowSize} />
+
+      <PopoverRow label="Max requests:" value={rateLimitingmaxRequests} />
+
+      {tokenLimitingSections}
+
+      {durationLimitingSection}
     </div>
   );
 }

--- a/ui/src/components/modals/route-analytics/columns/models.jsx
+++ b/ui/src/components/modals/route-analytics/columns/models.jsx
@@ -3,10 +3,12 @@ import { Divider, Popover } from '@radicalbit/radicalbit-design-system';
 function Models({ configuration }) {
   const chatModels = configuration?.chatModels || [];
   const embeddingModels = configuration?.embeddingModels || [];
+  const transcriptionModels = configuration?.transcriptionModels || [];
 
   const chatModelsCount = chatModels.length;
   const embeddingModelsCount = embeddingModels.length;
-  const count = chatModelsCount + embeddingModelsCount;
+  const transcriptionModelsCount = transcriptionModels.length;
+  const count = chatModelsCount + embeddingModelsCount + transcriptionModelsCount;
 
   if (count === 0) {
     return '--';
@@ -34,6 +36,20 @@ function Models({ configuration }) {
 
           <div className="flex flex-col">
             {embeddingModels.map(({ model }) => (
+              <div>{model}</div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(chatModelsCount > 0 || embeddingModelsCount > 0) && transcriptionModelsCount > 0 && <Divider style={{ margin: 0 }} />}
+
+      {transcriptionModelsCount > 0 && (
+        <div className="flex flex-col justify-center w-full gap-1">
+          <strong>Transcription models</strong>
+
+          <div className="flex flex-col">
+            {transcriptionModels.map(({ model }) => (
               <div>{model}</div>
             ))}
           </div>

--- a/ui/src/container/pages/routes/detail/body/configurations/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/configurations/index.jsx
@@ -11,6 +11,7 @@ import { useParams } from 'react-router-dom';
 import {
   AdvancedRouting,
   Cache,
+  DurationLimiting,
   Fallback,
   Guardrails,
   Models,
@@ -18,6 +19,7 @@ import {
   TokenLimit,
   useGetAdvancedRoutingItem,
   useGetCacheItem,
+  useGetDurationLimitingItem,
   useGetFallbackItem,
   useGetGuardrailsItem,
   useGetModelItem,
@@ -33,6 +35,7 @@ function Configurations() {
   const guardrailItem = useGetGuardrailsItem();
   const rateLimitingItem = useGetRateLimitingItem();
   const tokenLimitingItem = useGetTokenLimitingItem();
+  const durationLimitingItem = useGetDurationLimitingItem();
   const cacheItem = useGetCacheItem();
   const advancedRoutingItem = useGetAdvancedRoutingItem();
 
@@ -88,6 +91,11 @@ function Configurations() {
       key: 6,
       children: <TokenLimit />,
       ...tokenLimitingItem,
+    },
+    {
+      key: 7,
+      children: <DurationLimiting />,
+      ...durationLimitingItem,
     },
   ];
 

--- a/ui/src/container/pages/routes/detail/body/configurations/items.jsx
+++ b/ui/src/container/pages/routes/detail/body/configurations/items.jsx
@@ -5,7 +5,7 @@ import {
 } from '@radicalbit/radicalbit-design-system';
 import isEmpty from 'lodash/isEmpty';
 import {
-  Bot, CircleCheck, CornerDownRight, Route, Shield, TableColumnsSplit, Timer,
+  Bot, CircleCheck, CornerDownRight, Hourglass, Route, Shield, TableColumnsSplit, Timer,
 } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 
@@ -16,8 +16,9 @@ export function useGetModelItem() {
   const { data } = useGetRouteByNameWithRange(name);
   const chatModels = data?.configuration?.chatModels;
   const embeddingModels = data?.configuration?.embeddingModels;
+  const transcriptionModels = data?.configuration?.transcriptionModels;
 
-  if (isEmpty(chatModels) && isEmpty(embeddingModels)) {
+  if (isEmpty(chatModels) && isEmpty(embeddingModels) && isEmpty(transcriptionModels)) {
     return {
       collapsible: 'disabled',
       showArrow: false,
@@ -50,8 +51,9 @@ export function Models() {
   const { data } = useGetRouteByNameWithRange(name);
   const chatModels = data?.configuration?.chatModels || [];
   const embeddingModels = data?.configuration?.embeddingModels || [];
+  const transcriptionModels = data?.configuration?.transcriptionModels || [];
 
-  return <Json data={{ chatModels, embeddingModels }} />;
+  return <Json data={{ chatModels, embeddingModels, transcriptionModels }} />;
 }
 
 // *** Fallback ***
@@ -224,13 +226,19 @@ export function useGetTokenLimitingItem() {
   const tokenLimiting = data?.configuration?.tokenLimiting;
   const tokenInputLimitTriggered = data?.metrics?.tokenInputLimitTriggered;
   const tokenOutputLimitTriggered = data?.metrics?.tokenOutputLimitTriggered;
+  const chatModels = data?.configuration?.chatModels;
+  const embeddingModels = data?.configuration?.embeddingModels;
 
   if (isEmpty(tokenLimiting)) {
+    const tooltip = isEmpty(chatModels) && isEmpty(embeddingModels)
+      ? 'Requires a chat or embedding model on this route'
+      : 'Configure this section into your configuration file';
+
     return {
       collapsible: 'disabled',
       showArrow: false,
       label: (
-        <Popover content="Configure this section into your configuration file" placement="top">
+        <Popover content={tooltip} placement="top">
           <div className="flex justify-start items-center gap-4">
             <Button disabled shape="circle" type="secondary-light"><Lucide icon={TableColumnsSplit} /></Button>
 
@@ -268,6 +276,64 @@ export function TokenLimit() {
   const tokenLimiting = data?.configuration?.tokenLimiting;
 
   return <Json data={tokenLimiting} />;
+}
+
+// *** DurationLimiting ***
+export function useGetDurationLimitingItem() {
+  const { name } = useParams();
+
+  const { data } = useGetRouteByNameWithRange(name);
+  const durationLimiting = data?.configuration?.durationLimiting;
+  const transcriptionModels = data?.configuration?.transcriptionModels;
+
+  if (isEmpty(durationLimiting)) {
+    const tooltip = isEmpty(transcriptionModels)
+      ? 'Requires a transcription model on this route'
+      : 'Configure this section into your configuration file';
+
+    return {
+      collapsible: 'disabled',
+      showArrow: false,
+      label: (
+        <Popover content={tooltip} placement="top">
+          <div className="flex justify-start items-center gap-4">
+            <Button disabled shape="circle"><Lucide icon={Hourglass} /></Button>
+
+            <div>Duration Limiting</div>
+          </div>
+        </Popover>
+      ),
+    };
+  }
+
+  const durationLimitTriggered = data?.metrics?.durationLimitTriggered;
+  const type = (function getType() {
+    if (durationLimitTriggered > 0) {
+      return { type: 'primary' };
+    } if (!durationLimitTriggered) {
+      return { type: 'primary-light' };
+    }
+    return { disabled: true };
+  }());
+
+  return {
+    label: (
+      <div className="flex justify-start items-center gap-4">
+        <Button shape="circle" {...type}><Lucide icon={Hourglass} /></Button>
+
+        <div>Duration Limiting</div>
+      </div>
+    ),
+  };
+}
+
+export function DurationLimiting() {
+  const { name } = useParams();
+
+  const { data } = useGetRouteByNameWithRange(name);
+  const durationLimiting = data?.configuration?.durationLimiting;
+
+  return <Json data={durationLimiting} />;
 }
 
 // *** Caching ***

--- a/ui/src/container/pages/routes/detail/body/curl/chat/01-inner.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/chat/01-inner.jsx
@@ -1,0 +1,83 @@
+import CodeBlock from '@Components/code-block';
+import CodeBlockRawText from '@Components/code-block/raw-text';
+import Lucide from '@Components/lucide';
+import { useGetRouteByNameWithRange } from '@State/routes/vertical-hooks';
+import { useFormbitContext } from '@radicalbit/formbit';
+import {
+  Board, Button, FormField, SectionTitle,
+} from '@radicalbit/radicalbit-design-system';
+import { KeyRound } from 'lucide-react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { CHAT_CURL } from '../commands';
+import useCurlParams from '../use-curl-params';
+import Modal from './modal';
+
+function Inner() {
+  const { name } = useParams();
+
+  const { data: route } = useGetRouteByNameWithRange(name);
+  const chatModels = route?.configuration?.chatModels;
+
+  if (!chatModels?.length) {
+    return false;
+  }
+
+  return (
+    <Board
+      borderType="none"
+      header={<SectionTitle size="small" title="Chat model cURL" />}
+      main={<Content />}
+      size="small"
+    />
+  );
+}
+
+function Content() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { projectName, routeName } = useCurlParams();
+
+  const { form } = useFormbitContext();
+  const apiKey = form?.apiKey;
+
+  const code = CHAT_CURL(projectName, routeName, apiKey);
+
+  const handleOnOpenModal = () => { setIsModalOpen(true); };
+  const handleOnCloseModal = () => { setIsModalOpen(false); };
+
+  return (
+    <>
+      <CodeBlock
+        actions={(
+          <Button onClick={handleOnOpenModal} type="secondary">
+            <Lucide icon={KeyRound} />
+
+            <div>Fill credential</div>
+          </Button>
+        )}
+        code={code}
+        hasCopyToClipboard
+      >
+        <CodeBlockRawText text={code} />
+      </CodeBlock>
+
+      <BoardError />
+
+      <Modal onClose={handleOnCloseModal} open={isModalOpen} />
+    </>
+  );
+}
+
+function BoardError() {
+  const { error } = useFormbitContext();
+  const message = error('apiKey');
+
+  if (!message) {
+    return false;
+  }
+
+  return <FormField message={message} />;
+}
+
+export default Inner;

--- a/ui/src/container/pages/routes/detail/body/curl/chat/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/chat/index.jsx
@@ -1,0 +1,13 @@
+import { FormbitContextProvider } from '@radicalbit/formbit';
+import Inner from './01-inner';
+import { initialValues, schema } from './schema';
+
+function ChatCurl() {
+  return (
+    <FormbitContextProvider initialValues={initialValues} schema={schema}>
+      <Inner />
+    </FormbitContextProvider>
+  );
+}
+
+export default ChatCurl;

--- a/ui/src/container/pages/routes/detail/body/curl/chat/modal/01-form-fields.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/chat/modal/01-form-fields.jsx
@@ -1,0 +1,33 @@
+import Lucide from '@Components/lucide';
+import useAutoFocus from '@Hooks/use-auto-focus';
+import { useFormbitContext } from '@radicalbit/formbit';
+import { FormField, Input } from '@radicalbit/radicalbit-design-system';
+import { KeyRound } from 'lucide-react';
+import { useRef } from 'react';
+
+export function ApiKey() {
+  const ref = useRef();
+
+  const { error, form, write } = useFormbitContext();
+  const apiKey = form?.apiKey;
+
+  const handleOnChange = ({ target: { value } }) => { write('apiKey', value); };
+
+  useAutoFocus(ref);
+
+  return (
+    <FormField
+      label="Credential"
+      message={error('apiKey')}
+      required
+    >
+      <Input
+        onChange={handleOnChange}
+        placeholder="Paste your credential"
+        prefix={<Lucide icon={KeyRound} />}
+        ref={ref}
+        value={apiKey}
+      />
+    </FormField>
+  );
+}

--- a/ui/src/container/pages/routes/detail/body/curl/chat/modal/02-actions.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/chat/modal/02-actions.jsx
@@ -1,0 +1,22 @@
+import Lucide from '@Components/lucide';
+import { Button } from '@radicalbit/radicalbit-design-system';
+import { Copy } from 'lucide-react';
+import useHandleOnSubmit from './use-handle-on-submit';
+
+function Actions({ onClose }) {
+  const { handleOnSubmit, isSubmitDisabled } = useHandleOnSubmit(onClose);
+
+  return (
+    <Button
+      disabled={isSubmitDisabled}
+      onClick={handleOnSubmit}
+      type="primary"
+    >
+      <Lucide icon={Copy} />
+
+      <div>Copy</div>
+    </Button>
+  );
+}
+
+export default Actions;

--- a/ui/src/container/pages/routes/detail/body/curl/chat/modal/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/chat/modal/index.jsx
@@ -1,0 +1,53 @@
+import CodeBlock from '@Components/code-block';
+import CodeBlockRawText from '@Components/code-block/raw-text';
+import { useFormbitContext } from '@radicalbit/formbit';
+import { RbitModal, SectionTitle } from '@radicalbit/radicalbit-design-system';
+import { CHAT_CURL } from '../../commands';
+import useCurlParams from '../../use-curl-params';
+import Actions from './02-actions';
+import { ApiKey } from './01-form-fields';
+
+function Modal({ onClose, open }) {
+  if (!open) {
+    return false;
+  }
+
+  return (
+    <RbitModal
+      actions={<Actions onClose={onClose} />}
+      closable
+      header={(
+        <SectionTitle
+          subtitle="Paste the credential you generated in the Credentials section. The request below updates as you type."
+          title="Fill credential"
+        />
+      )}
+      onCancel={onClose}
+      open
+      width={700}
+    >
+      <div className="flex flex-col gap-4">
+        <ApiKey />
+
+        <Preview />
+      </div>
+    </RbitModal>
+  );
+}
+
+function Preview() {
+  const { projectName, routeName } = useCurlParams();
+
+  const { form } = useFormbitContext();
+  const apiKey = form?.apiKey;
+
+  const code = CHAT_CURL(projectName, routeName, apiKey);
+
+  return (
+    <CodeBlock code={code}>
+      <CodeBlockRawText text={code} />
+    </CodeBlock>
+  );
+}
+
+export default Modal;

--- a/ui/src/container/pages/routes/detail/body/curl/chat/modal/use-handle-on-submit.js
+++ b/ui/src/container/pages/routes/detail/body/curl/chat/modal/use-handle-on-submit.js
@@ -1,0 +1,21 @@
+import { useFormbitContext } from '@radicalbit/formbit';
+import { CHAT_CURL } from '../../commands';
+import useCurlParams from '../../use-curl-params';
+
+export default (onClose) => {
+  const { projectName, routeName } = useCurlParams();
+
+  const { isFormInvalid, submitForm } = useFormbitContext();
+
+  const isSubmitDisabled = isFormInvalid();
+
+  const handleOnSubmit = () => {
+    submitForm(async ({ form: formData }) => {
+      await navigator.clipboard.writeText(CHAT_CURL(projectName, routeName, formData.apiKey));
+
+      onClose();
+    });
+  };
+
+  return { handleOnSubmit, isSubmitDisabled };
+};

--- a/ui/src/container/pages/routes/detail/body/curl/chat/schema.js
+++ b/ui/src/container/pages/routes/detail/body/curl/chat/schema.js
@@ -1,0 +1,10 @@
+import * as yup from 'yup';
+
+const schema = yup.object().shape({
+  apiKey: yup.string()
+    .required('Paste a credential to complete the request'),
+});
+
+const initialValues = { apiKey: '' };
+
+export { initialValues, schema };

--- a/ui/src/container/pages/routes/detail/body/curl/commands.js
+++ b/ui/src/container/pages/routes/detail/body/curl/commands.js
@@ -1,0 +1,18 @@
+import { GATEWAY_BASE_URL } from '@Api/config';
+
+const CHAT_CURL = (projectName, routeName, apiKey) => `curl ${GATEWAY_BASE_URL}/v1/chat/completions \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer ${apiKey || '<your-secret-key>'}" \\
+  -d '{
+    "model": "${projectName}/${routeName}",
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'`;
+
+const TRANSCRIPTION_CURL = (projectName, routeName, apiKey, audioPath) => `curl ${GATEWAY_BASE_URL}/v1/audio/transcriptions \\
+  -H "Authorization: Bearer ${apiKey || '<your-secret-key>'}" \\
+  -F "model=${projectName}/${routeName}" \\
+  -F "file=@${audioPath || '<path-to-your-audio-file>'}"`;
+
+export { CHAT_CURL, TRANSCRIPTION_CURL };

--- a/ui/src/container/pages/routes/detail/body/curl/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/index.jsx
@@ -1,29 +1,10 @@
-import { GATEWAY_BASE_URL } from '@Api/config';
-import CodeBlock from '@Components/code-block';
-import CodeBlockRawText from '@Components/code-block/raw-text';
 import SomethingWentWrong from '@Components/error-page/something-went-wrong';
-import Lucide from '@Components/lucide';
 import { useGetProjectQuery } from '@State/projects/api';
 import { useGetRouteByNameWithRange } from '@State/routes/vertical-hooks';
-import { Board, Input, SectionTitle, Skeleton, Void } from '@radicalbit/radicalbit-design-system';
-import { Key } from 'lucide-react';
-import { useState } from 'react';
+import { Board, Skeleton, Void } from '@radicalbit/radicalbit-design-system';
 import { useParams, useSearchParams } from 'react-router-dom';
-
-const CURL_COMMAND = (projectName, routeName, apiKey) => `curl ${GATEWAY_BASE_URL}/v1/chat/completions \
--H "Content-Type: application/json" \
--H "Authorization: Bearer ${apiKey || '<your-secret-key>'}" \
--d '{
-  "model": "${projectName}/${routeName}",
-  "messages": [
-    {"role": "user", "content": "Hello"}
-  ]
-}'`;
-
-const CURL_COMMAND_TRANSCRIPTION = (projectName, routeName, apiKey) => `curl ${GATEWAY_BASE_URL}/v1/audio/transcriptions \
--H "Authorization: Bearer ${apiKey || '<your-secret-key>'}" \
--F "model=${projectName}/${routeName}" \
--F "file=@/path/to/audio.mp3"`;
+import ChatCurl from './chat';
+import TranscriptionCurl from './transcription';
 
 function Curl() {
   const { name } = useParams();
@@ -73,94 +54,6 @@ function IsEmpty() {
           size="small"
           title="No cURL available"
         />
-      )}
-      size="small"
-    />
-  );
-}
-
-function ChatCurl() {
-  const { name } = useParams();
-  const [apiKey, setApiKey] = useState('');
-
-  const [searchParams] = useSearchParams();
-  const projectUuid = searchParams.get('projectUuid');
-
-  const { data } = useGetProjectQuery(projectUuid, { skip: !projectUuid });
-  const projectName = data?.name;
-
-  const { data: route } = useGetRouteByNameWithRange(name);
-  const chatModels = route?.configuration?.chatModels;
-
-  const handleOnChangeApiKey = ({ target: { value } }) => { setApiKey(value); };
-
-  if (!chatModels?.length) {
-    return false;
-  }
-
-  return (
-    <Board
-      borderType="none"
-      header={<SectionTitle title="Chat model cURL" />}
-      main={(
-        <CodeBlock
-          actions={(
-            <Input
-              onChange={handleOnChangeApiKey}
-              placeholder="Paste your credential"
-              prefix={<Lucide icon={Key} />}
-              value={apiKey}
-            />
-          )}
-          code={CURL_COMMAND(projectName, name, apiKey)}
-          hasCopyToClipboard
-        >
-          <CodeBlockRawText text={CURL_COMMAND(projectName, name, apiKey)} />
-        </CodeBlock>
-      )}
-      size="small"
-    />
-  );
-}
-
-function TranscriptionCurl() {
-  const { name } = useParams();
-  const [apiKey, setApiKey] = useState('');
-
-  const [searchParams] = useSearchParams();
-  const projectUuid = searchParams.get('projectUuid');
-
-  const { data } = useGetProjectQuery(projectUuid, { skip: !projectUuid });
-  const projectName = data?.name;
-
-  const { data: route } = useGetRouteByNameWithRange(name);
-  const transcriptionModels = route?.configuration?.transcriptionModels;
-
-  const handleOnChangeApiKey = ({ target: { value } }) => { setApiKey(value); };
-
-  if (!transcriptionModels?.length) {
-    return false;
-  }
-
-  return (
-    <Board
-      borderType="none"
-      header={<SectionTitle title="Transcription model cURL" />}
-      main={(
-        <CodeBlock
-          actions={(
-            <Input
-              onChange={handleOnChangeApiKey}
-              placeholder="Paste your credential"
-              prefix={<Lucide icon={Key} />}
-              value={apiKey}
-            />
-          )}
-          code={CURL_COMMAND_TRANSCRIPTION(projectName, name, apiKey)}
-          hasCopyToClipboard
-        >
-          <CodeBlockRawText text={CURL_COMMAND_TRANSCRIPTION(projectName, name, apiKey)} />
-        </CodeBlock>
       )}
       size="small"
     />

--- a/ui/src/container/pages/routes/detail/body/curl/transcription/01-inner.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/transcription/01-inner.jsx
@@ -1,0 +1,84 @@
+import CodeBlock from '@Components/code-block';
+import CodeBlockRawText from '@Components/code-block/raw-text';
+import Lucide from '@Components/lucide';
+import { useGetRouteByNameWithRange } from '@State/routes/vertical-hooks';
+import { useFormbitContext } from '@radicalbit/formbit';
+import {
+  Board, Button, FormField, SectionTitle,
+} from '@radicalbit/radicalbit-design-system';
+import { SlidersHorizontal } from 'lucide-react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { TRANSCRIPTION_CURL } from '../commands';
+import useCurlParams from '../use-curl-params';
+import Modal from './modal';
+
+function Inner() {
+  const { name } = useParams();
+
+  const { data: route } = useGetRouteByNameWithRange(name);
+  const transcriptionModels = route?.configuration?.transcriptionModels;
+
+  if (!transcriptionModels?.length) {
+    return false;
+  }
+
+  return (
+    <Board
+      borderType="none"
+      header={<SectionTitle size="small" title="Transcription model cURL" />}
+      main={<Content />}
+      size="small"
+    />
+  );
+}
+
+function Content() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { projectName, routeName } = useCurlParams();
+
+  const { form } = useFormbitContext();
+  const apiKey = form?.apiKey;
+  const audioPath = form?.audioPath;
+
+  const code = TRANSCRIPTION_CURL(projectName, routeName, apiKey, audioPath);
+
+  const handleOnOpenModal = () => { setIsModalOpen(true); };
+  const handleOnCloseModal = () => { setIsModalOpen(false); };
+
+  return (
+    <>
+      <CodeBlock
+        actions={(
+          <Button onClick={handleOnOpenModal} type="secondary">
+            <Lucide icon={SlidersHorizontal} />
+
+            <div>Fill parameters</div>
+          </Button>
+        )}
+        code={code}
+        hasCopyToClipboard
+      >
+        <CodeBlockRawText text={code} />
+      </CodeBlock>
+
+      <BoardError />
+
+      <Modal onClose={handleOnCloseModal} open={isModalOpen} />
+    </>
+  );
+}
+
+function BoardError() {
+  const { error } = useFormbitContext();
+  const message = error('apiKey') || error('audioPath');
+
+  if (!message) {
+    return false;
+  }
+
+  return <FormField message={message} />;
+}
+
+export default Inner;

--- a/ui/src/container/pages/routes/detail/body/curl/transcription/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/transcription/index.jsx
@@ -1,0 +1,13 @@
+import { FormbitContextProvider } from '@radicalbit/formbit';
+import Inner from './01-inner';
+import { initialValues, schema } from './schema';
+
+function TranscriptionCurl() {
+  return (
+    <FormbitContextProvider initialValues={initialValues} schema={schema}>
+      <Inner />
+    </FormbitContextProvider>
+  );
+}
+
+export default TranscriptionCurl;

--- a/ui/src/container/pages/routes/detail/body/curl/transcription/modal/01-form-fields.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/transcription/modal/01-form-fields.jsx
@@ -1,0 +1,55 @@
+import Lucide from '@Components/lucide';
+import useAutoFocus from '@Hooks/use-auto-focus';
+import { useFormbitContext } from '@radicalbit/formbit';
+import { FormField, Input } from '@radicalbit/radicalbit-design-system';
+import { FileAudio, KeyRound } from 'lucide-react';
+import { useRef } from 'react';
+
+export function ApiKey() {
+  const ref = useRef();
+
+  const { error, form, write } = useFormbitContext();
+  const apiKey = form?.apiKey;
+
+  const handleOnChange = ({ target: { value } }) => { write('apiKey', value); };
+
+  useAutoFocus(ref);
+
+  return (
+    <FormField
+      label="Credential"
+      message={error('apiKey')}
+      required
+    >
+      <Input
+        onChange={handleOnChange}
+        placeholder="Paste your credential"
+        prefix={<Lucide icon={KeyRound} />}
+        ref={ref}
+        value={apiKey}
+      />
+    </FormField>
+  );
+}
+
+export function AudioPath() {
+  const { error, form, write } = useFormbitContext();
+  const audioPath = form?.audioPath;
+
+  const handleOnChange = ({ target: { value } }) => { write('audioPath', value); };
+
+  return (
+    <FormField
+      label="Audio file path"
+      message={error('audioPath')}
+      required
+    >
+      <Input
+        onChange={handleOnChange}
+        placeholder="/Users/me/audio.mp3"
+        prefix={<Lucide icon={FileAudio} />}
+        value={audioPath}
+      />
+    </FormField>
+  );
+}

--- a/ui/src/container/pages/routes/detail/body/curl/transcription/modal/02-actions.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/transcription/modal/02-actions.jsx
@@ -1,0 +1,22 @@
+import Lucide from '@Components/lucide';
+import { Button } from '@radicalbit/radicalbit-design-system';
+import { Copy } from 'lucide-react';
+import useHandleOnSubmit from './use-handle-on-submit';
+
+function Actions({ onClose }) {
+  const { handleOnSubmit, isSubmitDisabled } = useHandleOnSubmit(onClose);
+
+  return (
+    <Button
+      disabled={isSubmitDisabled}
+      onClick={handleOnSubmit}
+      type="primary"
+    >
+      <Lucide icon={Copy} />
+
+      <div>Copy</div>
+    </Button>
+  );
+}
+
+export default Actions;

--- a/ui/src/container/pages/routes/detail/body/curl/transcription/modal/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/curl/transcription/modal/index.jsx
@@ -1,0 +1,56 @@
+import CodeBlock from '@Components/code-block';
+import CodeBlockRawText from '@Components/code-block/raw-text';
+import { useFormbitContext } from '@radicalbit/formbit';
+import { RbitModal, SectionTitle } from '@radicalbit/radicalbit-design-system';
+import { TRANSCRIPTION_CURL } from '../../commands';
+import useCurlParams from '../../use-curl-params';
+import { ApiKey, AudioPath } from './01-form-fields';
+import Actions from './02-actions';
+
+function Modal({ onClose, open }) {
+  if (!open) {
+    return false;
+  }
+
+  return (
+    <RbitModal
+      actions={<Actions onClose={onClose} />}
+      closable
+      header={(
+        <SectionTitle
+          subtitle="Paste your credential and the absolute path of the audio file to transcribe. The request below updates as you type."
+          title="Fill parameters"
+        />
+      )}
+      onCancel={onClose}
+      open
+      width={700}
+    >
+      <div className="flex flex-col gap-4">
+        <ApiKey />
+
+        <AudioPath />
+
+        <Preview />
+      </div>
+    </RbitModal>
+  );
+}
+
+function Preview() {
+  const { projectName, routeName } = useCurlParams();
+
+  const { form } = useFormbitContext();
+  const apiKey = form?.apiKey;
+  const audioPath = form?.audioPath;
+
+  const code = TRANSCRIPTION_CURL(projectName, routeName, apiKey, audioPath);
+
+  return (
+    <CodeBlock code={code}>
+      <CodeBlockRawText text={code} />
+    </CodeBlock>
+  );
+}
+
+export default Modal;

--- a/ui/src/container/pages/routes/detail/body/curl/transcription/modal/use-handle-on-submit.js
+++ b/ui/src/container/pages/routes/detail/body/curl/transcription/modal/use-handle-on-submit.js
@@ -1,0 +1,23 @@
+import { useFormbitContext } from '@radicalbit/formbit';
+import { TRANSCRIPTION_CURL } from '../../commands';
+import useCurlParams from '../../use-curl-params';
+
+export default (onClose) => {
+  const { projectName, routeName } = useCurlParams();
+
+  const { isFormInvalid, submitForm } = useFormbitContext();
+
+  const isSubmitDisabled = isFormInvalid();
+
+  const handleOnSubmit = () => {
+    submitForm(async ({ form: formData }) => {
+      await navigator.clipboard.writeText(
+        TRANSCRIPTION_CURL(projectName, routeName, formData.apiKey, formData.audioPath),
+      );
+
+      onClose();
+    });
+  };
+
+  return { handleOnSubmit, isSubmitDisabled };
+};

--- a/ui/src/container/pages/routes/detail/body/curl/transcription/schema.js
+++ b/ui/src/container/pages/routes/detail/body/curl/transcription/schema.js
@@ -1,0 +1,12 @@
+import * as yup from 'yup';
+
+const schema = yup.object().shape({
+  apiKey: yup.string()
+    .required('Paste a credential to complete the request'),
+  audioPath: yup.string()
+    .required('Add the absolute path of the audio file to transcribe'),
+});
+
+const initialValues = { apiKey: '', audioPath: '' };
+
+export { initialValues, schema };

--- a/ui/src/container/pages/routes/detail/body/curl/use-curl-params.js
+++ b/ui/src/container/pages/routes/detail/body/curl/use-curl-params.js
@@ -1,0 +1,16 @@
+import { useGetProjectQuery } from '@State/projects/api';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+const useCurlParams = () => {
+  const { name } = useParams();
+
+  const [searchParams] = useSearchParams();
+  const projectUuid = searchParams.get('projectUuid');
+
+  const { data } = useGetProjectQuery(projectUuid, { skip: !projectUuid });
+  const projectName = data?.name;
+
+  return { projectName, routeName: name };
+};
+
+export default useCurlParams;

--- a/ui/src/container/pages/routes/detail/body/events/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/events/index.jsx
@@ -6,6 +6,8 @@ import {
 import { useParams } from 'react-router-dom';
 import Caching from './items/caching';
 import useGetCachingItem from './items/caching/use-get-caching-items';
+import DurationLimiting from './items/duration-limiting';
+import useGetDurationLimitingItem from './items/duration-limiting/use-get-duration-limiting-items';
 import Fallbacks from './items/fallbacks';
 import useGetFallbacksItem from './items/fallbacks/use-get-fallbacks-items';
 import Guardrails from './items/guardrails';
@@ -25,6 +27,7 @@ function Events() {
   const guardrailItem = useGetGuardrailsItem();
   const rateLimitingItem = useGetRateLimitingItem();
   const tokenLimitingItem = useGetTokensLimitingItem();
+  const durationLimitingItem = useGetDurationLimitingItem();
 
   if (isLoading) {
     return <IsLoading />;
@@ -64,7 +67,12 @@ function Events() {
       children: <TokensLimiting />,
       ...tokenLimitingItem,
     },
-  ];
+    {
+      key: 6,
+      children: <DurationLimiting />,
+      ...durationLimitingItem,
+    },
+  ].filter((item) => !item.hidden);
 
   return (
     <Collapse

--- a/ui/src/container/pages/routes/detail/body/events/items/duration-limiting/columns.jsx
+++ b/ui/src/container/pages/routes/detail/body/events/items/duration-limiting/columns.jsx
@@ -1,0 +1,20 @@
+import dateFormatter from '@Helpers/date-formatter';
+import dayjs from 'dayjs';
+
+const columns = [
+  {
+    title: 'Timestamp',
+    dataIndex: 'timestamp',
+    key: 'timestamp',
+    sorter: (a, b) => dayjs(a.timestamp).unix() - dayjs(b.timestamp).unix(),
+    render: (value) => dateFormatter(value),
+  },
+  {
+    title: 'Credential Name',
+    dataIndex: 'apiKeyName',
+    key: 'apiKeyName',
+    ellipsis: true,
+  },
+];
+
+export default columns;

--- a/ui/src/container/pages/routes/detail/body/events/items/duration-limiting/index.jsx
+++ b/ui/src/container/pages/routes/detail/body/events/items/duration-limiting/index.jsx
@@ -1,0 +1,25 @@
+import { useGetEventsByRouteWithRange } from '@Src/store/state/routes/vertical-hooks';
+import { DataTable } from '@radicalbit/radicalbit-design-system';
+import { useParams } from 'react-router-dom';
+import columns from './columns';
+
+function DurationLimiting() {
+  const { name } = useParams();
+
+  const { data, isLoading } = useGetEventsByRouteWithRange(name);
+  const durationLimit = data?.durationLimit;
+
+  return (
+    <DataTable
+      columns={columns}
+      dataSource={durationLimit}
+      loading={isLoading}
+      pagination={{
+        hideOnSinglePage: true,
+      }}
+      rowKey="timestamp"
+    />
+  );
+}
+
+export default DurationLimiting;

--- a/ui/src/container/pages/routes/detail/body/events/items/duration-limiting/use-get-duration-limiting-items.jsx
+++ b/ui/src/container/pages/routes/detail/body/events/items/duration-limiting/use-get-duration-limiting-items.jsx
@@ -2,35 +2,33 @@ import Lucide from '@Components/lucide';
 import { useGetEventsByRouteWithRange, useGetRouteByNameWithRange } from '@Src/store/state/routes/vertical-hooks';
 import { Button } from '@radicalbit/radicalbit-design-system';
 import isEmpty from 'lodash/isEmpty';
-import { TableColumnsSplit } from 'lucide-react';
+import { Hourglass } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 
-const useGetTokensLimitingItem = () => {
+const useGetDurationLimitingItem = () => {
   const { name } = useParams();
 
   const { data } = useGetEventsByRouteWithRange(name);
   const { data: route } = useGetRouteByNameWithRange(name);
 
-  const tokenInputLimit = data?.tokenInputLimit;
-  const tokenOutputLimit = data?.tokenOutputLimit;
-  const chatModels = route?.configuration?.chatModels;
-  const embeddingModels = route?.configuration?.embeddingModels;
+  const durationLimit = data?.durationLimit;
+  const transcriptionModels = route?.configuration?.transcriptionModels;
 
-  if (isEmpty(chatModels) && isEmpty(embeddingModels)) {
+  if (isEmpty(transcriptionModels)) {
     return { hidden: true };
   }
 
   const type = (function getType() {
-    if (tokenInputLimit === undefined && tokenOutputLimit === undefined) {
+    if (durationLimit === undefined) {
       return { disabled: true };
     }
-    if (tokenInputLimit?.length === 0 && tokenOutputLimit?.length === 0) {
+    if (durationLimit.length === 0) {
       return { type: 'primary-light' };
     }
     return { type: 'primary' };
   }());
 
-  const collapseProps = !tokenInputLimit?.length && !tokenOutputLimit?.length
+  const collapseProps = !durationLimit?.length
     ? { collapsible: 'disabled', showArrow: false }
     : {};
 
@@ -38,12 +36,12 @@ const useGetTokensLimitingItem = () => {
     ...collapseProps,
     label: (
       <div className="flex justify-start items-center gap-4">
-        <Button shape="circle" {...type}><Lucide icon={TableColumnsSplit} /></Button>
+        <Button shape="circle" {...type}><Lucide icon={Hourglass} /></Button>
 
-        <div>Token Limiting</div>
+        <div>Duration Limiting</div>
       </div>
     ),
   };
 };
 
-export default useGetTokensLimitingItem;
+export default useGetDurationLimitingItem;

--- a/ui/src/container/pages/routes/list/body/table/columns/limits.jsx
+++ b/ui/src/container/pages/routes/list/body/table/columns/limits.jsx
@@ -37,6 +37,9 @@ function PopoverContent({ configuration, metrics }) {
   const tokenLimitingOutput = configuration?.tokenLimiting?.output;
   const durationLimiting = configuration?.durationLimiting;
 
+  const supportsTokenLimiting = !!configuration?.chatModels?.length || !!configuration?.embeddingModels?.length;
+  const supportsDurationLimiting = !!configuration?.transcriptionModels?.length;
+
   const rate = numberFormatterInt(metrics.rateLimitTriggered) ?? '--';
   const tokenIn = numberFormatterInt(metrics.tokenInputLimitTriggered) ?? '--';
   const tokenOut = numberFormatterInt(metrics.tokenOutputLimitTriggered) ?? '--';
@@ -58,26 +61,20 @@ function PopoverContent({ configuration, metrics }) {
   const durationLimitingWindowSize = durationLimiting?.windowSize ?? '--';
   const durationLimitingMaxDurationSeconds = numberFormatterInt(durationLimiting?.maxDurationSeconds) ?? '--';
 
-  return (
-    <div className="flex flex-col">
-      <PopoverRow label="Rate:" value={rate} />
-
+  const tokenTriggerRows = supportsTokenLimiting ? (
+    <>
       <PopoverRow label="Token in:" value={tokenIn} />
 
       <PopoverRow label="Token out:" value={tokenOut} />
+    </>
+  ) : false;
 
-      <PopoverRow label="Duration:" value={duration} />
+  const durationTriggerRow = supportsDurationLimiting
+    ? <PopoverRow label="Duration:" value={duration} />
+    : false;
 
-      <Divider style={{ margin: '.5rem' }} />
-
-      <strong>Rate Limiting</strong>
-
-      <PopoverRow label="Algorithm:" value={rateLimitingalgorithm} />
-
-      <PopoverRow label="Window size:" value={rateLimitingwindowSize} />
-
-      <PopoverRow label="Max requests:" value={rateLimitingmaxRequests} />
-
+  const tokenLimitingSections = supportsTokenLimiting ? (
+    <>
       <Divider style={{ margin: '.5rem' }} />
 
       <strong>Token Limiting Input</strong>
@@ -97,7 +94,11 @@ function PopoverContent({ configuration, metrics }) {
       <PopoverRow label="Window size:" value={tokenLimitingOutputWindowSize} />
 
       <PopoverRow label="Max tokens:" value={tokenLimitingOutputMaxTokens} />
+    </>
+  ) : false;
 
+  const durationLimitingSection = supportsDurationLimiting ? (
+    <>
       <Divider style={{ margin: '.5rem' }} />
 
       <strong>Duration Limiting</strong>
@@ -107,6 +108,30 @@ function PopoverContent({ configuration, metrics }) {
       <PopoverRow label="Window size:" value={durationLimitingWindowSize} />
 
       <PopoverRow label="Max duration (s):" value={durationLimitingMaxDurationSeconds} />
+    </>
+  ) : false;
+
+  return (
+    <div className="flex flex-col">
+      <PopoverRow label="Rate:" value={rate} />
+
+      {tokenTriggerRows}
+
+      {durationTriggerRow}
+
+      <Divider style={{ margin: '.5rem' }} />
+
+      <strong>Rate Limiting</strong>
+
+      <PopoverRow label="Algorithm:" value={rateLimitingalgorithm} />
+
+      <PopoverRow label="Window size:" value={rateLimitingwindowSize} />
+
+      <PopoverRow label="Max requests:" value={rateLimitingmaxRequests} />
+
+      {tokenLimitingSections}
+
+      {durationLimitingSection}
     </div>
   );
 }

--- a/ui/src/container/pages/routes/list/body/table/columns/models.jsx
+++ b/ui/src/container/pages/routes/list/body/table/columns/models.jsx
@@ -3,10 +3,12 @@ import { Divider, Popover } from '@radicalbit/radicalbit-design-system';
 function Models({ configuration }) {
   const chatModels = configuration?.chatModels || [];
   const embeddingModels = configuration?.embeddingModels || [];
+  const transcriptionModels = configuration?.transcriptionModels || [];
 
   const chatModelsCount = chatModels.length;
   const embeddingModelsCount = embeddingModels.length;
-  const count = chatModelsCount + embeddingModelsCount;
+  const transcriptionModelsCount = transcriptionModels.length;
+  const count = chatModelsCount + embeddingModelsCount + transcriptionModelsCount;
 
   if (count === 0) {
     return '--';
@@ -34,6 +36,20 @@ function Models({ configuration }) {
 
           <div className="flex flex-col">
             {embeddingModels.map(({ model }) => (
+              <div>{model}</div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(chatModelsCount > 0 || embeddingModelsCount > 0) && transcriptionModelsCount > 0 && <Divider style={{ margin: 0 }} />}
+
+      {transcriptionModelsCount > 0 && (
+        <div className="flex flex-col justify-center w-full gap-1">
+          <strong>Transcription models</strong>
+
+          <div className="flex flex-col">
+            {transcriptionModels.map(({ model }) => (
               <div>{model}</div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

  Two independent changes to the routes UI: duration limiting gains the two
  surfaces it was missing, and the cURL tab lets you fill in a request's
  parameters through a modal instead of editing the copied command by hand.

  ## Duration limiting

  Duration limiting was already shown in the routes list popover and the
  usage/limits table, but not on the route detail tabs. This adds it to both:

  - **Events tab** — a new `Duration Limiting` entry listing `AUDIO_DURATION_LIMIT`
    events, mirroring the existing `Rate Limiting` item.
  - **Configurations tab** — a new `Duration Limiting` section rendering
    `configuration.durationLimiting`.

  Limiting sections a route cannot support are no longer shown as permanently
  inert: token limiting needs a chat or embedding model, duration limiting needs
  a transcription model. On the Events tab those entries are hidden; on the
  Configurations tab they stay visible with a tooltip explaining why they are
  unavailable; in the Limits popover the corresponding rows are skipped instead
  of rendering `--`.

  ### Fixes

  - **Transcription models were invisible in the Models section and column.**
    Both only counted `chatModels` and `embeddingModels`, so a transcription-only
    route showed `Models: --` and a disabled Models section despite having a
    model configured.
  - **The route analytics modal had drifted from the routes list.** Its
    `limits.jsx` is a copy of the routes-list one that never received the
    duration limiting additions, so a route with only `duration_limiting`
    configured looked unconfigured in the drill-down. The two files are identical
    again.

  ## cURL parameters modal

  The cURL tab asked for a credential through an inline input, and the
  transcription command carried a hardcoded `/path/to/audio.mp3` that had to be
  edited after copying. Both sections now open a modal instead:

  - chat asks for a credential, transcription for a credential and the audio
    file path;
  - the command previews live as you type, inside the modal and in the tab
    behind it;
  - submitting validates, copies to the clipboard and closes.

  Each section owns a `FormbitContextProvider` spanning its board and its modal,
  so values and validation messages are shared without lifting state.

  Also fixes the command formatting: a `\` at the end of a line inside a
  template literal is a JavaScript line continuation, so it consumed the newline
  instead of emitting a backslash — the transcription command rendered as a
  single long line.