### PR TITLE
feat: add credential level limiting

### DIFF
--- a/gateway/alembic/versions/b7c8d9e0f1a2_add_key_limit_table.py
+++ b/gateway/alembic/versions/b7c8d9e0f1a2_add_key_limit_table.py
@@ -1,0 +1,51 @@
+"""add_key_limit_table
+
+Revision ID: b7c8d9e0f1a2
+Revises: af9453aaa568
+Create Date: 2026-09-03 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7c8d9e0f1a2'
+down_revision: Union[str, Sequence[str], None] = 'af9453aaa568'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'key_limit',
+        sa.Column('UUID', sa.UUID(), nullable=False),
+        sa.Column('KEY_UUID', sa.UUID(), nullable=False),
+        sa.Column('CATEGORY', sa.VARCHAR(), nullable=False),
+        sa.Column('ALGORITHM', sa.VARCHAR(), nullable=False),
+        sa.Column('WINDOW_SIZE', sa.VARCHAR(), nullable=False),
+        sa.Column('MAX_VALUE', sa.NUMERIC(), nullable=False),
+        sa.Column('CREATED_AT', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('UPDATED_AT', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('UUID', name=op.f('pk_key_limit')),
+        sa.ForeignKeyConstraint(
+            ['KEY_UUID'],
+            ['key.UUID'],
+            name=op.f('fk_key_limit_KEY_UUID_key'),
+            ondelete='CASCADE',
+        ),
+        sa.UniqueConstraint(
+            'KEY_UUID',
+            'CATEGORY',
+            'ALGORITHM',
+            'WINDOW_SIZE',
+            name='uq_key_limit_KEY_UUID_CATEGORY_ALGORITHM_WINDOW_SIZE',
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('key_limit')

--- a/gateway/radicalbit_ai_gateway/db/dao/key_limit_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/key_limit_dao.py
@@ -17,6 +17,15 @@ class KeyLimitDAO:
             session.flush()
             return key_limit
 
+    def insert_many(self, key_limits: list[KeyLimit]) -> list[KeyLimit]:
+        """Insert all limits in a single transaction: either all succeed, or
+        none do (e.g. if one duplicates an existing or another batch entry).
+        """
+        with self.db.begin_session() as session:
+            session.add_all(key_limits)
+            session.flush()
+            return key_limits
+
     def get_by_uuid(self, limit_uuid: UUID) -> KeyLimit | None:
         with self.db.begin_session() as session:
             return session.scalar(select(KeyLimit).where(KeyLimit.uuid == limit_uuid))

--- a/gateway/radicalbit_ai_gateway/db/dao/key_limit_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/key_limit_dao.py
@@ -1,0 +1,34 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+
+from radicalbit_ai_gateway.db.database import Database
+from radicalbit_ai_gateway.db.tables.key_limit_table import KeyLimit
+
+
+class KeyLimitDAO:
+    def __init__(self, database: Database):
+        self.db = database
+
+    def insert(self, key_limit: KeyLimit) -> KeyLimit:
+        with self.db.begin_session() as session:
+            session.add(key_limit)
+            session.flush()
+            return key_limit
+
+    def get_by_uuid(self, limit_uuid: UUID) -> KeyLimit | None:
+        with self.db.begin_session() as session:
+            return session.scalar(select(KeyLimit).where(KeyLimit.uuid == limit_uuid))
+
+    def get_by_key_uuid(self, key_uuid: UUID) -> Sequence[KeyLimit]:
+        with self.db.begin_session() as session:
+            stmt = select(KeyLimit).where(KeyLimit.key_uuid == key_uuid)
+            return session.scalars(stmt).all()
+
+    def get_all_by_key_uuids(self, key_uuids: list[UUID]) -> Sequence[KeyLimit]:
+        if not key_uuids:
+            return []
+        with self.db.begin_session() as session:
+            stmt = select(KeyLimit).where(KeyLimit.key_uuid.in_(key_uuids))
+            return session.scalars(stmt).all()

--- a/gateway/radicalbit_ai_gateway/db/tables/key_limit_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/key_limit_table.py
@@ -1,0 +1,54 @@
+import uuid
+
+from sqlalchemy import (
+    NUMERIC,
+    TIMESTAMP,
+    UUID,
+    VARCHAR,
+    Column,
+    ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from radicalbit_ai_gateway.db.dao.base_dao import BaseDAO
+from radicalbit_ai_gateway.db.database import BaseTable, Reflected
+
+
+class KeyLimit(Reflected, BaseTable, BaseDAO):
+    __tablename__ = 'key_limit'
+    __table_args__ = (
+        UniqueConstraint(
+            'KEY_UUID',
+            'CATEGORY',
+            'ALGORITHM',
+            'WINDOW_SIZE',
+            name='uq_key_limit_KEY_UUID_CATEGORY_ALGORITHM_WINDOW_SIZE',
+        ),
+    )
+
+    uuid = Column(
+        'UUID',
+        UUID(as_uuid=True),
+        nullable=False,
+        default=uuid.uuid4,
+        primary_key=True,
+    )
+    key_uuid = Column(
+        'KEY_UUID',
+        UUID(as_uuid=True),
+        ForeignKey('key.UUID', ondelete='CASCADE'),
+        nullable=False,
+    )
+    category = Column('CATEGORY', VARCHAR(), nullable=False)
+    algorithm = Column('ALGORITHM', VARCHAR(), nullable=False)
+    window_size = Column('WINDOW_SIZE', VARCHAR(), nullable=False)
+    max_value = Column('MAX_VALUE', NUMERIC(), nullable=False)
+    created_at = Column('CREATED_AT', TIMESTAMP(timezone=True), nullable=False)
+    updated_at = Column('UPDATED_AT', TIMESTAMP(timezone=True), nullable=False)
+
+    key = relationship(
+        'Key',
+        back_populates='limits',
+        lazy='selectin',
+    )

--- a/gateway/radicalbit_ai_gateway/db/tables/key_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/key_table.py
@@ -44,3 +44,10 @@ class Key(Reflected, BaseTable, BaseDAO):
         back_populates='keys',
         lazy='selectin',
     )
+    limits = relationship(
+        'KeyLimit',
+        back_populates='key',
+        cascade='all, delete-orphan',
+        passive_deletes=True,
+        lazy='selectin',
+    )

--- a/gateway/radicalbit_ai_gateway/models/auth_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/auth_dto.py
@@ -8,6 +8,7 @@ from pydantic.alias_generators import to_camel
 from radicalbit_ai_gateway.db.tables.group_route_table import GroupRoute
 from radicalbit_ai_gateway.db.tables.group_table import Group
 from radicalbit_ai_gateway.db.tables.key_table import Key
+from radicalbit_ai_gateway.models.credential_limiting import CredentialLimitOut
 
 
 class KeyIn(BaseModel, validate_assignment=True):
@@ -183,6 +184,7 @@ class GroupOut(BaseModel):
 
 class KeyFullOut(KeyOut):
     group: GroupOut | None
+    limits: list[CredentialLimitOut] | None = None
 
     model_config = ConfigDict(
         populate_by_name=True, alias_generator=to_camel, protected_namespaces=()
@@ -191,7 +193,10 @@ class KeyFullOut(KeyOut):
     # Used only on Key creation, to return api_key not obscured
     @staticmethod
     def from_key(
-        key: Key, plain_api_key: str, include_groups: bool = False
+        key: Key,
+        plain_api_key: str,
+        include_groups: bool = False,
+        include_limits: bool = False,
     ) -> 'KeyFullOut':
         return KeyFullOut(
             uuid=key.uuid,
@@ -203,13 +208,20 @@ class KeyFullOut(KeyOut):
             group=GroupOut.from_group(key.group)
             if include_groups and key.group
             else None,
+            limits=[CredentialLimitOut.from_key_limit(limit) for limit in key.limits]
+            if include_limits
+            else None,
             created_at=str(key.created_at),
             updated_at=str(key.updated_at),
         )
 
     # Used to return Key with api_key obscured
     @staticmethod
-    def from_key_obscured(key: Key, include_groups: bool = False) -> 'KeyFullOut':
+    def from_key_obscured(
+        key: Key,
+        include_groups: bool = False,
+        include_limits: bool = False,
+    ) -> 'KeyFullOut':
         return KeyFullOut(
             uuid=key.uuid,
             name=key.name,
@@ -219,6 +231,9 @@ class KeyFullOut(KeyOut):
             api_key=key.obscured_key,
             group=GroupOut.from_group(key.group)
             if include_groups and key.group
+            else None,
+            limits=[CredentialLimitOut.from_key_limit(limit) for limit in key.limits]
+            if include_limits
             else None,
             created_at=str(key.created_at),
             updated_at=str(key.updated_at),

--- a/gateway/radicalbit_ai_gateway/models/credential_limiting.py
+++ b/gateway/radicalbit_ai_gateway/models/credential_limiting.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic.alias_generators import to_camel
+
+from radicalbit_ai_gateway.db.tables.key_limit_table import KeyLimit
+from radicalbit_ai_gateway.limiter.window_config import ScenarioType
+from radicalbit_ai_gateway.models.limiting import Limiting, LimitingAlgorithmType
+
+
+class CredentialLimitCategory(str, Enum):
+    RATE = ScenarioType.REQUEST_RATE.value
+    TOKEN_INPUT = ScenarioType.TOKEN_INPUT.value
+    TOKEN_OUTPUT = ScenarioType.TOKEN_OUTPUT.value
+    BUDGET = ScenarioType.BUDGET.value
+
+
+# Which field of the existing `Limiting` model each category maps to, so we can
+# reuse its algorithm/window_size validation instead of duplicating it.
+_CATEGORY_TO_LIMITING_FIELD: dict[CredentialLimitCategory, str] = {
+    CredentialLimitCategory.RATE: 'max_requests',
+    CredentialLimitCategory.TOKEN_INPUT: 'max_tokens',
+    CredentialLimitCategory.TOKEN_OUTPUT: 'max_tokens',
+    CredentialLimitCategory.BUDGET: 'max_budget',
+}
+
+
+class CredentialLimitIn(BaseModel):
+    category: CredentialLimitCategory
+    algorithm: LimitingAlgorithmType = LimitingAlgorithmType.FIXED_WINDOW
+    window_size: int | str = '1 minute'
+    value: float = Field(
+        ...,
+        gt=0,
+        description='Threshold for this limit: request count, token count, or budget amount depending on category.',
+        examples=[10, 1000, 1.5],
+    )
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    @model_validator(mode='after')
+    def validate_against_limiting_schema(self) -> CredentialLimitIn:
+        field_name = _CATEGORY_TO_LIMITING_FIELD[self.category]
+        # Raises ValueError (-> 422) if algorithm/window_size are inconsistent,
+        # reusing the validation already defined on `Limiting`.
+        Limiting(
+            algorithm=self.algorithm,
+            window_size=self.window_size,
+            **{field_name: self.value},
+        )
+        return self
+
+    def to_key_limit(self, key_uuid: UUID) -> KeyLimit:
+        UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
+        now = datetime.datetime.now(tz=UTC)
+        return KeyLimit(
+            key_uuid=key_uuid,
+            category=self.category.value,
+            algorithm=self.algorithm.value,
+            window_size=str(self.window_size),
+            max_value=self.value,
+            created_at=now,
+            updated_at=now,
+        )
+
+
+class CredentialLimitOut(BaseModel):
+    uuid: UUID
+    category: CredentialLimitCategory
+    algorithm: LimitingAlgorithmType
+    window_size: str
+    value: float
+    created_at: str
+    updated_at: str
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    @staticmethod
+    def from_key_limit(key_limit: KeyLimit) -> CredentialLimitOut:
+        return CredentialLimitOut(
+            uuid=key_limit.uuid,
+            category=CredentialLimitCategory(key_limit.category),
+            algorithm=LimitingAlgorithmType(key_limit.algorithm),
+            window_size=key_limit.window_size,
+            value=float(key_limit.max_value),
+            created_at=str(key_limit.created_at),
+            updated_at=str(key_limit.updated_at),
+        )

--- a/gateway/radicalbit_ai_gateway/models/credential_limiting.py
+++ b/gateway/radicalbit_ai_gateway/models/credential_limiting.py
@@ -68,6 +68,33 @@ class CredentialLimitIn(BaseModel):
         )
 
 
+class CredentialLimitsIn(BaseModel):
+    """A batch of limits to create on a credential in a single call — e.g. a rate,
+    a token and a budget limit configured together from one UI form submission.
+    """
+
+    limits: list[CredentialLimitIn] = Field(..., min_length=1)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    @model_validator(mode='after')
+    def no_duplicates_within_batch(self) -> CredentialLimitsIn:
+        seen = set()
+        for limit in self.limits:
+            key = (limit.category, limit.algorithm, str(limit.window_size))
+            if key in seen:
+                raise ValueError(
+                    f'Duplicate limit in request: {limit.category.value} with '
+                    f'algorithm {limit.algorithm.value} and window '
+                    f'{limit.window_size} was submitted more than once.'
+                )
+            seen.add(key)
+        return self
+
+    def to_key_limits(self, key_uuid: UUID) -> list[KeyLimit]:
+        return [limit.to_key_limit(key_uuid) for limit in self.limits]
+
+
 class CredentialLimitOut(BaseModel):
     uuid: UUID
     category: CredentialLimitCategory

--- a/gateway/radicalbit_ai_gateway/routes/key_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/key_route.py
@@ -9,6 +9,7 @@ from radicalbit_ai_gateway.models.auth_dto import (
     KeyGroupIn,
     KeyIn,
 )
+from radicalbit_ai_gateway.models.credential_limiting import CredentialLimitIn
 from radicalbit_ai_gateway.route_meta import route_meta
 from radicalbit_ai_gateway.services.key_service import KeyService
 from radicalbit_ai_gateway.utils.app_config import get_app_config
@@ -33,12 +34,20 @@ class KeyRoute:
             return key
 
         @router.get('/keys', status_code=200, response_model=list[KeyFullOut])
-        def get_all(include_groups: bool = False, only_unassigned: bool = Query(False)):
-            return key_service.get_all(include_groups, only_unassigned)
+        def get_all(
+            include_groups: bool = False,
+            only_unassigned: bool = Query(False),
+            include_limits: bool = Query(False),
+        ):
+            return key_service.get_all(include_groups, only_unassigned, include_limits)
 
         @router.get('/keys/{key_uuid}', status_code=200, response_model=KeyFullOut)
-        def get_key_by_uuid(key_uuid: UUID, include_groups: bool = False):
-            return key_service.get_key_by_uuid(key_uuid, include_groups)
+        def get_key_by_uuid(
+            key_uuid: UUID,
+            include_groups: bool = False,
+            include_limits: bool = Query(False),
+        ):
+            return key_service.get_key_by_uuid(key_uuid, include_groups, include_limits)
 
         @router.patch('/keys/{key_uuid}', status_code=200, response_model=KeyFullOut)
         @route_meta(entity_type='KEY', entity_uuid_param='key_uuid')
@@ -74,5 +83,14 @@ class KeyRoute:
             return key_service.get_associable_groups(
                 key_uuid, include_routes, include_keys
             )
+
+        @router.post(
+            '/keys/{key_uuid}/limits', status_code=201, response_model=KeyFullOut
+        )
+        @route_meta(entity_type='KEY', entity_uuid_param='key_uuid', action='ADD_LIMIT')
+        def add_limit_to_key(key_uuid: UUID, limit_in: CredentialLimitIn):
+            key = key_service.add_limit_to_key(key_uuid, limit_in)
+            logger.info('Added %s limit to key %s', limit_in.category.value, key_uuid)
+            return key
 
         return router

--- a/gateway/radicalbit_ai_gateway/routes/key_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/key_route.py
@@ -9,7 +9,10 @@ from radicalbit_ai_gateway.models.auth_dto import (
     KeyGroupIn,
     KeyIn,
 )
-from radicalbit_ai_gateway.models.credential_limiting import CredentialLimitIn
+from radicalbit_ai_gateway.models.credential_limiting import (
+    CredentialLimitOut,
+    CredentialLimitsIn,
+)
 from radicalbit_ai_gateway.route_meta import route_meta
 from radicalbit_ai_gateway.services.key_service import KeyService
 from radicalbit_ai_gateway.utils.app_config import get_app_config
@@ -88,9 +91,21 @@ class KeyRoute:
             '/keys/{key_uuid}/limits', status_code=201, response_model=KeyFullOut
         )
         @route_meta(entity_type='KEY', entity_uuid_param='key_uuid', action='ADD_LIMIT')
-        def add_limit_to_key(key_uuid: UUID, limit_in: CredentialLimitIn):
-            key = key_service.add_limit_to_key(key_uuid, limit_in)
-            logger.info('Added %s limit to key %s', limit_in.category.value, key_uuid)
+        def add_limits_to_key(
+            key_uuid: UUID,
+            limits_in: CredentialLimitsIn,
+            include_groups: bool = Query(False),
+        ):
+            key = key_service.add_limits_to_key(key_uuid, limits_in, include_groups)
+            logger.info('Added %s limit(s) to key %s', len(limits_in.limits), key_uuid)
             return key
+
+        @router.get(
+            '/keys/{key_uuid}/limits',
+            status_code=200,
+            response_model=list[CredentialLimitOut],
+        )
+        def get_limits_for_key(key_uuid: UUID):
+            return key_service.get_limits_for_key(key_uuid)
 
         return router

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -451,7 +451,10 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         body = ''
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        content={'detail': exc.errors(), 'body': body},
+        # exc.errors() can contain raw exception objects (e.g. the ctx.error of
+        # a model_validator that raised ValueError), which plain json.dumps
+        # cannot serialize — jsonable_encoder handles those.
+        content=jsonable_encoder({'detail': exc.errors(), 'body': body}),
     )
 
 

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -33,6 +33,7 @@ from radicalbit_ai_gateway.db.dao.event_dao import EventDAO
 from radicalbit_ai_gateway.db.dao.group_dao import GroupDAO
 from radicalbit_ai_gateway.db.dao.group_route_dao import GroupRouteDAO
 from radicalbit_ai_gateway.db.dao.key_dao import KeyDAO
+from radicalbit_ai_gateway.db.dao.key_limit_dao import KeyLimitDAO
 from radicalbit_ai_gateway.db.dao.otel_traces_dao import OtelTracesDAO
 from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
@@ -182,6 +183,7 @@ database = Database(conf=app_config.db_config)
 discover_plugins()
 
 key_dao = KeyDAO(database)
+key_limit_dao = KeyLimitDAO(database)
 group_dao = GroupDAO(database)
 group_route_dao = GroupRouteDAO(database)
 project_dao = ProjectDAO(database)
@@ -196,6 +198,7 @@ key_service = KeyService(
     key_dao=key_dao,
     api_key_security=api_key_security,
     group_dao=group_dao,
+    key_limit_dao=key_limit_dao,
 )
 group_service = GroupService(
     group_dao=group_dao,

--- a/gateway/radicalbit_ai_gateway/services/key_service.py
+++ b/gateway/radicalbit_ai_gateway/services/key_service.py
@@ -12,8 +12,8 @@ from radicalbit_ai_gateway.models.auth_dto import (
     KeyIn,
 )
 from radicalbit_ai_gateway.models.credential_limiting import (
-    CredentialLimitIn,
     CredentialLimitOut,
+    CredentialLimitsIn,
 )
 from radicalbit_ai_gateway.services.api_key_security import ApiKeySecurity
 from radicalbit_ai_gateway.utils.exceptions import (
@@ -230,8 +230,11 @@ class KeyService:
     def get_names_by_uuids(self, uuids: list[UUID]) -> dict[UUID, str]:
         return self.key_dao.get_names_by_uuids(uuids)
 
-    def add_limit_to_key(
-        self, key_uuid: UUID, limit_in: CredentialLimitIn
+    def add_limits_to_key(
+        self,
+        key_uuid: UUID,
+        limits_in: CredentialLimitsIn,
+        include_groups: bool = False,
     ) -> KeyFullOut:
         key = self.key_dao.get_by_uuid(key_uuid)
         if not key:
@@ -241,22 +244,26 @@ class KeyService:
                 f'Key {key_uuid} cannot have limits configured because owner is "{key.owner}"'
             )
         try:
-            self.key_limit_dao.insert(limit_in.to_key_limit(key_uuid))
+            self.key_limit_dao.insert_many(limits_in.to_key_limits(key_uuid))
         except IntegrityError as e:
             if 'uq_key_limit_KEY_UUID_CATEGORY_ALGORITHM_WINDOW_SIZE' in str(e.orig):
+                categories = ', '.join(
+                    limit.category.value for limit in limits_in.limits
+                )
                 raise CredentialLimitAlreadyExistsError(
-                    f'A {limit_in.category.value} limit with algorithm '
-                    f'{limit_in.algorithm.value} and window {limit_in.window_size} '
-                    f'already exists on key {key_uuid}'
+                    f'One of the requested limits ({categories}) already exists '
+                    f'on key {key_uuid} with the same algorithm and window'
                 ) from e
             raise KeyInternalError(
-                f'An error occurred while adding the limit: {e}'
+                f'An error occurred while adding the limits: {e}'
             ) from e
         except Exception as e:
             raise KeyInternalError(
-                f'An error occurred while adding the limit: {e}'
+                f'An error occurred while adding the limits: {e}'
             ) from e
-        return self._get_key(key_uuid, include_limits=True)
+        return self._get_key(
+            key_uuid, include_groups=include_groups, include_limits=True
+        )
 
     def get_limits_for_key(self, key_uuid: UUID) -> list[CredentialLimitOut]:
         key = self.key_dao.get_by_uuid(key_uuid)

--- a/gateway/radicalbit_ai_gateway/services/key_service.py
+++ b/gateway/radicalbit_ai_gateway/services/key_service.py
@@ -4,14 +4,20 @@ from sqlalchemy.exc import IntegrityError
 
 from radicalbit_ai_gateway.db.dao.group_dao import GroupDAO
 from radicalbit_ai_gateway.db.dao.key_dao import KeyDAO
+from radicalbit_ai_gateway.db.dao.key_limit_dao import KeyLimitDAO
 from radicalbit_ai_gateway.models.auth_dto import (
     GroupFullOut,
     KeyFullOut,
     KeyGroupIn,
     KeyIn,
 )
+from radicalbit_ai_gateway.models.credential_limiting import (
+    CredentialLimitIn,
+    CredentialLimitOut,
+)
 from radicalbit_ai_gateway.services.api_key_security import ApiKeySecurity
 from radicalbit_ai_gateway.utils.exceptions import (
+    CredentialLimitAlreadyExistsError,
     GroupNotFoundError,
     KeyAlreadyExistsError,
     KeyGroupAlreadyExistsError,
@@ -27,18 +33,26 @@ class KeyService:
         key_dao: KeyDAO,
         api_key_security: ApiKeySecurity,
         group_dao: GroupDAO,
+        key_limit_dao: KeyLimitDAO,
     ):
         self.key_dao = key_dao
         self.api_key_security = api_key_security
         self.group_dao = group_dao
+        self.key_limit_dao = key_limit_dao
 
-    def _get_key(self, key_uuid: UUID, include_groups: bool = False) -> KeyFullOut:
+    def _get_key(
+        self,
+        key_uuid: UUID,
+        include_groups: bool = False,
+        include_limits: bool = False,
+    ) -> KeyFullOut:
         key = self.key_dao.get_by_uuid(key_uuid)
         if not key:
             raise KeyNotFoundError(f'Key with UUID {key_uuid} not exists')
         return KeyFullOut.from_key_obscured(
             key=key,
             include_groups=include_groups,
+            include_limits=include_limits,
         )
 
     def create_key(self, key_in: KeyIn) -> KeyFullOut:
@@ -65,12 +79,18 @@ class KeyService:
                 f'An error occurred while creating the key: {e}'
             ) from e
 
-    def get_all(self, include_groups: bool, only_unassigned: bool) -> list[KeyFullOut]:
+    def get_all(
+        self,
+        include_groups: bool,
+        only_unassigned: bool,
+        include_limits: bool = False,
+    ) -> list[KeyFullOut]:
         keys = self.key_dao.get_all(only_unassigned=only_unassigned)
         return [
             KeyFullOut.from_key_obscured(
                 key=key,
                 include_groups=include_groups,
+                include_limits=include_limits,
             )
             for key in keys
         ]
@@ -88,8 +108,17 @@ class KeyService:
             raise KeyInternalError(f'Key {key.name} not deleted')
         return KeyFullOut.from_key_obscured(key=key, include_groups=include_groups)
 
-    def get_key_by_uuid(self, key_uuid: UUID, include_groups: bool) -> KeyFullOut:
-        return self._get_key(key_uuid=key_uuid, include_groups=include_groups)
+    def get_key_by_uuid(
+        self,
+        key_uuid: UUID,
+        include_groups: bool,
+        include_limits: bool = False,
+    ) -> KeyFullOut:
+        return self._get_key(
+            key_uuid=key_uuid,
+            include_groups=include_groups,
+            include_limits=include_limits,
+        )
 
     def update_key_name(self, key_uuid: UUID, key_in: KeyIn) -> KeyFullOut:
         key = self.key_dao.get_by_uuid(key_uuid)
@@ -200,3 +229,40 @@ class KeyService:
 
     def get_names_by_uuids(self, uuids: list[UUID]) -> dict[UUID, str]:
         return self.key_dao.get_names_by_uuids(uuids)
+
+    def add_limit_to_key(
+        self, key_uuid: UUID, limit_in: CredentialLimitIn
+    ) -> KeyFullOut:
+        key = self.key_dao.get_by_uuid(key_uuid)
+        if not key:
+            raise KeyNotFoundError(f'Key with UUID {key_uuid} not exists')
+        if key.owner != 'gateway':
+            raise KeyOperationNotAllowedError(
+                f'Key {key_uuid} cannot have limits configured because owner is "{key.owner}"'
+            )
+        try:
+            self.key_limit_dao.insert(limit_in.to_key_limit(key_uuid))
+        except IntegrityError as e:
+            if 'uq_key_limit_KEY_UUID_CATEGORY_ALGORITHM_WINDOW_SIZE' in str(e.orig):
+                raise CredentialLimitAlreadyExistsError(
+                    f'A {limit_in.category.value} limit with algorithm '
+                    f'{limit_in.algorithm.value} and window {limit_in.window_size} '
+                    f'already exists on key {key_uuid}'
+                ) from e
+            raise KeyInternalError(
+                f'An error occurred while adding the limit: {e}'
+            ) from e
+        except Exception as e:
+            raise KeyInternalError(
+                f'An error occurred while adding the limit: {e}'
+            ) from e
+        return self._get_key(key_uuid, include_limits=True)
+
+    def get_limits_for_key(self, key_uuid: UUID) -> list[CredentialLimitOut]:
+        key = self.key_dao.get_by_uuid(key_uuid)
+        if not key:
+            raise KeyNotFoundError(f'Key with UUID {key_uuid} not exists')
+        return [
+            CredentialLimitOut.from_key_limit(limit)
+            for limit in self.key_limit_dao.get_by_key_uuid(key_uuid)
+        ]

--- a/gateway/radicalbit_ai_gateway/services/key_service.py
+++ b/gateway/radicalbit_ai_gateway/services/key_service.py
@@ -252,7 +252,7 @@ class KeyService:
                 )
                 raise CredentialLimitAlreadyExistsError(
                     f'One of the requested limits ({categories}) already exists '
-                    f'on key {key_uuid} with the same algorithm and window'
+                    f'on credential "{key.name}" with the same algorithm and window'
                 ) from e
             raise KeyInternalError(
                 f'An error occurred while adding the limits: {e}'

--- a/gateway/radicalbit_ai_gateway/utils/exceptions.py
+++ b/gateway/radicalbit_ai_gateway/utils/exceptions.py
@@ -531,6 +531,16 @@ class KeyGroupAlreadyExistsError(AuthRegistryError):
         )
 
 
+class CredentialLimitAlreadyExistsError(AuthRegistryError):
+    def __init__(self, message: str, *, log_message: str | None = None):
+        super().__init__(
+            message,
+            status.HTTP_400_BAD_REQUEST,
+            'credential_limit_already_exists_bad_request',
+            log_message=log_message,
+        )
+
+
 class GroupInternalError(AuthRegistryError):
     def __init__(self, message: str, *, log_message: str | None = None):
         super().__init__(

--- a/gateway/tests/common/db_integration.py
+++ b/gateway/tests/common/db_integration.py
@@ -37,24 +37,37 @@ class DatabaseIntegration(unittest.TestCase):
     def _sanitize_unique_constraints(cls) -> None:
         """Remove duplicated UNIQUE constraints that may have been added by reflection.
         This avoids re-emitting both UNIQUE and UNIQUE NULLS DISTINCT on the same columns.
