### PR TITLE
feat(api): add project budget limits

### DIFF
--- a/gateway/alembic/versions/b79da332d03f_add_project_budget_limit_table.py
+++ b/gateway/alembic/versions/b79da332d03f_add_project_budget_limit_table.py
@@ -1,0 +1,48 @@
+"""add_project_budget_limit_table
+
+Revision ID: b79da332d03f
+Revises: b7c8d9e0f1a2
+Create Date: 2026-09-07 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b79da332d03f'
+down_revision: Union[str, Sequence[str], None] = 'b7c8d9e0f1a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'project_budget_limit',
+        sa.Column('UUID', sa.UUID(), nullable=False),
+        sa.Column('PROJECT_UUID', sa.UUID(), nullable=False),
+        sa.Column('ALGORITHM', sa.VARCHAR(), nullable=False),
+        sa.Column('WINDOW_SIZE', sa.VARCHAR(), nullable=False),
+        sa.Column('MAX_VALUE', sa.NUMERIC(), nullable=False),
+        sa.Column('CREATED_AT', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('UPDATED_AT', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('UUID', name=op.f('pk_project_budget_limit')),
+        sa.ForeignKeyConstraint(
+            ['PROJECT_UUID'],
+            ['project.UUID'],
+            name=op.f('fk_project_budget_limit_PROJECT_UUID_project'),
+            ondelete='CASCADE',
+        ),
+        sa.UniqueConstraint(
+            'PROJECT_UUID',
+            'WINDOW_SIZE',
+            name='uq_project_budget_limit_PROJECT_UUID_WINDOW_SIZE',
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('project_budget_limit')

--- a/gateway/radicalbit_ai_gateway/db/dao/project_budget_limit_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_budget_limit_dao.py
@@ -1,0 +1,45 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+
+from radicalbit_ai_gateway.db.database import Database
+from radicalbit_ai_gateway.db.tables.project_budget_limit_table import (
+    ProjectBudgetLimit,
+)
+
+
+class ProjectBudgetLimitDAO:
+    def __init__(self, database: Database):
+        self.db = database
+
+    def insert(self, project_budget_limit: ProjectBudgetLimit) -> ProjectBudgetLimit:
+        with self.db.begin_session() as session:
+            session.add(project_budget_limit)
+            session.flush()
+            return project_budget_limit
+
+    def insert_many(
+        self, project_budget_limits: list[ProjectBudgetLimit]
+    ) -> list[ProjectBudgetLimit]:
+        """Insert all limits in a single transaction: either all succeed, or
+        none do (e.g. if one duplicates an existing or another batch entry).
+        """
+        with self.db.begin_session() as session:
+            session.add_all(project_budget_limits)
+            session.flush()
+            return project_budget_limits
+
+    def get_by_uuid(self, limit_uuid: UUID) -> ProjectBudgetLimit | None:
+        with self.db.begin_session() as session:
+            stmt = select(ProjectBudgetLimit).where(
+                ProjectBudgetLimit.uuid == limit_uuid
+            )
+            return session.scalar(stmt)
+
+    def get_by_project_uuid(self, project_uuid: UUID) -> Sequence[ProjectBudgetLimit]:
+        with self.db.begin_session() as session:
+            stmt = select(ProjectBudgetLimit).where(
+                ProjectBudgetLimit.project_uuid == project_uuid
+            )
+            return session.scalars(stmt).all()

--- a/gateway/radicalbit_ai_gateway/db/tables/project_budget_limit_table.py
+++ b/gateway/radicalbit_ai_gateway/db/tables/project_budget_limit_table.py
@@ -1,0 +1,44 @@
+import uuid
+
+from sqlalchemy import (
+    NUMERIC,
+    TIMESTAMP,
+    UUID,
+    VARCHAR,
+    Column,
+    ForeignKey,
+    UniqueConstraint,
+)
+
+from radicalbit_ai_gateway.db.dao.base_dao import BaseDAO
+from radicalbit_ai_gateway.db.database import BaseTable, Reflected
+
+
+class ProjectBudgetLimit(Reflected, BaseTable, BaseDAO):
+    __tablename__ = 'project_budget_limit'
+    __table_args__ = (
+        UniqueConstraint(
+            'PROJECT_UUID',
+            'WINDOW_SIZE',
+            name='uq_project_budget_limit_PROJECT_UUID_WINDOW_SIZE',
+        ),
+    )
+
+    uuid = Column(
+        'UUID',
+        UUID(as_uuid=True),
+        nullable=False,
+        default=uuid.uuid4,
+        primary_key=True,
+    )
+    project_uuid = Column(
+        'PROJECT_UUID',
+        UUID(as_uuid=True),
+        ForeignKey('project.UUID', ondelete='CASCADE'),
+        nullable=False,
+    )
+    algorithm = Column('ALGORITHM', VARCHAR(), nullable=False)
+    window_size = Column('WINDOW_SIZE', VARCHAR(), nullable=False)
+    max_value = Column('MAX_VALUE', NUMERIC(), nullable=False)
+    created_at = Column('CREATED_AT', TIMESTAMP(timezone=True), nullable=False)
+    updated_at = Column('UPDATED_AT', TIMESTAMP(timezone=True), nullable=False)

--- a/gateway/radicalbit_ai_gateway/models/project_budget_limiting.py
+++ b/gateway/radicalbit_ai_gateway/models/project_budget_limiting.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic.alias_generators import to_camel
+
+from radicalbit_ai_gateway.db.tables.project_budget_limit_table import (
+    ProjectBudgetLimit,
+)
+from radicalbit_ai_gateway.models.limiting import Limiting, LimitingAlgorithmType
+
+
+class ProjectBudgetLimitIn(BaseModel):
+    algorithm: LimitingAlgorithmType = LimitingAlgorithmType.FIXED_WINDOW
+    window_size: int | str = '1 minute'
+    value: float = Field(
+        ...,
+        gt=0,
+        description='Budget threshold for this time window.',
+        examples=[1.0, 15.0],
+    )
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    @model_validator(mode='after')
+    def validate_against_limiting_schema(self) -> ProjectBudgetLimitIn:
+        # Raises ValueError (-> 422) if algorithm/window_size are inconsistent,
+        # reusing the validation already defined on `Limiting`.
+        Limiting(
+            algorithm=self.algorithm,
+            window_size=self.window_size,
+            max_budget=self.value,
+        )
+        return self
+
+    def to_project_budget_limit(self, project_uuid: UUID) -> ProjectBudgetLimit:
+        UTC = getattr(datetime, 'UTC', datetime.timezone.utc)
+        now = datetime.datetime.now(tz=UTC)
+        return ProjectBudgetLimit(
+            project_uuid=project_uuid,
+            algorithm=self.algorithm.value,
+            window_size=str(self.window_size),
+            max_value=self.value,
+            created_at=now,
+            updated_at=now,
+        )
+
+
+class ProjectBudgetLimitsIn(BaseModel):
+    """A batch of budget limits to create on a project in a single call — e.g.
+    a daily and a monthly budget configured together from one UI form submission.
+    """
+
+    limits: list[ProjectBudgetLimitIn] = Field(..., min_length=1)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    @model_validator(mode='after')
+    def no_duplicates_within_batch(self) -> ProjectBudgetLimitsIn:
+        seen = set()
+        for limit in self.limits:
+            key = (limit.algorithm, str(limit.window_size))
+            if key in seen:
+                raise ValueError(
+                    f'Duplicate limit in request: a budget limit with algorithm '
+                    f'{limit.algorithm.value} and window {limit.window_size} was '
+                    'submitted more than once.'
+                )
+            seen.add(key)
+        return self
+
+    def to_project_budget_limits(self, project_uuid: UUID) -> list[ProjectBudgetLimit]:
+        return [limit.to_project_budget_limit(project_uuid) for limit in self.limits]
+
+
+class ProjectBudgetLimitOut(BaseModel):
+    uuid: UUID
+    algorithm: LimitingAlgorithmType
+    window_size: str
+    value: float
+    created_at: str
+    updated_at: str
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+    @staticmethod
+    def from_project_budget_limit(
+        project_budget_limit: ProjectBudgetLimit,
+    ) -> ProjectBudgetLimitOut:
+        return ProjectBudgetLimitOut(
+            uuid=project_budget_limit.uuid,
+            algorithm=LimitingAlgorithmType(project_budget_limit.algorithm),
+            window_size=project_budget_limit.window_size,
+            value=float(project_budget_limit.max_value),
+            created_at=str(project_budget_limit.created_at),
+            updated_at=str(project_budget_limit.updated_at),
+        )

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -8,6 +8,7 @@ from pydantic.alias_generators import to_camel
 from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
+from radicalbit_ai_gateway.models.project_budget_limiting import ProjectBudgetLimitOut
 from radicalbit_ai_gateway.models.project_status import ProjectStatus
 
 
@@ -126,6 +127,7 @@ class ProjectOut(BaseModel):
     project_status: ProjectStatus
     served_config_uuid: UUID | None
     configs: list[ConfigSlotOut]
+    limits: ProjectBudgetLimitOut | None = None
     created_at: str
     updated_at: str
 
@@ -134,7 +136,11 @@ class ProjectOut(BaseModel):
     )
 
     @staticmethod
-    def from_project(project: Project, configs: list[ProjectConfig]) -> 'ProjectOut':
+    def from_project(
+        project: Project,
+        configs: list[ProjectConfig],
+        limits: ProjectBudgetLimitOut | None = None,
+    ) -> 'ProjectOut':
         ordered = sorted(configs, key=lambda c: c.slot)
         served = next(
             (c for c in ordered if c.config_status == ConfigStatus.SERVED.value),
@@ -147,6 +153,7 @@ class ProjectOut(BaseModel):
             project_status=ProjectStatus.PROD if served else ProjectStatus.DEV,
             served_config_uuid=served.uuid if served else None,
             configs=[ConfigSlotOut.from_config(c) for c in ordered],
+            limits=limits,
             created_at=str(project.created_at),
             updated_at=str(project.updated_at),
         )

--- a/gateway/radicalbit_ai_gateway/models/project_dto.py
+++ b/gateway/radicalbit_ai_gateway/models/project_dto.py
@@ -127,7 +127,7 @@ class ProjectOut(BaseModel):
     project_status: ProjectStatus
     served_config_uuid: UUID | None
     configs: list[ConfigSlotOut]
-    limits: ProjectBudgetLimitOut | None = None
+    limits: list[ProjectBudgetLimitOut] | None = None
     created_at: str
     updated_at: str
 
@@ -139,7 +139,7 @@ class ProjectOut(BaseModel):
     def from_project(
         project: Project,
         configs: list[ProjectConfig],
-        limits: ProjectBudgetLimitOut | None = None,
+        limits: list[ProjectBudgetLimitOut] | None = None,
     ) -> 'ProjectOut':
         ordered = sorted(configs, key=lambda c: c.slot)
         served = next(

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -12,6 +12,10 @@ from radicalbit_ai_gateway.models.auth_dto import (
     RouteGroupsIn,
 )
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
+from radicalbit_ai_gateway.models.project_budget_limiting import (
+    ProjectBudgetLimitOut,
+    ProjectBudgetLimitsIn,
+)
 from radicalbit_ai_gateway.models.project_dto import (
     GenerateConfigIn,
     GenerateConfigOut,
@@ -39,8 +43,8 @@ _ALLOWED_IMPORT_SUFFIXES = ('.yaml', '.yml')
 
 @dataclass
 class ProjectRouteConfig:
-    get_projects_fn: Callable[[Request, ProjectFilter | None], Any] | None = None
-    get_project_fn: Callable[[Request, UUID], Any] | None = None
+    get_projects_fn: Callable[[Request, ProjectFilter | None, bool], Any] | None = None
+    get_project_fn: Callable[[Request, UUID, bool], Any] | None = None
     list_response_model: type = field(default_factory=lambda: list[ProjectOut])
     item_response_model: type = field(default_factory=lambda: ProjectOut)
 
@@ -59,10 +63,12 @@ class ProjectRoute:
     ) -> APIRouter:
         config = config or ProjectRouteConfig()
         get_projects_fn = config.get_projects_fn or (
-            lambda _, f: project_service.get_all_filtered(f)
+            lambda _, f, include_limits: project_service.get_all_filtered(
+                f, include_limits
+            )
         )
         get_project_fn = config.get_project_fn or (
-            lambda _, u: project_service.get_by_uuid(u)
+            lambda _, u, include_limits: project_service.get_by_uuid(u, include_limits)
         )
         router = APIRouter(tags=['project_api'])
 
@@ -79,16 +85,21 @@ class ProjectRoute:
         def get_all(
             request: Request,
             filter: ProjectFilter | None = Query(None),
+            include_limits: bool = Query(False),
         ):
-            return get_projects_fn(request, filter)
+            return get_projects_fn(request, filter, include_limits)
 
         @router.get(
             '/projects/{project_uuid}',
             status_code=200,
             response_model=config.item_response_model,
         )
-        def get_project_by_uuid(project_uuid: UUID, request: Request):
-            return get_project_fn(request, project_uuid)
+        def get_project_by_uuid(
+            project_uuid: UUID,
+            request: Request,
+            include_limits: bool = Query(False),
+        ):
+            return get_project_fn(request, project_uuid, include_limits)
 
         @router.patch(
             '/projects/{project_uuid}/configs/{config_uuid}',
@@ -308,5 +319,36 @@ class ProjectRoute:
             return group_service.get_associable_groups_for_project_route(
                 project.name, route_name, include_routes, include_keys
             )
+
+        @router.post(
+            '/projects/{project_uuid}/budget-limits',
+            status_code=201,
+            response_model=list[ProjectBudgetLimitOut],
+        )
+        @route_meta(
+            entity_type='PROJECT',
+            entity_uuid_param='project_uuid',
+            action='ADD_BUDGET_LIMIT',
+        )
+        def add_budget_limits_to_project(
+            project_uuid: UUID, limits_in: ProjectBudgetLimitsIn
+        ):
+            limits = project_service.add_budget_limits_to_project(
+                project_uuid, limits_in
+            )
+            logger.info(
+                'Added %s budget limit(s) to project %s',
+                len(limits_in.limits),
+                project_uuid,
+            )
+            return limits
+
+        @router.get(
+            '/projects/{project_uuid}/budget-limits',
+            status_code=200,
+            response_model=list[ProjectBudgetLimitOut],
+        )
+        def get_budget_limits_for_project(project_uuid: UUID):
+            return project_service.get_budget_limits_for_project(project_uuid)
 
         return router

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -35,6 +35,7 @@ from radicalbit_ai_gateway.db.dao.group_route_dao import GroupRouteDAO
 from radicalbit_ai_gateway.db.dao.key_dao import KeyDAO
 from radicalbit_ai_gateway.db.dao.key_limit_dao import KeyLimitDAO
 from radicalbit_ai_gateway.db.dao.otel_traces_dao import OtelTracesDAO
+from radicalbit_ai_gateway.db.dao.project_budget_limit_dao import ProjectBudgetLimitDAO
 from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.db.dao.request_event_dao import RequestEventDAO
@@ -188,6 +189,7 @@ group_dao = GroupDAO(database)
 group_route_dao = GroupRouteDAO(database)
 project_dao = ProjectDAO(database)
 project_config_dao = ProjectConfigDAO(database)
+project_budget_limit_dao = ProjectBudgetLimitDAO(database)
 event_dao = EventDAO(ch_database)
 request_event_dao = RequestEventDAO(ch_database)
 otel_traces_dao = OtelTracesDAO(ch_database)
@@ -207,7 +209,9 @@ group_service = GroupService(
     project_configs=project_configs,
 )
 project_service = ProjectService(
-    project_dao=project_dao, project_config_dao=project_config_dao
+    project_dao=project_dao,
+    project_config_dao=project_config_dao,
+    project_budget_limit_dao=project_budget_limit_dao,
 )
 config_generator_service = ConfigGeneratorService()
 event_service = EventService(

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -5,12 +5,17 @@ import zipfile
 
 from sqlalchemy.exc import IntegrityError
 
+from radicalbit_ai_gateway.db.dao.project_budget_limit_dao import ProjectBudgetLimitDAO
 from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
 from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
+from radicalbit_ai_gateway.models.project_budget_limiting import (
+    ProjectBudgetLimitOut,
+    ProjectBudgetLimitsIn,
+)
 from radicalbit_ai_gateway.models.project_dto import (
     ConfigListFilter,
     ConfigSlotOut,
@@ -21,11 +26,14 @@ from radicalbit_ai_gateway.models.project_dto import (
 )
 from radicalbit_ai_gateway.utils.exceptions import (
     ProjectAlreadyExistsError,
+    ProjectBudgetLimitAlreadyExistsError,
+    ProjectBudgetLimitConflictError,
     ProjectConfigValidationError,
     ProjectInternalError,
     ProjectNotFoundError,
 )
 from radicalbit_ai_gateway.utils.yaml_utils import (
+    config_has_route_budget_limiting,
     get_default_config_template,
     validate_gateway_config,
 )
@@ -37,9 +45,15 @@ def _sanitize_filename(name: str) -> str:
 
 
 class ProjectService:
-    def __init__(self, project_dao: ProjectDAO, project_config_dao: ProjectConfigDAO):
+    def __init__(
+        self,
+        project_dao: ProjectDAO,
+        project_config_dao: ProjectConfigDAO,
+        project_budget_limit_dao: ProjectBudgetLimitDAO,
+    ):
         self.project_dao = project_dao
         self.project_config_dao = project_config_dao
+        self.project_budget_limit_dao = project_budget_limit_dao
 
     def _get_project_or_raise(self, project_uuid: UUID) -> Project:
         project = self.project_dao.get_by_uuid(project_uuid)
@@ -57,17 +71,24 @@ class ProjectService:
             )
         return config
 
-    def _build_out(self, project: Project) -> ProjectOut:
+    def _build_out(self, project: Project, include_limits: bool = False) -> ProjectOut:
         configs = list(self.project_config_dao.list_by_project(project.uuid))
-        return ProjectOut.from_project(project, configs)
+        limit = None
+        if include_limits:
+            found = self.project_budget_limit_dao.get_by_project_uuid(project.uuid)
+            if found:
+                limit = ProjectBudgetLimitOut.from_project_budget_limit(found[0])
+        return ProjectOut.from_project(project, configs, limits=limit)
 
-    def _build_out_or_raise(self, project_uuid: UUID) -> ProjectOut:
+    def _build_out_or_raise(
+        self, project_uuid: UUID, include_limits: bool = False
+    ) -> ProjectOut:
         project = self.project_dao.get_by_uuid(project_uuid)
         if not project:
             raise ProjectInternalError(
                 f'Failed to fetch updated project {project_uuid}'
             )
-        return self._build_out(project)
+        return self._build_out(project, include_limits)
 
     def create_project(self, project_in: ProjectIn) -> ProjectOut:
         template = get_default_config_template()
@@ -93,10 +114,22 @@ class ProjectService:
 
         return self._build_out_or_raise(inserted.uuid)
 
+    def _reject_route_budget_limiting_conflict(
+        self, project_uuid: UUID, yaml_str: str
+    ) -> None:
+        if not config_has_route_budget_limiting(yaml_str):
+            return
+        if self.project_budget_limit_dao.get_by_project_uuid(project_uuid):
+            raise ProjectConfigValidationError(
+                f'Project {project_uuid} already has a budget limit assigned; '
+                'routes cannot configure budget_limiting'
+            )
+
     def update_config(
         self, project_uuid: UUID, config_uuid: UUID, config_in: ProjectConfigFileIn
     ) -> ProjectOut:
         validate_gateway_config(config_in.config_file, check_secrets=True)
+        self._reject_route_budget_limiting_conflict(project_uuid, config_in.config_file)
 
         config = self._get_config_or_raise(project_uuid, config_uuid)
         if config.config_status == ConfigStatus.SERVED.value:
@@ -121,6 +154,7 @@ class ProjectService:
             )
 
         validate_gateway_config(config.config_file, check_secrets=True)
+        self._reject_route_budget_limiting_conflict(project_uuid, config.config_file)
 
         self.project_config_dao.set_status(config_uuid, ConfigStatus.READY_TO_SERVE)
         return self._build_out_or_raise(project_uuid)
@@ -149,6 +183,7 @@ class ProjectService:
             )
 
         validate_gateway_config(config.config_file, check_secrets=True)
+        self._reject_route_budget_limiting_conflict(project_uuid, config.config_file)
 
         served = self.project_config_dao.serve(config_uuid)
         if served is None:
@@ -183,8 +218,10 @@ class ProjectService:
         self.project_dao.soft_delete(project_uuid)
         return out
 
-    def get_by_uuid(self, project_uuid: UUID) -> ProjectOut:
-        return self._build_out(self._get_project_or_raise(project_uuid))
+    def get_by_uuid(
+        self, project_uuid: UUID, include_limits: bool = False
+    ) -> ProjectOut:
+        return self._build_out(self._get_project_or_raise(project_uuid), include_limits)
 
     def get_config(self, project_uuid: UUID, config_uuid: UUID) -> ConfigSlotOut:
         return ConfigSlotOut.from_config(
@@ -251,6 +288,7 @@ class ProjectService:
             ) from e
 
         validate_gateway_config(config_file, check_secrets=True)
+        self._reject_route_budget_limiting_conflict(project_uuid, config_file)
 
         rows_updated = self.project_config_dao.update_config_file(
             config_uuid, config_file
@@ -258,6 +296,53 @@ class ProjectService:
         if rows_updated == 0:
             raise ProjectNotFoundError(f'Config {config_uuid} not found')
         return self._build_out_or_raise(project_uuid)
+
+    def add_budget_limits_to_project(
+        self, project_uuid: UUID, limits_in: ProjectBudgetLimitsIn
+    ) -> list[ProjectBudgetLimitOut]:
+        project = self._get_project_or_raise(project_uuid)
+
+        served = self.project_config_dao.get_served_by_project(project_uuid)
+        if (
+            served
+            and served.config_file
+            and config_has_route_budget_limiting(served.config_file)
+        ):
+            raise ProjectBudgetLimitConflictError(
+                f'Project "{project.name}" has a published route with '
+                'budget_limiting configured; remove it before assigning a '
+                'project-level budget limit'
+            )
+
+        try:
+            inserted = self.project_budget_limit_dao.insert_many(
+                limits_in.to_project_budget_limits(project_uuid)
+            )
+        except IntegrityError as e:
+            if 'uq_project_budget_limit_PROJECT_UUID_WINDOW_SIZE' in str(e.orig):
+                raise ProjectBudgetLimitAlreadyExistsError(
+                    f'Project "{project.name}" already has a budget limit for '
+                    'one of the requested time windows'
+                ) from e
+            raise ProjectInternalError(
+                f'An error occurred while adding the budget limits: {e}'
+            ) from e
+        except Exception as e:
+            raise ProjectInternalError(
+                f'An error occurred while adding the budget limits: {e}'
+            ) from e
+        return [
+            ProjectBudgetLimitOut.from_project_budget_limit(limit) for limit in inserted
+        ]
+
+    def get_budget_limits_for_project(
+        self, project_uuid: UUID
+    ) -> list[ProjectBudgetLimitOut]:
+        self._get_project_or_raise(project_uuid)
+        return [
+            ProjectBudgetLimitOut.from_project_budget_limit(limit)
+            for limit in self.project_budget_limit_dao.get_by_project_uuid(project_uuid)
+        ]
 
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):
@@ -267,10 +352,12 @@ class ProjectService:
         return [self._build_out(project) for project in self.project_dao.get_all()]
 
     def get_all_filtered(
-        self, project_filter: ProjectFilter | None = None
+        self,
+        project_filter: ProjectFilter | None = None,
+        include_limits: bool = False,
     ) -> list[ProjectOut]:
         projects = self.project_dao.get_all_filtered(project_filter)
-        return [self._build_out(project) for project in projects]
+        return [self._build_out(project, include_limits) for project in projects]
 
     def get_configs(
         self, config_filter: ConfigListFilter | None = None

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -73,12 +73,15 @@ class ProjectService:
 
     def _build_out(self, project: Project, include_limits: bool = False) -> ProjectOut:
         configs = list(self.project_config_dao.list_by_project(project.uuid))
-        limit = None
+        limits = None
         if include_limits:
-            found = self.project_budget_limit_dao.get_by_project_uuid(project.uuid)
-            if found:
-                limit = ProjectBudgetLimitOut.from_project_budget_limit(found[0])
-        return ProjectOut.from_project(project, configs, limits=limit)
+            limits = [
+                ProjectBudgetLimitOut.from_project_budget_limit(limit)
+                for limit in self.project_budget_limit_dao.get_by_project_uuid(
+                    project.uuid
+                )
+            ]
+        return ProjectOut.from_project(project, configs, limits=limits)
 
     def _build_out_or_raise(
         self, project_uuid: UUID, include_limits: bool = False

--- a/gateway/radicalbit_ai_gateway/utils/exceptions.py
+++ b/gateway/radicalbit_ai_gateway/utils/exceptions.py
@@ -631,6 +631,26 @@ class ProjectConfigValidationError(AuthRegistryError):
         )
 
 
+class ProjectBudgetLimitAlreadyExistsError(AuthRegistryError):
+    def __init__(self, message: str, *, log_message: str | None = None):
+        super().__init__(
+            message,
+            status.HTTP_400_BAD_REQUEST,
+            'project_budget_limit_already_exists_bad_request',
+            log_message=log_message,
+        )
+
+
+class ProjectBudgetLimitConflictError(AuthRegistryError):
+    def __init__(self, message: str, *, log_message: str | None = None):
+        super().__init__(
+            message,
+            status.HTTP_400_BAD_REQUEST,
+            'project_budget_limit_conflict_bad_request',
+            log_message=log_message,
+        )
+
+
 class SecretNotFoundError(AppError):
     def __init__(self, key: str, source: str = ''):
         message = f"Secret '{key}' not found"

--- a/gateway/radicalbit_ai_gateway/utils/yaml_utils.py
+++ b/gateway/radicalbit_ai_gateway/utils/yaml_utils.py
@@ -205,6 +205,16 @@ def validate_gateway_config(yaml_str: str, *, check_secrets: bool) -> str:
     return yaml_str
 
 
+def config_has_route_budget_limiting(yaml_str: str) -> bool:
+    """Whether any route in *yaml_str* sets `budget_limiting`.
+
+    Assumes *yaml_str* already passed :func:`validate_gateway_config`.
+    """
+    parsed = parse_yaml_with_secret_placeholders(yaml_str)
+    config = GatewayConfig.model_validate(parsed)
+    return any(route.budget_limiting is not None for route in config.routes.values())
+
+
 def get_default_config_template() -> str:
     return (
         files('radicalbit_ai_gateway.resources')

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -452,7 +452,7 @@ def get_sample_project_out(
     description: str | None = None,
     served_config_uuid: uuid.UUID | None = None,
     configs: list[ConfigSlotOut] | None = None,
-    limits: ProjectBudgetLimitOut | None = None,
+    limits: list[ProjectBudgetLimitOut] | None = None,
 ) -> ProjectOut:
     now = datetime.datetime.now(tz=UTC)
     if configs is None:

--- a/gateway/tests/common/db_mock.py
+++ b/gateway/tests/common/db_mock.py
@@ -9,6 +9,9 @@ from radicalbit_ai_gateway.db.tables.group_table import Group
 from radicalbit_ai_gateway.db.tables.key_limit_table import KeyLimit
 from radicalbit_ai_gateway.db.tables.key_table import Key
 from radicalbit_ai_gateway.db.tables.otel_traces_table import OtelTraces
+from radicalbit_ai_gateway.db.tables.project_budget_limit_table import (
+    ProjectBudgetLimit,
+)
 from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
 from radicalbit_ai_gateway.db.tables.request_event_table import RequestEvent
@@ -32,6 +35,11 @@ from radicalbit_ai_gateway.models.credential_limiting import (
     CredentialLimitCategory,
     CredentialLimitIn,
     CredentialLimitsIn,
+)
+from radicalbit_ai_gateway.models.project_budget_limiting import (
+    ProjectBudgetLimitIn,
+    ProjectBudgetLimitOut,
+    ProjectBudgetLimitsIn,
 )
 from radicalbit_ai_gateway.models.project_dto import (
     ConfigSlotOut,
@@ -138,6 +146,45 @@ def get_sample_credential_limits_in(
     limits: list[CredentialLimitIn] | None = None,
 ) -> CredentialLimitsIn:
     return CredentialLimitsIn(limits=limits or [get_sample_credential_limit_in()])
+
+
+def get_sample_project_budget_limit(
+    uuid: uuid.UUID = RANDOM_UUID,
+    project_uuid: uuid.UUID = RANDOM_UUID,
+    algorithm: str = 'FIXED_WINDOW',
+    window_size: str = '1 day',
+    max_value: float = 10.0,
+) -> ProjectBudgetLimit:
+    now = datetime.datetime.now(tz=UTC)
+    return ProjectBudgetLimit(
+        uuid=uuid,
+        project_uuid=project_uuid,
+        algorithm=algorithm,
+        window_size=window_size,
+        max_value=max_value,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def get_sample_project_budget_limit_in(
+    algorithm: str = 'FIXED_WINDOW',
+    window_size: str = '1 day',
+    value: float = 10.0,
+) -> ProjectBudgetLimitIn:
+    return ProjectBudgetLimitIn(
+        algorithm=algorithm,
+        window_size=window_size,
+        value=value,
+    )
+
+
+def get_sample_project_budget_limits_in(
+    limits: list[ProjectBudgetLimitIn] | None = None,
+) -> ProjectBudgetLimitsIn:
+    return ProjectBudgetLimitsIn(
+        limits=limits or [get_sample_project_budget_limit_in()]
+    )
 
 
 def get_sample_group_plain(
@@ -405,6 +452,7 @@ def get_sample_project_out(
     description: str | None = None,
     served_config_uuid: uuid.UUID | None = None,
     configs: list[ConfigSlotOut] | None = None,
+    limits: ProjectBudgetLimitOut | None = None,
 ) -> ProjectOut:
     now = datetime.datetime.now(tz=UTC)
     if configs is None:
@@ -421,6 +469,7 @@ def get_sample_project_out(
         else ProjectStatus.DEV,
         served_config_uuid=served_config_uuid,
         configs=configs,
+        limits=limits,
         created_at=str(now),
         updated_at=str(now),
     )

--- a/gateway/tests/dao/project_budget_limit_dao_test.py
+++ b/gateway/tests/dao/project_budget_limit_dao_test.py
@@ -1,0 +1,106 @@
+import uuid
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
+
+from tests.common import db_mock
+from tests.common.db_integration import DatabaseIntegration
+
+from radicalbit_ai_gateway.db.dao.project_budget_limit_dao import ProjectBudgetLimitDAO
+from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
+from radicalbit_ai_gateway.db.tables.project_table import Project
+
+
+class ProjectBudgetLimitDAOTest(DatabaseIntegration):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.project_dao = ProjectDAO(cls.db)
+        cls.project_budget_limit_dao = ProjectBudgetLimitDAO(cls.db)
+
+    def _insert_project(self, name='rb-project'):
+        project = db_mock.get_sample_project(uuid=uuid.uuid4(), name=name)
+        return self.project_dao.insert(project)
+
+    def test_insert(self):
+        project = self._insert_project()
+        limit = db_mock.get_sample_project_budget_limit(project_uuid=project.uuid)
+        inserted = self.project_budget_limit_dao.insert(limit)
+        assert inserted.uuid == limit.uuid
+
+    def test_get_by_uuid(self):
+        project = self._insert_project()
+        limit = db_mock.get_sample_project_budget_limit(
+            uuid=uuid.uuid4(), project_uuid=project.uuid
+        )
+        self.project_budget_limit_dao.insert(limit)
+        res = self.project_budget_limit_dao.get_by_uuid(limit.uuid)
+        assert res.uuid == limit.uuid
+
+    def test_get_by_project_uuid(self):
+        project = self._insert_project()
+        limits = [
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 day'
+            ),
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 month'
+            ),
+        ]
+        _ = [self.project_budget_limit_dao.insert(limit) for limit in limits]
+        res = self.project_budget_limit_dao.get_by_project_uuid(project.uuid)
+        assert len(res) == 2
+
+    def test_duplicate_window_raises_integrity_error(self):
+        project = self._insert_project()
+        limit_one = db_mock.get_sample_project_budget_limit(
+            uuid=uuid.uuid4(), project_uuid=project.uuid
+        )
+        limit_two = db_mock.get_sample_project_budget_limit(
+            uuid=uuid.uuid4(), project_uuid=project.uuid
+        )
+        self.project_budget_limit_dao.insert(limit_one)
+        pytest.raises(IntegrityError, self.project_budget_limit_dao.insert, limit_two)
+
+    def test_insert_many(self):
+        project = self._insert_project()
+        limits = [
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 day'
+            ),
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 month'
+            ),
+        ]
+        inserted = self.project_budget_limit_dao.insert_many(limits)
+        assert len(inserted) == 2
+        assert len(self.project_budget_limit_dao.get_by_project_uuid(project.uuid)) == 2
+
+    def test_insert_many_is_atomic_on_conflict(self):
+        project = self._insert_project()
+        limits = [
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 day'
+            ),
+            # Duplicates the first one: same window.
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 day'
+            ),
+        ]
+        pytest.raises(IntegrityError, self.project_budget_limit_dao.insert_many, limits)
+        # Neither row should have been committed.
+        assert self.project_budget_limit_dao.get_by_project_uuid(project.uuid) == []
+
+    def test_cascade_delete_on_project_delete(self):
+        project = self._insert_project()
+        self.project_budget_limit_dao.insert(
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid
+            )
+        )
+        # ProjectDAO only exposes a soft delete; exercise the FK's
+        # `ondelete='CASCADE'` directly with a hard delete of the row.
+        with self.project_budget_limit_dao.db.begin_session() as session:
+            session.execute(delete(Project).where(Project.uuid == project.uuid))
+        assert self.project_budget_limit_dao.get_by_project_uuid(project.uuid) == []

--- a/gateway/tests/models/test_project_budget_limiting.py
+++ b/gateway/tests/models/test_project_budget_limiting.py
@@ -1,0 +1,93 @@
+import uuid
+
+import pytest
+
+from radicalbit_ai_gateway.models.limiting import LimitingAlgorithmType
+from radicalbit_ai_gateway.models.project_budget_limiting import (
+    ProjectBudgetLimitIn,
+    ProjectBudgetLimitOut,
+    ProjectBudgetLimitsIn,
+)
+
+
+def test_valid_limit():
+    limit_in = ProjectBudgetLimitIn(window_size='1 day', value=10)
+    assert limit_in.algorithm == LimitingAlgorithmType.FIXED_WINDOW
+    assert limit_in.window_size == '1 day'
+    assert limit_in.value == 10
+
+
+def test_invalid_window_size_for_aligned_fixed_window_rejected():
+    with pytest.raises(ValueError, match='not allowed for ALIGNED_FIXED_WINDOW'):
+        ProjectBudgetLimitIn(
+            algorithm=LimitingAlgorithmType.ALIGNED_FIXED_WINDOW,
+            window_size='3 days',
+            value=10,
+        )
+
+
+def test_value_must_be_positive():
+    with pytest.raises(ValueError):
+        ProjectBudgetLimitIn(window_size='1 day', value=0)
+
+
+def test_to_project_budget_limit_maps_fields():
+    project_uuid = uuid.uuid4()
+    limit_in = ProjectBudgetLimitIn(window_size='1 day', value=10)
+    project_budget_limit = limit_in.to_project_budget_limit(project_uuid)
+    assert project_budget_limit.project_uuid == project_uuid
+    assert project_budget_limit.algorithm == 'FIXED_WINDOW'
+    assert project_budget_limit.window_size == '1 day'
+    assert project_budget_limit.max_value == 10
+
+
+def test_limits_in_requires_at_least_one():
+    with pytest.raises(ValueError):
+        ProjectBudgetLimitsIn(limits=[])
+
+
+def test_limits_in_rejects_duplicate_within_batch():
+    with pytest.raises(ValueError, match='Duplicate limit in request'):
+        ProjectBudgetLimitsIn(
+            limits=[
+                ProjectBudgetLimitIn(window_size='1 day', value=1),
+                ProjectBudgetLimitIn(window_size='1 day', value=2),
+            ]
+        )
+
+
+def test_limits_in_allows_different_windows():
+    limits_in = ProjectBudgetLimitsIn(
+        limits=[
+            ProjectBudgetLimitIn(window_size='1 day', value=1),
+            ProjectBudgetLimitIn(window_size='1 month', value=15),
+        ]
+    )
+    assert len(limits_in.limits) == 2
+
+
+def test_to_project_budget_limits_maps_all_entries():
+    project_uuid = uuid.uuid4()
+    limits_in = ProjectBudgetLimitsIn(
+        limits=[
+            ProjectBudgetLimitIn(window_size='1 day', value=1),
+            ProjectBudgetLimitIn(window_size='1 month', value=15),
+        ]
+    )
+    project_budget_limits = limits_in.to_project_budget_limits(project_uuid)
+    assert len(project_budget_limits) == 2
+    assert all(pbl.project_uuid == project_uuid for pbl in project_budget_limits)
+    assert {pbl.window_size for pbl in project_budget_limits} == {'1 day', '1 month'}
+
+
+def test_project_budget_limit_out_round_trip():
+    project_uuid = uuid.uuid4()
+    limit_in = ProjectBudgetLimitIn(window_size='1 minute', value=100)
+    project_budget_limit = limit_in.to_project_budget_limit(project_uuid)
+    # `uuid` has a column default applied at flush time by SQLAlchemy, not at
+    # construction time, so set it explicitly to mimic an already-persisted row.
+    project_budget_limit.uuid = uuid.uuid4()
+    limit_out = ProjectBudgetLimitOut.from_project_budget_limit(project_budget_limit)
+    assert limit_out.algorithm == LimitingAlgorithmType.FIXED_WINDOW
+    assert limit_out.window_size == '1 minute'
+    assert limit_out.value == 100

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -10,6 +10,7 @@ from tests.common import db_mock
 
 from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
+from radicalbit_ai_gateway.models.project_budget_limiting import ProjectBudgetLimitOut
 from radicalbit_ai_gateway.models.project_dto import ProjectFilter
 from radicalbit_ai_gateway.routes.project_route import ProjectRoute
 from radicalbit_ai_gateway.services.config_generator_service import (
@@ -20,6 +21,8 @@ from radicalbit_ai_gateway.services.project_service import ProjectService
 from radicalbit_ai_gateway.utils.exceptions import (
     AuthRegistryError,
     ProjectAlreadyExistsError,
+    ProjectBudgetLimitAlreadyExistsError,
+    ProjectBudgetLimitConflictError,
     ProjectConfigValidationError,
     ProjectNotFoundError,
     auth_registry_exception_handler,
@@ -77,8 +80,17 @@ class TestProjectRoute(unittest.TestCase):
         res = self.client.get(f'{self.prefix}/projects', params={'filter': 'prod'})
         assert res.status_code == 200
         self.project_service.get_all_filtered.assert_called_once_with(
-            ProjectFilter.PROD
+            ProjectFilter.PROD, False
         )
+
+    def test_get_all_with_include_limits(self):
+        out = db_mock.get_sample_project_out()
+        self.project_service.get_all_filtered = MagicMock(return_value=[out])
+        res = self.client.get(
+            f'{self.prefix}/projects', params={'include_limits': 'true'}
+        )
+        assert res.status_code == 200
+        self.project_service.get_all_filtered.assert_called_once_with(None, True)
 
     def test_get_by_uuid(self):
         pid = uuid.uuid4()
@@ -86,7 +98,21 @@ class TestProjectRoute(unittest.TestCase):
         self.project_service.get_by_uuid = MagicMock(return_value=out)
         res = self.client.get(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
-        self.project_service.get_by_uuid.assert_called_once_with(pid)
+        self.project_service.get_by_uuid.assert_called_once_with(pid, False)
+
+    def test_get_by_uuid_with_include_limits(self):
+        pid = uuid.uuid4()
+        limit_out = ProjectBudgetLimitOut.from_project_budget_limit(
+            db_mock.get_sample_project_budget_limit(uuid=uuid.uuid4(), project_uuid=pid)
+        )
+        out = db_mock.get_sample_project_out(uuid=pid, limits=limit_out)
+        self.project_service.get_by_uuid = MagicMock(return_value=out)
+        res = self.client.get(
+            f'{self.prefix}/projects/{pid}', params={'include_limits': 'true'}
+        )
+        assert res.status_code == 200
+        assert res.json()['limits'] == jsonable_encoder(limit_out)
+        self.project_service.get_by_uuid.assert_called_once_with(pid, True)
 
     def test_get_by_uuid_not_found(self):
         pid = uuid.uuid4()
@@ -363,6 +389,81 @@ class TestProjectRoute(unittest.TestCase):
         res = self.client.delete(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
         self.deregister.assert_not_awaited()
+
+    # --- project budget limits ---
+
+    def test_add_budget_limits_to_project_success(self):
+        pid = uuid.uuid4()
+        limits_in = db_mock.get_sample_project_budget_limits_in()
+        limit_out = ProjectBudgetLimitOut.from_project_budget_limit(
+            db_mock.get_sample_project_budget_limit(uuid=uuid.uuid4(), project_uuid=pid)
+        )
+        self.project_service.add_budget_limits_to_project = MagicMock(
+            return_value=[limit_out]
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/budget-limits',
+            json=jsonable_encoder(limits_in),
+        )
+        assert res.status_code == 201
+        assert res.json() == jsonable_encoder([limit_out])
+        self.project_service.add_budget_limits_to_project.assert_called_once_with(
+            pid, limits_in
+        )
+
+    def test_add_budget_limits_to_project_not_found(self):
+        pid = uuid.uuid4()
+        self.project_service.add_budget_limits_to_project = MagicMock(
+            side_effect=ProjectNotFoundError('nope')
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/budget-limits',
+            json=jsonable_encoder(db_mock.get_sample_project_budget_limits_in()),
+        )
+        assert res.status_code == 404
+
+    def test_add_budget_limits_to_project_already_exists(self):
+        pid = uuid.uuid4()
+        self.project_service.add_budget_limits_to_project = MagicMock(
+            side_effect=ProjectBudgetLimitAlreadyExistsError('dup')
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/budget-limits',
+            json=jsonable_encoder(db_mock.get_sample_project_budget_limits_in()),
+        )
+        assert res.status_code == 400
+
+    def test_add_budget_limits_to_project_conflict(self):
+        pid = uuid.uuid4()
+        self.project_service.add_budget_limits_to_project = MagicMock(
+            side_effect=ProjectBudgetLimitConflictError('conflict')
+        )
+        res = self.client.post(
+            f'{self.prefix}/projects/{pid}/budget-limits',
+            json=jsonable_encoder(db_mock.get_sample_project_budget_limits_in()),
+        )
+        assert res.status_code == 400
+
+    def test_get_budget_limits_for_project_success(self):
+        pid = uuid.uuid4()
+        limit_out = ProjectBudgetLimitOut.from_project_budget_limit(
+            db_mock.get_sample_project_budget_limit(uuid=uuid.uuid4(), project_uuid=pid)
+        )
+        self.project_service.get_budget_limits_for_project = MagicMock(
+            return_value=[limit_out]
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/budget-limits')
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder([limit_out])
+        self.project_service.get_budget_limits_for_project.assert_called_once_with(pid)
+
+    def test_get_budget_limits_for_project_not_found(self):
+        pid = uuid.uuid4()
+        self.project_service.get_budget_limits_for_project = MagicMock(
+            side_effect=ProjectNotFoundError('nope')
+        )
+        res = self.client.get(f'{self.prefix}/projects/{pid}/budget-limits')
+        assert res.status_code == 404
 
     # --- route_meta ---
 

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -105,13 +105,13 @@ class TestProjectRoute(unittest.TestCase):
         limit_out = ProjectBudgetLimitOut.from_project_budget_limit(
             db_mock.get_sample_project_budget_limit(uuid=uuid.uuid4(), project_uuid=pid)
         )
-        out = db_mock.get_sample_project_out(uuid=pid, limits=limit_out)
+        out = db_mock.get_sample_project_out(uuid=pid, limits=[limit_out])
         self.project_service.get_by_uuid = MagicMock(return_value=out)
         res = self.client.get(
             f'{self.prefix}/projects/{pid}', params={'include_limits': 'true'}
         )
         assert res.status_code == 200
-        assert res.json()['limits'] == jsonable_encoder(limit_out)
+        assert res.json()['limits'] == jsonable_encoder([limit_out])
         self.project_service.get_by_uuid.assert_called_once_with(pid, True)
 
     def test_get_by_uuid_not_found(self):

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from tests.common import db_mock
 from tests.common.db_integration import DatabaseIntegration
 
+from radicalbit_ai_gateway.db.dao.project_budget_limit_dao import ProjectBudgetLimitDAO
 from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.models.config_slot import Slot
@@ -23,18 +24,40 @@ from radicalbit_ai_gateway.models.project_status import ProjectStatus
 from radicalbit_ai_gateway.services.project_service import ProjectService
 from radicalbit_ai_gateway.utils.exceptions import (
     ProjectAlreadyExistsError,
+    ProjectBudgetLimitAlreadyExistsError,
+    ProjectBudgetLimitConflictError,
     ProjectConfigValidationError,
     ProjectNotFoundError,
 )
 
 _VALID = db_mock.VALID_CONFIG_YAML
 
+_VALID_WITH_ROUTE_BUDGET_LIMITING = """\
+chat_models:
+  - model_id: mock-chat
+    model: mock/gateway
+    params:
+      latency_ms: 150
+      response_text: "mock response"
+routes:
+  test-route:
+    chat_models:
+      - mock-chat
+    budget_limiting:
+      window_size: "1 day"
+      max_budget: 5.0
+"""
+
 
 class ProjectServiceTest(DatabaseIntegration):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.svc = ProjectService(ProjectDAO(cls.db), ProjectConfigDAO(cls.db))
+        cls.svc = ProjectService(
+            ProjectDAO(cls.db),
+            ProjectConfigDAO(cls.db),
+            ProjectBudgetLimitDAO(cls.db),
+        )
 
     def _create(self, name='proj'):
         out = self.svc.create_project(ProjectIn(name=name))
@@ -65,7 +88,7 @@ class ProjectServiceTest(DatabaseIntegration):
     def test_create_project_already_exists(self):
         # IntegrityError -> ProjectAlreadyExistsError mapping is a unit concern,
         # tested with a mocked DAO to stay independent of create_all metadata.
-        svc = ProjectService(MagicMock(), MagicMock())
+        svc = ProjectService(MagicMock(), MagicMock(), MagicMock())
         svc.project_dao.insert_with_configs = MagicMock(
             side_effect=IntegrityError(None, None, BaseException('uq_project_NAME'))
         )
@@ -75,6 +98,39 @@ class ProjectServiceTest(DatabaseIntegration):
     def test_get_by_uuid_not_found(self):
         with pytest.raises(ProjectNotFoundError):
             self.svc.get_by_uuid(uuid.uuid4())
+
+    def test_get_by_uuid_omits_limits_by_default(self):
+        out, _, _ = self._create(name='no-limits')
+        res = self.svc.get_by_uuid(out.uuid)
+        assert res.limits is None
+
+    def test_get_by_uuid_include_limits(self):
+        out, _, _ = self._create(name='with-limits')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        res = self.svc.get_by_uuid(out.uuid, include_limits=True)
+        assert res.limits is not None
+        assert res.limits.window_size == '1 day'
+
+    def test_get_all_filtered_include_limits(self):
+        out, _, _ = self._create(name='filtered-with-limits')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        results = self.svc.get_all_filtered(include_limits=True)
+        found = next(p for p in results if p.uuid == out.uuid)
+        assert found.limits is not None
+        assert found.limits.window_size == '1 day'
+
+    def test_get_all_filtered_omits_limits_by_default(self):
+        out, _, _ = self._create(name='filtered-no-limits')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        results = self.svc.get_all_filtered()
+        found = next(p for p in results if p.uuid == out.uuid)
+        assert found.limits is None
 
     # --- update ---
 
@@ -363,3 +419,129 @@ class ProjectServiceTest(DatabaseIntegration):
         assert [p.uuid for p in draft] == [draft_proj.uuid]
 
         assert self.svc.get_configs(ConfigListFilter.REQUEST_TO_PUBLISH) == []
+
+    # --- project budget limits ---
+
+    def test_add_budget_limits_to_project_ok(self):
+        out, _, _ = self._create(name='budget-ok')
+        limits = self.svc.add_budget_limits_to_project(
+            out.uuid,
+            db_mock.get_sample_project_budget_limits_in(
+                limits=[
+                    db_mock.get_sample_project_budget_limit_in(window_size='1 day'),
+                    db_mock.get_sample_project_budget_limit_in(
+                        window_size='1 month', value=15
+                    ),
+                ]
+            ),
+        )
+        assert {limit.window_size for limit in limits} == {'1 day', '1 month'}
+        fetched = self.svc.get_budget_limits_for_project(out.uuid)
+        assert {limit.window_size for limit in fetched} == {'1 day', '1 month'}
+
+    def test_add_budget_limits_to_project_not_found(self):
+        with pytest.raises(ProjectNotFoundError):
+            self.svc.add_budget_limits_to_project(
+                uuid.uuid4(), db_mock.get_sample_project_budget_limits_in()
+            )
+
+    def test_add_budget_limits_to_project_duplicate_window_raises(self):
+        out, _, _ = self._create(name='budget-dup')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        with pytest.raises(ProjectBudgetLimitAlreadyExistsError):
+            self.svc.add_budget_limits_to_project(
+                out.uuid, db_mock.get_sample_project_budget_limits_in()
+            )
+
+    def test_add_budget_limits_rejected_when_published_route_has_budget_limiting(
+        self,
+    ):
+        out, a, _ = self._create(name='budget-conflict')
+        self.svc.update_config(
+            out.uuid,
+            a,
+            ProjectConfigFileIn(config_file=_VALID_WITH_ROUTE_BUDGET_LIMITING),
+        )
+        self.svc.approve_config(out.uuid, a)
+        self.svc.serve_config(out.uuid, a)
+        with pytest.raises(ProjectBudgetLimitConflictError):
+            self.svc.add_budget_limits_to_project(
+                out.uuid, db_mock.get_sample_project_budget_limits_in()
+            )
+
+    def test_get_budget_limits_for_project_not_found(self):
+        with pytest.raises(ProjectNotFoundError):
+            self.svc.get_budget_limits_for_project(uuid.uuid4())
+
+    # --- reverse validation: route config vs. existing project budget limit ---
+
+    def test_update_config_rejected_when_project_has_budget_limit_and_route_sets_it(
+        self,
+    ):
+        out, a, _ = self._create(name='route-conflict-update')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.update_config(
+                out.uuid,
+                a,
+                ProjectConfigFileIn(config_file=_VALID_WITH_ROUTE_BUDGET_LIMITING),
+            )
+
+    def test_approve_config_rejected_when_project_has_budget_limit_and_route_sets_it(
+        self,
+    ):
+        out, a, _ = self._create(name='route-conflict-approve')
+        self.svc.update_config(
+            out.uuid,
+            a,
+            ProjectConfigFileIn(config_file=_VALID_WITH_ROUTE_BUDGET_LIMITING),
+        )
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.approve_config(out.uuid, a)
+
+    def test_serve_config_rejected_when_project_has_budget_limit_and_route_sets_it(
+        self,
+    ):
+        out, a, _ = self._create(name='route-conflict-serve')
+        self.svc.update_config(
+            out.uuid,
+            a,
+            ProjectConfigFileIn(config_file=_VALID_WITH_ROUTE_BUDGET_LIMITING),
+        )
+        self.svc.approve_config(out.uuid, a)
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.serve_config(out.uuid, a)
+
+    def test_import_config_rejected_when_project_has_budget_limit_and_route_sets_it(
+        self,
+    ):
+        out, a, _ = self._create(name='route-conflict-import')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        with pytest.raises(ProjectConfigValidationError):
+            self.svc.import_config(
+                out.uuid, a, _VALID_WITH_ROUTE_BUDGET_LIMITING.encode()
+            )
+
+    def test_update_config_allowed_when_no_conflict(self):
+        # Guards against over-rejection: a project budget limit alone (no route
+        # budget_limiting in the submitted config) must not block saving.
+        out, a, _ = self._create(name='route-no-conflict')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        res = self.svc.update_config(
+            out.uuid, a, ProjectConfigFileIn(config_file=_VALID)
+        )
+        assert next(c for c in res.configs if c.uuid == a).config_file == _VALID

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -111,7 +111,8 @@ class ProjectServiceTest(DatabaseIntegration):
         )
         res = self.svc.get_by_uuid(out.uuid, include_limits=True)
         assert res.limits is not None
-        assert res.limits.window_size == '1 day'
+        assert len(res.limits) == 1
+        assert res.limits[0].window_size == '1 day'
 
     def test_get_all_filtered_include_limits(self):
         out, _, _ = self._create(name='filtered-with-limits')
@@ -121,7 +122,7 @@ class ProjectServiceTest(DatabaseIntegration):
         results = self.svc.get_all_filtered(include_limits=True)
         found = next(p for p in results if p.uuid == out.uuid)
         assert found.limits is not None
-        assert found.limits.window_size == '1 day'
+        assert len(found.limits) == 1
 
     def test_get_all_filtered_omits_limits_by_default(self):
         out, _, _ = self._create(name='filtered-no-limits')


### PR DESCRIPTION
## Summary

Adds project-level budget limits plus an `include_limits` flag on the project read endpoints.

- Projects can now have one or more budget limits attached, each with its own time window (e.g. `$1/day` + `$15/month`).
- Two-way validation keeps project-level budget limits and route-level `budget_limiting` mutually exclusive per project:
  - Creating a project budget limit is rejected if the project's currently **published** config has `budget_limiting` set on any route.
  - Saving/approving/serving/importing a route config is rejected if the project already has a budget limit and the config sets `budget_limiting` on a route.
- `GET /projects` and `GET /projects/{project_uuid}` gained an `include_limits` query param (default `false`) to optionally surface the project's budget limit in the response.

## What's new

**Data model**
- New `project_budget_limit` table (migration `b79da332d03f`), unique on `(PROJECT_UUID, WINDOW_SIZE)`, cascade-deleted with the project.
- `ProjectBudgetLimitDAO` (insert / insert_many / get_by_uuid / get_by_project_uuid).

**DTOs** (`models/project_budget_limiting.py`)
- `ProjectBudgetLimitIn` / `ProjectBudgetLimitsIn` (batch) / `ProjectBudgetLimitOut`, reusing the existing `Limiting` model for algorithm/window validation.

**API**
- `POST /projects/{project_uuid}/budget-limits` — create one or more budget limits for a project.
- `GET /projects/{project_uuid}/budget-limits` — list a project's budget limits.
- `GET /projects` / `GET /projects/{project_uuid}?include_limits=true` — optionally embed the project's budget limit in `ProjectOut.limits`.

**Validation / errors**
- `utils/yaml_utils.py`: new `config_has_route_budget_limiting()` helper.
- `services/project_service.py`: new `add_budget_limits_to_project` / `get_budget_limits_for_project`; new `_reject_route_budget_limiting_conflict` hooked into `update_config`, `approve_config`, `serve_config`, `import_config`.
- New exceptions: `ProjectBudgetLimitAlreadyExistsError`, `ProjectBudgetLimitConflictError`.

**Tests**
- New: `tests/models/test_project_budget_limiting.py`, `tests/dao/project_budget_limit_dao_test.py`.
- Extended: `tests/services/project_service_test.py`, `tests/routes/test_project_route.py`, `tests/common/db_mock.py`.