+
+        `table.constraints` is a set, so iteration order is not deterministic.
+        Grouping by (name, cols) before deciding which copy to keep avoids a
+        prior bug where, depending on iteration order, both the declared and
+        the reflected copy of a constraint could independently match removal
+        criteria and both end up removed, dropping the constraint entirely.
         """
         for table in list(database.BaseTable.metadata.tables.values()):
-            seen: set[tuple[str, tuple[str, ...]]] = set()
+            groups: dict[tuple[str, tuple[str, ...]], list] = {}
+            for constraint in table.constraints:
+                if type(constraint).__name__ != 'UniqueConstraint':
+                    continue
+                name = constraint.name or ''
+                cols = tuple(col.name for col in constraint.columns)
+                groups.setdefault((name, cols), []).append(constraint)
+
+            def _has_nulls_kwarg(constraint) -> bool:
+                dialect_kwargs = getattr(constraint, 'dialect_kwargs', {}) or {}
+                return any('nulls' in k for k in dialect_kwargs)
+
             to_remove = []
-            for constraint in list(table.constraints):
-                if type(constraint).__name__ == 'UniqueConstraint':
-                    name = constraint.name or ''
-                    cols = tuple(col.name for col in constraint.columns)
-                    key = (name, cols)
-                    # Remove if duplicated by name+columns
-                    if key in seen:
-                        to_remove.append(constraint)
-                        continue
-                    seen.add(key)
-                    # Remove dialect-added variants like NULLS DISTINCT if detected
-                    dialect_kwargs = getattr(constraint, 'dialect_kwargs', {}) or {}
-                    if any('nulls' in k for k in dialect_kwargs):
-                        to_remove.append(constraint)
+            for constraints in groups.values():
+                # Prefer to keep a copy with no dialect-added NULLS variant
+                # (the declared one); fall back to an arbitrary copy so a
+                # constraint is never dropped entirely.
+                survivor = next(
+                    (c for c in constraints if not _has_nulls_kwarg(c)),
+                    constraints[0],
+                )
+                to_remove.extend(c for c in constraints if c is not survivor)
+
             for c in to_remove:
                 table.constraints.remove(c)
 

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -31,6 +31,7 @@ from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.credential_limiting import (
     CredentialLimitCategory,
     CredentialLimitIn,
+    CredentialLimitsIn,
 )
 from radicalbit_ai_gateway.models.project_dto import (
     ConfigSlotOut,
@@ -131,6 +132,12 @@ def get_sample_credential_limit_in(
         window_size=window_size,
         value=value,
     )
+
+
+def get_sample_credential_limits_in(
+    limits: list[CredentialLimitIn] | None = None,
+) -> CredentialLimitsIn:
+    return CredentialLimitsIn(limits=limits or [get_sample_credential_limit_in()])
 
 
 def get_sample_group_plain(

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -6,6 +6,7 @@ from radicalbit_ai_gateway.db.models.event import EventDetails
 from radicalbit_ai_gateway.db.tables.event_table import Event
 from radicalbit_ai_gateway.db.tables.group_route_table import GroupRoute
 from radicalbit_ai_gateway.db.tables.group_table import Group
+from radicalbit_ai_gateway.db.tables.key_limit_table import KeyLimit
 from radicalbit_ai_gateway.db.tables.key_table import Key
 from radicalbit_ai_gateway.db.tables.otel_traces_table import OtelTraces
 from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
@@ -27,6 +28,10 @@ from radicalbit_ai_gateway.models.auth_dto import (
 )
 from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
+from radicalbit_ai_gateway.models.credential_limiting import (
+    CredentialLimitCategory,
+    CredentialLimitIn,
+)
 from radicalbit_ai_gateway.models.project_dto import (
     ConfigSlotOut,
     ProjectConfigFileIn,
@@ -90,6 +95,41 @@ def get_sample_key_with_group(
         updated_at=now,
         group_uuid=group_uuid,
         group=get_sample_group(uuid=group_uuid),
+    )
+
+
+def get_sample_key_limit(
+    uuid: uuid.UUID = RANDOM_UUID,
+    key_uuid: uuid.UUID = RANDOM_UUID,
+    category: str = CredentialLimitCategory.BUDGET.value,
+    algorithm: str = 'FIXED_WINDOW',
+    window_size: str = '1 day',
+    max_value: float = 10.0,
+) -> KeyLimit:
+    now = datetime.datetime.now(tz=UTC)
+    return KeyLimit(
+        uuid=uuid,
+        key_uuid=key_uuid,
+        category=category,
+        algorithm=algorithm,
+        window_size=window_size,
+        max_value=max_value,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def get_sample_credential_limit_in(
+    category: CredentialLimitCategory = CredentialLimitCategory.BUDGET,
+    algorithm: str = 'FIXED_WINDOW',
+    window_size: str = '1 day',
+    value: float = 10.0,
+) -> CredentialLimitIn:
+    return CredentialLimitIn(
+        category=category,
+        algorithm=algorithm,
+        window_size=window_size,
+        value=value,
     )
 
 

--- a/gateway/tests/dao/key_limit_dao_test.py
+++ b/gateway/tests/dao/key_limit_dao_test.py
@@ -1,0 +1,86 @@
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from tests.common import db_mock
+from tests.common.db_integration import DatabaseIntegration
+
+from radicalbit_ai_gateway.db.dao.key_dao import KeyDAO
+from radicalbit_ai_gateway.db.dao.key_limit_dao import KeyLimitDAO
+
+
+class KeyLimitDAOTest(DatabaseIntegration):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.key_dao = KeyDAO(cls.db)
+        cls.key_limit_dao = KeyLimitDAO(cls.db)
+
+    def _insert_key(self, name='rb-key'):
+        key = db_mock.get_sample_key(uuid=uuid.uuid4(), name=name)
+        return self.key_dao.insert(key)
+
+    def test_insert(self):
+        key = self._insert_key()
+        limit = db_mock.get_sample_key_limit(key_uuid=key.uuid)
+        inserted = self.key_limit_dao.insert(limit)
+        assert inserted.uuid == limit.uuid
+
+    def test_get_by_uuid(self):
+        key = self._insert_key()
+        limit = db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key.uuid)
+        self.key_limit_dao.insert(limit)
+        res = self.key_limit_dao.get_by_uuid(limit.uuid)
+        assert res.uuid == limit.uuid
+
+    def test_get_by_key_uuid(self):
+        key = self._insert_key()
+        limits = [
+            db_mock.get_sample_key_limit(
+                uuid=uuid.uuid4(),
+                key_uuid=key.uuid,
+                category='budget',
+                window_size='1 day',
+            ),
+            db_mock.get_sample_key_limit(
+                uuid=uuid.uuid4(),
+                key_uuid=key.uuid,
+                category='budget',
+                window_size='1 month',
+            ),
+        ]
+        _ = [self.key_limit_dao.insert(i) for i in limits]
+        res = self.key_limit_dao.get_by_key_uuid(key.uuid)
+        assert len(res) == 2
+
+    def test_get_all_by_key_uuids(self):
+        key_one = self._insert_key(name='one')
+        key_two = self._insert_key(name='two')
+        self.key_limit_dao.insert(
+            db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key_one.uuid)
+        )
+        self.key_limit_dao.insert(
+            db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key_two.uuid)
+        )
+        res = self.key_limit_dao.get_all_by_key_uuids([key_one.uuid, key_two.uuid])
+        assert len(res) == 2
+
+    def test_get_all_by_key_uuids_empty_input(self):
+        assert self.key_limit_dao.get_all_by_key_uuids([]) == []
+
+    def test_duplicate_limit_raises_integrity_error(self):
+        key = self._insert_key()
+        limit_one = db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key.uuid)
+        limit_two = db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key.uuid)
+        self.key_limit_dao.insert(limit_one)
+        pytest.raises(IntegrityError, self.key_limit_dao.insert, limit_two)
+
+    def test_cascade_delete_on_key_delete(self):
+        key = self._insert_key()
+        self.key_limit_dao.insert(
+            db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key.uuid)
+        )
+        deleted_rows = self.key_dao.delete_by_uuid(key.uuid)
+        assert deleted_rows == 1
+        assert self.key_limit_dao.get_by_key_uuid(key.uuid) == []

--- a/gateway/tests/dao/key_limit_dao_test.py
+++ b/gateway/tests/dao/key_limit_dao_test.py
@@ -76,6 +76,38 @@ class KeyLimitDAOTest(DatabaseIntegration):
         self.key_limit_dao.insert(limit_one)
         pytest.raises(IntegrityError, self.key_limit_dao.insert, limit_two)
 
+    def test_insert_many(self):
+        key = self._insert_key()
+        limits = [
+            db_mock.get_sample_key_limit(
+                uuid=uuid.uuid4(), key_uuid=key.uuid, category='budget'
+            ),
+            db_mock.get_sample_key_limit(
+                uuid=uuid.uuid4(),
+                key_uuid=key.uuid,
+                category='request_rate',
+                window_size='1 hour',
+            ),
+        ]
+        inserted = self.key_limit_dao.insert_many(limits)
+        assert len(inserted) == 2
+        assert len(self.key_limit_dao.get_by_key_uuid(key.uuid)) == 2
+
+    def test_insert_many_is_atomic_on_conflict(self):
+        key = self._insert_key()
+        limits = [
+            db_mock.get_sample_key_limit(
+                uuid=uuid.uuid4(), key_uuid=key.uuid, category='request_rate'
+            ),
+            # Duplicates the first one: same category/algorithm/window.
+            db_mock.get_sample_key_limit(
+                uuid=uuid.uuid4(), key_uuid=key.uuid, category='request_rate'
+            ),
+        ]
+        pytest.raises(IntegrityError, self.key_limit_dao.insert_many, limits)
+        # Neither row should have been committed.
+        assert self.key_limit_dao.get_by_key_uuid(key.uuid) == []
+
     def test_cascade_delete_on_key_delete(self):
         key = self._insert_key()
         self.key_limit_dao.insert(

--- a/gateway/tests/models/test_credential_limiting.py
+++ b/gateway/tests/models/test_credential_limiting.py
@@ -1,0 +1,71 @@
+import uuid
+
+import pytest
+
+from radicalbit_ai_gateway.models.credential_limiting import (
+    CredentialLimitCategory,
+    CredentialLimitIn,
+    CredentialLimitOut,
+)
+from radicalbit_ai_gateway.models.limiting import LimitingAlgorithmType
+
+
+@pytest.mark.parametrize(
+    'category',
+    [
+        CredentialLimitCategory.RATE,
+        CredentialLimitCategory.TOKEN_INPUT,
+        CredentialLimitCategory.TOKEN_OUTPUT,
+        CredentialLimitCategory.BUDGET,
+    ],
+)
+def test_valid_limit_for_each_category(category):
+    limit_in = CredentialLimitIn(category=category, window_size='1 day', value=10)
+    assert limit_in.category == category
+    assert limit_in.algorithm == LimitingAlgorithmType.FIXED_WINDOW
+
+
+def test_invalid_window_size_for_aligned_fixed_window_rejected():
+    with pytest.raises(ValueError, match='not allowed for ALIGNED_FIXED_WINDOW'):
+        CredentialLimitIn(
+            category=CredentialLimitCategory.BUDGET,
+            algorithm=LimitingAlgorithmType.ALIGNED_FIXED_WINDOW,
+            window_size='3 days',
+            value=10,
+        )
+
+
+def test_value_must_be_positive():
+    with pytest.raises(ValueError):
+        CredentialLimitIn(
+            category=CredentialLimitCategory.BUDGET, window_size='1 day', value=0
+        )
+
+
+def test_to_key_limit_maps_fields():
+    key_uuid = uuid.uuid4()
+    limit_in = CredentialLimitIn(
+        category=CredentialLimitCategory.BUDGET, window_size='1 day', value=10
+    )
+    key_limit = limit_in.to_key_limit(key_uuid)
+    assert key_limit.key_uuid == key_uuid
+    assert key_limit.category == 'budget'
+    assert key_limit.algorithm == 'FIXED_WINDOW'
+    assert key_limit.window_size == '1 day'
+    assert key_limit.max_value == 10
+
+
+def test_credential_limit_out_round_trip():
+    key_uuid = uuid.uuid4()
+    limit_in = CredentialLimitIn(
+        category=CredentialLimitCategory.RATE, window_size='1 minute', value=100
+    )
+    key_limit = limit_in.to_key_limit(key_uuid)
+    # `uuid` has a column default applied at flush time by SQLAlchemy, not at
+    # construction time, so set it explicitly to mimic an already-persisted row.
+    key_limit.uuid = uuid.uuid4()
+    limit_out = CredentialLimitOut.from_key_limit(key_limit)
+    assert limit_out.category == CredentialLimitCategory.RATE
+    assert limit_out.algorithm == LimitingAlgorithmType.FIXED_WINDOW
+    assert limit_out.window_size == '1 minute'
+    assert limit_out.value == 100

--- a/gateway/tests/models/test_credential_limiting.py
+++ b/gateway/tests/models/test_credential_limiting.py
@@ -6,6 +6,7 @@ from radicalbit_ai_gateway.models.credential_limiting import (
     CredentialLimitCategory,
     CredentialLimitIn,
     CredentialLimitOut,
+    CredentialLimitsIn,
 )
 from radicalbit_ai_gateway.models.limiting import LimitingAlgorithmType
 
@@ -53,6 +54,75 @@ def test_to_key_limit_maps_fields():
     assert key_limit.algorithm == 'FIXED_WINDOW'
     assert key_limit.window_size == '1 day'
     assert key_limit.max_value == 10
+
+
+def test_limits_in_requires_at_least_one():
+    with pytest.raises(ValueError):
+        CredentialLimitsIn(limits=[])
+
+
+def test_limits_in_accepts_multiple_different_categories():
+    limits_in = CredentialLimitsIn(
+        limits=[
+            CredentialLimitIn(
+                category=CredentialLimitCategory.RATE, window_size='1 hour', value=10
+            ),
+            CredentialLimitIn(
+                category=CredentialLimitCategory.BUDGET, window_size='1 day', value=5
+            ),
+        ]
+    )
+    assert len(limits_in.limits) == 2
+
+
+def test_limits_in_rejects_duplicate_within_batch():
+    with pytest.raises(ValueError, match='Duplicate limit in request'):
+        CredentialLimitsIn(
+            limits=[
+                CredentialLimitIn(
+                    category=CredentialLimitCategory.BUDGET,
+                    window_size='1 day',
+                    value=10,
+                ),
+                CredentialLimitIn(
+                    category=CredentialLimitCategory.BUDGET,
+                    window_size='1 day',
+                    value=20,
+                ),
+            ]
+        )
+
+
+def test_limits_in_allows_same_category_with_different_window():
+    limits_in = CredentialLimitsIn(
+        limits=[
+            CredentialLimitIn(
+                category=CredentialLimitCategory.BUDGET, window_size='1 day', value=1
+            ),
+            CredentialLimitIn(
+                category=CredentialLimitCategory.BUDGET, window_size='1 month', value=15
+            ),
+        ]
+    )
+    assert len(limits_in.limits) == 2
+
+
+def test_to_key_limits_maps_all_entries():
+    key_uuid = uuid.uuid4()
+    limits_in = CredentialLimitsIn(
+        limits=[
+            CredentialLimitIn(
+                category=CredentialLimitCategory.RATE, window_size='1 hour', value=10
+            ),
+            CredentialLimitIn(
+                category=CredentialLimitCategory.BUDGET, window_size='1 day', value=5
+            ),
+        ]
+    )
+    key_limits = limits_in.to_key_limits(key_uuid)
+    assert len(key_limits) == 2
+    assert all(kl.key_uuid == key_uuid for kl in key_limits)
+    assert {kl.category for kl in key_limits} == {'request_rate', 'budget'}
 
 
 def test_credential_limit_out_round_trip():

--- a/gateway/tests/routes/test_key_route.py
+++ b/gateway/tests/routes/test_key_route.py
@@ -115,7 +115,7 @@ class TestKeyRoute(unittest.TestCase):
         res = self.client.get(f'{self.prefix}/keys/{key.uuid}')
         assert res.status_code == 200
         assert jsonable_encoder(key_out) == res.json()
-        self.key_service.get_key_by_uuid.assert_called_once_with(key.uuid, False)
+        self.key_service.get_key_by_uuid.assert_called_once_with(key.uuid, False, False)
 
     def test_get_missing_key_by_uuid(self):
         key = db_mock.get_sample_key()
@@ -130,7 +130,7 @@ class TestKeyRoute(unittest.TestCase):
                 'error', 'auth_registry_error', code='key_not_found', param=None
             ).error
         )
-        self.key_service.get_key_by_uuid.assert_called_once_with(key.uuid, False)
+        self.key_service.get_key_by_uuid.assert_called_once_with(key.uuid, False, False)
 
     def test_update_key_name(self):
         key_in = db_mock.get_sample_key_in()
@@ -268,4 +268,35 @@ class TestKeyRoute(unittest.TestCase):
         )
         self.key_service.get_associable_groups.assert_called_once_with(
             key.uuid, False, False
+        )
+
+    def test_add_limit_to_key_success(self):
+        key = db_mock.get_sample_key()
+        limit_in = db_mock.get_sample_credential_limit_in()
+        key_out = db_mock.get_sample_key_full_out()
+        self.key_service.add_limit_to_key = MagicMock(return_value=key_out)
+        res = self.client.post(
+            f'{self.prefix}/keys/{key.uuid}/limits',
+            json=jsonable_encoder(limit_in),
+        )
+        assert res.status_code == 201
+        assert res.json() == jsonable_encoder(key_out)
+        self.key_service.add_limit_to_key.assert_called_once_with(key.uuid, limit_in)
+
+    def test_add_limit_to_key_not_found(self):
+        key = db_mock.get_sample_key()
+        limit_in = db_mock.get_sample_credential_limit_in()
+        self.key_service.add_limit_to_key = MagicMock(
+            side_effect=KeyNotFoundError('error')
+        )
+        res = self.client.post(
+            f'{self.prefix}/keys/{key.uuid}/limits',
+            json=jsonable_encoder(limit_in),
+        )
+        assert res.status_code == 404
+        assert (
+            res.json()['error']
+            == ErrorOut(
+                'error', 'auth_registry_error', code='key_not_found', param=None
+            ).error
         )

--- a/gateway/tests/routes/test_key_route.py
+++ b/gateway/tests/routes/test_key_route.py
@@ -9,6 +9,7 @@ from starlette.testclient import TestClient
 from tests.common import db_mock
 
 from radicalbit_ai_gateway.models.auth_dto import GroupFullOut, KeyFullOut
+from radicalbit_ai_gateway.models.credential_limiting import CredentialLimitOut
 from radicalbit_ai_gateway.routes.key_route import KeyRoute
 from radicalbit_ai_gateway.services.key_service import KeyService
 from radicalbit_ai_gateway.utils.exceptions import (
@@ -270,29 +271,56 @@ class TestKeyRoute(unittest.TestCase):
             key.uuid, False, False
         )
 
-    def test_add_limit_to_key_success(self):
+    def test_add_limits_to_key_success(self):
         key = db_mock.get_sample_key()
-        limit_in = db_mock.get_sample_credential_limit_in()
+        limits_in = db_mock.get_sample_credential_limits_in()
         key_out = db_mock.get_sample_key_full_out()
-        self.key_service.add_limit_to_key = MagicMock(return_value=key_out)
+        self.key_service.add_limits_to_key = MagicMock(return_value=key_out)
         res = self.client.post(
             f'{self.prefix}/keys/{key.uuid}/limits',
-            json=jsonable_encoder(limit_in),
+            json=jsonable_encoder(limits_in),
         )
         assert res.status_code == 201
         assert res.json() == jsonable_encoder(key_out)
-        self.key_service.add_limit_to_key.assert_called_once_with(key.uuid, limit_in)
+        self.key_service.add_limits_to_key.assert_called_once_with(
+            key.uuid, limits_in, False
+        )
 
-    def test_add_limit_to_key_not_found(self):
+    def test_add_limits_to_key_not_found(self):
         key = db_mock.get_sample_key()
-        limit_in = db_mock.get_sample_credential_limit_in()
-        self.key_service.add_limit_to_key = MagicMock(
+        limits_in = db_mock.get_sample_credential_limits_in()
+        self.key_service.add_limits_to_key = MagicMock(
             side_effect=KeyNotFoundError('error')
         )
         res = self.client.post(
             f'{self.prefix}/keys/{key.uuid}/limits',
-            json=jsonable_encoder(limit_in),
+            json=jsonable_encoder(limits_in),
         )
+        assert res.status_code == 404
+        assert (
+            res.json()['error']
+            == ErrorOut(
+                'error', 'auth_registry_error', code='key_not_found', param=None
+            ).error
+        )
+
+    def test_get_limits_for_key_success(self):
+        key = db_mock.get_sample_key()
+        limit_out = CredentialLimitOut.from_key_limit(
+            db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key.uuid)
+        )
+        self.key_service.get_limits_for_key = MagicMock(return_value=[limit_out])
+        res = self.client.get(f'{self.prefix}/keys/{key.uuid}/limits')
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder([limit_out])
+        self.key_service.get_limits_for_key.assert_called_once_with(key.uuid)
+
+    def test_get_limits_for_key_not_found(self):
+        key = db_mock.get_sample_key()
+        self.key_service.get_limits_for_key = MagicMock(
+            side_effect=KeyNotFoundError('error')
+        )
+        res = self.client.get(f'{self.prefix}/keys/{key.uuid}/limits')
         assert res.status_code == 404
         assert (
             res.json()['error']

--- a/gateway/tests/services/key_service_test.py
+++ b/gateway/tests/services/key_service_test.py
@@ -435,7 +435,7 @@ class KeyServiceTest(unittest.TestCase):
 
     def test_add_limits_to_key_duplicate_raises(self):
         key_uuid = uuid.uuid4()
-        key = db_mock.get_sample_key(uuid=key_uuid)
+        key = db_mock.get_sample_key(uuid=key_uuid, name='my-credential')
         self.key_dao.get_by_uuid = MagicMock(return_value=key)
         self.key_limit_dao.insert_many = MagicMock(
             side_effect=IntegrityError(
@@ -447,12 +447,14 @@ class KeyServiceTest(unittest.TestCase):
                 ),
             )
         )
-        pytest.raises(
-            CredentialLimitAlreadyExistsError,
-            self.key_service.add_limits_to_key,
-            key_uuid,
-            db_mock.get_sample_credential_limits_in(),
-        )
+        with pytest.raises(CredentialLimitAlreadyExistsError) as exc_info:
+            self.key_service.add_limits_to_key(
+                key_uuid, db_mock.get_sample_credential_limits_in()
+            )
+        # The message should reference the credential by name, not by UUID,
+        # so it's actually readable to whoever hits this error.
+        assert 'my-credential' in str(exc_info.value)
+        assert str(key_uuid) not in str(exc_info.value)
 
     def test_get_limits_for_key_ok(self):
         key_uuid = uuid.uuid4()

--- a/gateway/tests/services/key_service_test.py
+++ b/gateway/tests/services/key_service_test.py
@@ -3,20 +3,24 @@ from unittest.mock import MagicMock
 import uuid
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from tests.common import db_mock
 
 from radicalbit_ai_gateway.db.dao.group_dao import GroupDAO
 from radicalbit_ai_gateway.db.dao.key_dao import KeyDAO
+from radicalbit_ai_gateway.db.dao.key_limit_dao import KeyLimitDAO
 from radicalbit_ai_gateway.models.auth_dto import (
     GroupFullOut,
     GroupOut,
     KeyFullOut,
     KeyGroupIn,
 )
+from radicalbit_ai_gateway.models.credential_limiting import CredentialLimitOut
 from radicalbit_ai_gateway.services.api_key_security import ApiKeySecurity
 from radicalbit_ai_gateway.services.key_service import KeyService
 from radicalbit_ai_gateway.utils.exceptions import (
+    CredentialLimitAlreadyExistsError,
     KeyGroupAlreadyExistsError,
     KeyInternalError,
     KeyNotFoundError,
@@ -30,12 +34,14 @@ class KeyServiceTest(unittest.TestCase):
         cls.key_dao: KeyDAO = MagicMock(spec_set=KeyDAO)
         cls.group_dao: GroupDAO = MagicMock(spec_set=GroupDAO)
         cls.api_key_security: ApiKeySecurity = MagicMock(spec_set=ApiKeySecurity)
+        cls.key_limit_dao: KeyLimitDAO = MagicMock(spec_set=KeyLimitDAO)
         cls.key_service = KeyService(
             key_dao=cls.key_dao,
             api_key_security=cls.api_key_security,
             group_dao=cls.group_dao,
+            key_limit_dao=cls.key_limit_dao,
         )
-        cls.mocks = [cls.key_dao, cls.group_dao]
+        cls.mocks = [cls.key_dao, cls.group_dao, cls.key_limit_dao]
 
     def test_create_key_ok(self):
         key = db_mock.get_sample_key()
@@ -351,3 +357,80 @@ class KeyServiceTest(unittest.TestCase):
             group_uuid,
         )
         self.key_dao.remove_group.assert_not_called()
+
+    def test_add_limit_to_key_ok(self):
+        key_uuid = uuid.uuid4()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        limit = db_mock.get_sample_key_limit(key_uuid=key_uuid)
+        key.limits = [limit]
+        limit_in = db_mock.get_sample_credential_limit_in()
+        self.key_dao.get_by_uuid = MagicMock(return_value=key)
+        self.key_limit_dao.insert = MagicMock(return_value=limit)
+        res = self.key_service.add_limit_to_key(key_uuid, limit_in)
+        self.key_limit_dao.insert.assert_called_once()
+        assert res.limits == [CredentialLimitOut.from_key_limit(limit)]
+        assert res == KeyFullOut.from_key_obscured(key, include_limits=True)
+
+    def test_add_limit_to_key_not_found(self):
+        self.key_dao.get_by_uuid = MagicMock(return_value=None)
+        self.key_limit_dao.insert = MagicMock()
+        pytest.raises(
+            KeyNotFoundError,
+            self.key_service.add_limit_to_key,
+            uuid.uuid4(),
+            db_mock.get_sample_credential_limit_in(),
+        )
+        self.key_limit_dao.insert.assert_not_called()
+
+    def test_add_limit_to_keycloak_key_raises(self):
+        key_uuid = uuid.uuid4()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        key.owner = 'keycloak'
+        self.key_dao.get_by_uuid = MagicMock(return_value=key)
+        self.key_limit_dao.insert = MagicMock()
+        pytest.raises(
+            KeyOperationNotAllowedError,
+            self.key_service.add_limit_to_key,
+            key_uuid,
+            db_mock.get_sample_credential_limit_in(),
+        )
+        self.key_limit_dao.insert.assert_not_called()
+
+    def test_add_limit_to_key_duplicate_raises(self):
+        key_uuid = uuid.uuid4()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        self.key_dao.get_by_uuid = MagicMock(return_value=key)
+        self.key_limit_dao.insert = MagicMock(
+            side_effect=IntegrityError(
+                'INSERT',
+                {},
+                Exception(
+                    'duplicate key value violates unique constraint '
+                    '"uq_key_limit_KEY_UUID_CATEGORY_ALGORITHM_WINDOW_SIZE"'
+                ),
+            )
+        )
+        pytest.raises(
+            CredentialLimitAlreadyExistsError,
+            self.key_service.add_limit_to_key,
+            key_uuid,
+            db_mock.get_sample_credential_limit_in(),
+        )
+
+    def test_get_limits_for_key_ok(self):
+        key_uuid = uuid.uuid4()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        limits = [db_mock.get_sample_key_limit(key_uuid=key_uuid)]
+        self.key_dao.get_by_uuid = MagicMock(return_value=key)
+        self.key_limit_dao.get_by_key_uuid = MagicMock(return_value=limits)
+        res = self.key_service.get_limits_for_key(key_uuid)
+        self.key_limit_dao.get_by_key_uuid.assert_called_once_with(key_uuid)
+        assert res == [CredentialLimitOut.from_key_limit(limits[0])]
+
+    def test_get_limits_for_key_not_found(self):
+        self.key_dao.get_by_uuid = MagicMock(return_value=None)
+        pytest.raises(
+            KeyNotFoundError,
+            self.key_service.get_limits_for_key,
+            uuid.uuid4(),
+        )

--- a/gateway/tests/services/key_service_test.py
+++ b/gateway/tests/services/key_service_test.py
@@ -16,7 +16,10 @@ from radicalbit_ai_gateway.models.auth_dto import (
     KeyFullOut,
     KeyGroupIn,
 )
-from radicalbit_ai_gateway.models.credential_limiting import CredentialLimitOut
+from radicalbit_ai_gateway.models.credential_limiting import (
+    CredentialLimitCategory,
+    CredentialLimitOut,
+)
 from radicalbit_ai_gateway.services.api_key_security import ApiKeySecurity
 from radicalbit_ai_gateway.services.key_service import KeyService
 from radicalbit_ai_gateway.utils.exceptions import (
@@ -358,49 +361,83 @@ class KeyServiceTest(unittest.TestCase):
         )
         self.key_dao.remove_group.assert_not_called()
 
-    def test_add_limit_to_key_ok(self):
+    def test_add_limits_to_key_ok(self):
         key_uuid = uuid.uuid4()
         key = db_mock.get_sample_key(uuid=key_uuid)
         limit = db_mock.get_sample_key_limit(key_uuid=key_uuid)
         key.limits = [limit]
-        limit_in = db_mock.get_sample_credential_limit_in()
+        limits_in = db_mock.get_sample_credential_limits_in()
         self.key_dao.get_by_uuid = MagicMock(return_value=key)
-        self.key_limit_dao.insert = MagicMock(return_value=limit)
-        res = self.key_service.add_limit_to_key(key_uuid, limit_in)
-        self.key_limit_dao.insert.assert_called_once()
+        self.key_limit_dao.insert_many = MagicMock(return_value=[limit])
+        res = self.key_service.add_limits_to_key(key_uuid, limits_in)
+        self.key_limit_dao.insert_many.assert_called_once()
         assert res.limits == [CredentialLimitOut.from_key_limit(limit)]
         assert res == KeyFullOut.from_key_obscured(key, include_limits=True)
 
-    def test_add_limit_to_key_not_found(self):
+    def test_add_limits_to_key_with_groups(self):
+        key_uuid = uuid.uuid4()
+        group = db_mock.get_sample_group()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        key.group = group
+        key.limits = []
+        limits_in = db_mock.get_sample_credential_limits_in()
+        self.key_dao.get_by_uuid = MagicMock(return_value=key)
+        self.key_limit_dao.insert_many = MagicMock(return_value=[])
+        res = self.key_service.add_limits_to_key(
+            key_uuid, limits_in, include_groups=True
+        )
+        assert res.group == GroupOut.from_group(group)
+
+    def test_add_limits_to_key_multiple_categories(self):
+        key_uuid = uuid.uuid4()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        limits_in = db_mock.get_sample_credential_limits_in(
+            limits=[
+                db_mock.get_sample_credential_limit_in(
+                    category=CredentialLimitCategory.RATE, window_size='1 hour'
+                ),
+                db_mock.get_sample_credential_limit_in(
+                    category=CredentialLimitCategory.BUDGET, window_size='1 day'
+                ),
+            ]
+        )
+        self.key_dao.get_by_uuid = MagicMock(return_value=key)
+        self.key_limit_dao.insert_many = MagicMock(return_value=[])
+        self.key_service.add_limits_to_key(key_uuid, limits_in)
+        inserted = self.key_limit_dao.insert_many.call_args[0][0]
+        assert len(inserted) == 2
+        assert {limit.category for limit in inserted} == {'request_rate', 'budget'}
+
+    def test_add_limits_to_key_not_found(self):
         self.key_dao.get_by_uuid = MagicMock(return_value=None)
-        self.key_limit_dao.insert = MagicMock()
+        self.key_limit_dao.insert_many = MagicMock()
         pytest.raises(
             KeyNotFoundError,
-            self.key_service.add_limit_to_key,
+            self.key_service.add_limits_to_key,
             uuid.uuid4(),
-            db_mock.get_sample_credential_limit_in(),
+            db_mock.get_sample_credential_limits_in(),
         )
-        self.key_limit_dao.insert.assert_not_called()
+        self.key_limit_dao.insert_many.assert_not_called()
 
-    def test_add_limit_to_keycloak_key_raises(self):
+    def test_add_limits_to_keycloak_key_raises(self):
         key_uuid = uuid.uuid4()
         key = db_mock.get_sample_key(uuid=key_uuid)
         key.owner = 'keycloak'
         self.key_dao.get_by_uuid = MagicMock(return_value=key)
-        self.key_limit_dao.insert = MagicMock()
+        self.key_limit_dao.insert_many = MagicMock()
         pytest.raises(
             KeyOperationNotAllowedError,
-            self.key_service.add_limit_to_key,
+            self.key_service.add_limits_to_key,
             key_uuid,
-            db_mock.get_sample_credential_limit_in(),
+            db_mock.get_sample_credential_limits_in(),
         )
-        self.key_limit_dao.insert.assert_not_called()
+        self.key_limit_dao.insert_many.assert_not_called()
 
-    def test_add_limit_to_key_duplicate_raises(self):
+    def test_add_limits_to_key_duplicate_raises(self):
         key_uuid = uuid.uuid4()
         key = db_mock.get_sample_key(uuid=key_uuid)
         self.key_dao.get_by_uuid = MagicMock(return_value=key)
-        self.key_limit_dao.insert = MagicMock(
+        self.key_limit_dao.insert_many = MagicMock(
             side_effect=IntegrityError(
                 'INSERT',
                 {},
@@ -412,9 +449,9 @@ class KeyServiceTest(unittest.TestCase):
         )
         pytest.raises(
             CredentialLimitAlreadyExistsError,
-            self.key_service.add_limit_to_key,
+            self.key_service.add_limits_to_key,
             key_uuid,
-            db_mock.get_sample_credential_limit_in(),
+            db_mock.get_sample_credential_limits_in(),
         )
 
     def test_get_limits_for_key_ok(self):

--- a/gateway/tests/test_validation_exception_handler.py
+++ b/gateway/tests/test_validation_exception_handler.py
@@ -1,0 +1,45 @@
+"""Regression test for the RequestValidationError handler.
+
+A pydantic model_validator(mode='after') that raises a plain ValueError (the
+documented, idiomatic way to fail cross-field validation) puts the raw
+exception object in the `ctx.error` key of exc.errors(). Passing that
+straight to json.dumps crashes with a 500 instead of returning the intended
+422. Reproduced here via CredentialLimitsIn (models/credential_limiting.py),
+whose own model_validator raises ValueError on a duplicate limit in the same
+batch — first found while running an end-to-end test through docker.
+"""
+
+import unittest
+
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+
+from radicalbit_ai_gateway.models.credential_limiting import CredentialLimitsIn
+from radicalbit_ai_gateway.server import validation_exception_handler
+
+
+class TestValidationExceptionHandler(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        app = FastAPI()
+        app.add_exception_handler(RequestValidationError, validation_exception_handler)
+
+        @app.post('/limits')
+        def _create_limits(limits_in: CredentialLimitsIn):
+            return limits_in.model_dump()
+
+        cls.client = TestClient(app)
+
+    def test_model_validator_value_error_returns_422_not_500(self):
+        res = self.client.post(
+            '/limits',
+            json={
+                'limits': [
+                    {'category': 'budget', 'windowSize': '1 day', 'value': 10},
+                    {'category': 'budget', 'windowSize': '1 day', 'value': 20},
+                ],
+            },
+        )
+        assert res.status_code == 422
+        assert 'Duplicate limit in request' in res.text


### PR DESCRIPTION
# PR Summary: feat/AG-918-credential-level-limiting

Adds per-credential rate/token/budget limits: a new `key_limit` table, DTOs, and REST endpoints to create (in batch) and list limits on an individual credential (`owner == 'gateway'`). 
This is configuration only: no runtime enforcement is included here. Also includes two small BE bugfixes surfaced while
end-to-end testing this feature.

---

## DTO Changes

### `CredentialLimitIn` (NEW)

| Field | Type | Description |
|-------|------|--------------|
| `category` | string | One of: `request_rate`, `token_input`, `token_output`, `budget` |
| `algorithm` | string | One of: `FIXED_WINDOW`, `ALIGNED_FIXED_WINDOW`. Defaults to `FIXED_WINDOW` |
| `windowSize` | string or integer | Time window, e.g. `"1 day"`, `"1 hour"`, or seconds as an integer |
| `value` | float | Threshold: request count, token count, or budget amount depending on `category`. Must be > 0 |

Reuses the same algorithm/window validation already defined on the
route-level `Limiting` model (incl. the allowed-window-size restriction for
`ALIGNED_FIXED_WINDOW`) instead of duplicating it.

**Example:**
```json
{
  "category": "budget",
  "algorithm": "FIXED_WINDOW",
  "windowSize": "1 day",
  "value": 10.0
}
```

### `CredentialLimitsIn` (NEW)

| Field | Type | Description |
|-------|------|--------------|
| `limits` | `CredentialLimitIn[]` | One or more limits to create in a single call, min length 1 |

All-or-nothing: inserted in one DB transaction, so either every limit in the
batch is created or none is. Rejects a batch containing two entries with the
same `category` + `algorithm` + `windowSize` (`422`) — this is on top of,
not instead of, rejecting a duplicate against an *already-existing* limit on
that credential (`400`, see below).

**Example request body:**
```json
{
  "limits": [
    {"category": "request_rate", "windowSize": "1 hour", "value": 100},
    {"category": "budget", "windowSize": "1 day", "value": 5}
  ]
}
```

### `CredentialLimitOut` (NEW)

| Field | Type | Description |
|-------|------|--------------|
| `uuid` | string | Limit identifier |
| `category` | string | One of: `request_rate`, `token_input`, `token_output`, `budget` |
| `algorithm` | string | One of: `FIXED_WINDOW`, `ALIGNED_FIXED_WINDOW` |
| `windowSize` | string | Time window as stored, e.g. `"1 day"` |
| `value` | float | Threshold value |
| `createdAt` | string | Creation timestamp |
| `updatedAt` | string | Last-update timestamp |

**Example response:**
```json
{
  "uuid": "3ac9f960-6887-44c6-b2ac-59c3f5345149",
  "category": "request_rate",
  "algorithm": "FIXED_WINDOW",
  "windowSize": "1 hour",
  "value": 100.0,
  "createdAt": "2026-09-04 15:44:43.921405+00:00",
  "updatedAt": "2026-09-04 15:44:43.921405+00:00"
}
```

**Used by:** `POST /keys/{key_uuid}/limits`, `GET /keys/{key_uuid}/limits`, and nested in `KeyFullOut.limits`

---

### `KeyFullOut` (MODIFIED)

**Changes:**
```diff
  uuid: string
  name: string
  owner: string
  metadata: object | null
  hashedKey: string
  apiKey: string
  group: GroupOut | null
+ limits: CredentialLimitOut[] | null
  createdAt: string
  updatedAt: string
```

| Field | Type | Description |
|-------|------|--------------|
| `uuid` | string | Credential identifier |
| `name` | string | Credential name |
| `owner` | string | `"gateway"` (created via API) or `"keycloak"` (SSO-provisioned) |
| `metadata` | object or null | Free-form metadata |
| `hashedKey` | string | Hashed API key |
| `apiKey` | string | Obscured (or, on creation, plain) API key |
| `group` | object or null | Associated group, only populated when `include_groups=true` |
| `limits` **NEW** | `CredentialLimitOut[]` or null | Configured limits, only populated when `include_limits=true` |
| `createdAt` | string | Creation timestamp |
| `updatedAt` | string | Last-update timestamp |

`limits` follows the exact same on-demand convention already used by
`group`/`include_groups`: `null` unless the caller opts in via
`include_limits=true`.

**Example response** (`GET /keys/{uuid}?include_groups=true&include_limits=true`):
```json
{
  "uuid": "09b5512c-2b11-4abb-9ff5-b499b2dc8307",
  "name": "e2e-limit-test",
  "owner": "gateway",
  "metadata": null,
  "hashedKey": "7aa8c8bc096af33fd6ed46f65845c04a10b39ea089ffcf99d0edce3c51b0831a",
  "apiKey": "sk-rb-cV...nFn",
  "createdAt": "2026-09-04 15:44:43.848620+00:00",
  "updatedAt": "2026-09-04 15:44:43.848620+00:00",
  "group": null,
  "limits": [
    {
      "uuid": "3ac9f960-6887-44c6-b2ac-59c3f5345149",
      "category": "request_rate",
      "algorithm": "FIXED_WINDOW",
      "windowSize": "1 hour",
      "value": 100.0,
      "createdAt": "2026-09-04 15:44:43.921405+00:00",
      "updatedAt": "2026-09-04 15:44:43.921405+00:00"
    }
  ]
}
```

**Used by:** `GET /keys`, `GET /keys/{key_uuid}`, `POST /keys`, `POST /keys/{key_uuid}/limits`, `PATCH /keys/{key_uuid}/group`

---

## Affected Endpoints

### `POST /keys/{key_uuid}/limits` (NEW)

Creates one or more limits on a credential in a single, atomic call.

**Example request:**
```
POST /keys/09b5512c-2b11-4abb-9ff5-b499b2dc8307/limits?include_groups=true
```
```json
{
  "limits": [
    {"category": "request_rate", "windowSize": "1 hour", "value": 100},
    {"category": "budget", "windowSize": "1 day", "value": 5}
  ]
}
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `key_uuid` | string | yes | Credential UUID (path) |
| `include_groups` | boolean | no | Include the credential's group in the response. Default `false` |

Returns `201` with the full `KeyFullOut` (limits always included). Fails
with `400 credential_limit_already_exists_bad_request` if any requested
limit duplicates one already on the credential, `404` if the credential
doesn't exist, `405` if it's not `owner == 'gateway'` (SSO-provisioned
credentials aren't supported yet), `422` on a duplicate
*within* the submitted batch.

### `GET /keys/{key_uuid}/limits` (NEW)

**Example request:**
```
GET /keys/09b5512c-2b11-4abb-9ff5-b499b2dc8307/limits
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `key_uuid` | string | yes | Credential UUID (path) |

Returns `200` with a `CredentialLimitOut[]` (empty array if none configured), `404` if the credential doesn't exist.

### `GET /keys` (MODIFIED — new optional parameter)

**Changes:**
```diff
  include_groups: boolean (optional)
  only_unassigned: boolean (optional)
+ include_limits: boolean (optional)
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `include_groups` | boolean | no | Include each credential's group |
| `only_unassigned` | boolean | no | Only return credentials with no group |
| `include_limits` **NEW** | boolean | no | Include each credential's configured limits. Default `false` |

### `GET /keys/{key_uuid}` (MODIFIED — new optional parameter)

**Changes:**
```diff
  include_groups: boolean (optional)
+ include_limits: boolean (optional)
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `key_uuid` | string | yes | Credential UUID (path) |
| `include_groups` | boolean | no | Include the credential's group |
| `include_limits` **NEW** | boolean | no | Include the credential's configured limits. Default `false` |

---

## Other Changes

- **New table `key_limit`** (`db/tables/key_limit_table.py` + Alembic
  migration `b7c8d9e0f1a2`): `UUID` PK, `KEY_UUID` FK → `key.UUID` with
  `ON DELETE CASCADE`, `CATEGORY`/`ALGORITHM`/`WINDOW_SIZE`/`MAX_VALUE`,
  timestamps. Composite unique constraint on
  `(KEY_UUID, CATEGORY, ALGORITHM, WINDOW_SIZE)` — this is what backs the
  400/422 duplicate rejections above.
- `db/tables/key_table.py` — new `limits` relationship (`Key.limits`,
  cascade delete-orphan) mirroring the existing `group` relationship.
- `db/dao/key_limit_dao.py` (NEW) — `insert`, `insert_many` (single
  transaction), `get_by_uuid`, `get_by_key_uuid`, `get_all_by_key_uuids`.
- `services/key_service.py` — `add_limits_to_key()` (owner check, batch
  insert, duplicate → `CredentialLimitAlreadyExistsError` with the
  credential's **name**, not its UUID, in the message) and
  `get_limits_for_key()`; `get_all()`/`get_key_by_uuid()`/`_get_key()`
  extended with `include_limits`.
- `utils/exceptions.py` — new `CredentialLimitAlreadyExistsError` (400,
  code `credential_limit_already_exists_bad_request`).
- `server.py` — wires up `KeyLimitDAO` into `KeyService`.
- **Bugfix, `server.py`** — `validation_exception_handler` passed
  `exc.errors()` straight into `JSONResponse`, but a pydantic
  `model_validator` that raises a plain `ValueError` (the idiomatic pattern,
  used here by `CredentialLimitsIn`'s intra-batch duplicate check) puts the
  raw exception object in `ctx.error`, which plain `json.dumps` can't
  serialize — this crashed with a `500` instead of returning the intended
  `422`. Fixed by wrapping with `jsonable_encoder`. Pre-existing bug, not
  specific to this feature; found via this feature's Docker end-to-end
  test. New regression test: `tests/test_validation_exception_handler.py`.
- Scope note: credential-level limits are currently restricted to
  `owner == 'gateway'` credentials. `owner == 'keycloak'` (SSO-provisioned)
  credentials are periodically deleted/recreated by the IDP sync job with a
  new UUID, which would silently drop their limits via the `ON DELETE
  CASCADE` FK — extending support to those is tracked separately.
- Test coverage: `tests/dao/key_limit_dao_test.py` (incl. FK cascade-delete
  and atomic-batch-rollback-on-conflict), `tests/models/test_credential_limiting.py`,
  `tests/services/key_service_test.py`, `tests/routes/test_key_route.py` —
  all extended for the new behavior.
- Also fixed a pre-existing flaky bug in the DB test harness itself
  (`tests/common/db_integration.py::_sanitize_unique_constraints`): for a
  composite `UNIQUE` constraint, non-deterministic set iteration order could
  cause *both* the declared and the reflected copy of the constraint to be
  removed instead of deduplicated to one, silently dropping the constraint
  from the test schema. Made deterministic; verified with 5 consecutive
  runs. Unrelated to this feature's own code but surfaced by
  `key_limit`'s composite unique constraint.
