### PR TITLE
feat(api): delete budget limit for project

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/project_budget_limit_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_budget_limit_dao.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from radicalbit_ai_gateway.db.database import Database
 from radicalbit_ai_gateway.db.tables.project_budget_limit_table import (
@@ -43,3 +43,10 @@ class ProjectBudgetLimitDAO:
                 ProjectBudgetLimit.project_uuid == project_uuid
             )
             return session.scalars(stmt).all()
+
+    def delete_by_uuid(self, limit_uuid: UUID) -> int:
+        with self.db.begin_session() as session:
+            query = delete(ProjectBudgetLimit).where(
+                ProjectBudgetLimit.uuid == limit_uuid
+            )
+            return session.execute(query).rowcount

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -351,4 +351,21 @@ class ProjectRoute:
         def get_budget_limits_for_project(project_uuid: UUID):
             return project_service.get_budget_limits_for_project(project_uuid)
 
+        @router.delete(
+            '/projects/{project_uuid}/budget-limits/{limit_uuid}',
+            status_code=200,
+            response_model=ProjectBudgetLimitOut,
+        )
+        @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
+        async def delete_budget_limit_from_project(
+            project_uuid: UUID, limit_uuid: UUID
+        ):
+            limit = project_service.delete_budget_limit_from_project(
+                project_uuid, limit_uuid
+            )
+            logger.info(
+                'Deleted budget limit %s from project %s', limit_uuid, project_uuid
+            )
+            return limit
+
         return router

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -28,6 +28,7 @@ from radicalbit_ai_gateway.utils.exceptions import (
     ProjectAlreadyExistsError,
     ProjectBudgetLimitAlreadyExistsError,
     ProjectBudgetLimitConflictError,
+    ProjectBudgetLimitNotFoundError,
     ProjectConfigValidationError,
     ProjectInternalError,
     ProjectNotFoundError,
@@ -346,6 +347,20 @@ class ProjectService:
             ProjectBudgetLimitOut.from_project_budget_limit(limit)
             for limit in self.project_budget_limit_dao.get_by_project_uuid(project_uuid)
         ]
+
+    def delete_budget_limit_from_project(
+        self, project_uuid: UUID, limit_uuid: UUID
+    ) -> ProjectBudgetLimitOut:
+        self._get_project_or_raise(project_uuid)
+        limit = self.project_budget_limit_dao.get_by_uuid(limit_uuid)
+        if not limit or limit.project_uuid != project_uuid:
+            raise ProjectBudgetLimitNotFoundError(
+                f'Budget limit {limit_uuid} not found for project {project_uuid}'
+            )
+        # Build the response before deletion so the caller can still see it.
+        out = ProjectBudgetLimitOut.from_project_budget_limit(limit)
+        self.project_budget_limit_dao.delete_by_uuid(limit_uuid)
+        return out
 
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):

--- a/gateway/radicalbit_ai_gateway/utils/exceptions.py
+++ b/gateway/radicalbit_ai_gateway/utils/exceptions.py
@@ -651,6 +651,16 @@ class ProjectBudgetLimitConflictError(AuthRegistryError):
         )
 
 
+class ProjectBudgetLimitNotFoundError(AuthRegistryError):
+    def __init__(self, message: str, *, log_message: str | None = None):
+        super().__init__(
+            message,
+            status.HTTP_404_NOT_FOUND,
+            'project_budget_limit_not_found',
+            log_message=log_message,
+        )
+
+
 class SecretNotFoundError(AppError):
     def __init__(self, key: str, source: str = ''):
         message = f"Secret '{key}' not found"

--- a/gateway/tests/dao/project_budget_limit_dao_test.py
+++ b/gateway/tests/dao/project_budget_limit_dao_test.py
@@ -92,6 +92,20 @@ class ProjectBudgetLimitDAOTest(DatabaseIntegration):
         # Neither row should have been committed.
         assert self.project_budget_limit_dao.get_by_project_uuid(project.uuid) == []
 
+    def test_delete_by_uuid(self):
+        project = self._insert_project()
+        limit = db_mock.get_sample_project_budget_limit(
+            uuid=uuid.uuid4(), project_uuid=project.uuid
+        )
+        self.project_budget_limit_dao.insert(limit)
+        rowcount = self.project_budget_limit_dao.delete_by_uuid(limit.uuid)
+        assert rowcount == 1
+        assert self.project_budget_limit_dao.get_by_uuid(limit.uuid) is None
+
+    def test_delete_by_uuid_nonexistent_returns_zero(self):
+        rowcount = self.project_budget_limit_dao.delete_by_uuid(uuid.uuid4())
+        assert rowcount == 0
+
     def test_cascade_delete_on_project_delete(self):
         project = self._insert_project()
         self.project_budget_limit_dao.insert(

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -23,6 +23,7 @@ from radicalbit_ai_gateway.utils.exceptions import (
     ProjectAlreadyExistsError,
     ProjectBudgetLimitAlreadyExistsError,
     ProjectBudgetLimitConflictError,
+    ProjectBudgetLimitNotFoundError,
     ProjectConfigValidationError,
     ProjectNotFoundError,
     auth_registry_exception_handler,
@@ -463,6 +464,29 @@ class TestProjectRoute(unittest.TestCase):
             side_effect=ProjectNotFoundError('nope')
         )
         res = self.client.get(f'{self.prefix}/projects/{pid}/budget-limits')
+        assert res.status_code == 404
+
+    def test_delete_budget_limit_from_project_success(self):
+        pid, lid = uuid.uuid4(), uuid.uuid4()
+        limit_out = ProjectBudgetLimitOut.from_project_budget_limit(
+            db_mock.get_sample_project_budget_limit(uuid=lid, project_uuid=pid)
+        )
+        self.project_service.delete_budget_limit_from_project = MagicMock(
+            return_value=limit_out
+        )
+        res = self.client.delete(f'{self.prefix}/projects/{pid}/budget-limits/{lid}')
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder(limit_out)
+        self.project_service.delete_budget_limit_from_project.assert_called_once_with(
+            pid, lid
+        )
+
+    def test_delete_budget_limit_from_project_not_found(self):
+        pid, lid = uuid.uuid4(), uuid.uuid4()
+        self.project_service.delete_budget_limit_from_project = MagicMock(
+            side_effect=ProjectBudgetLimitNotFoundError('nope')
+        )
+        res = self.client.delete(f'{self.prefix}/projects/{pid}/budget-limits/{lid}')
         assert res.status_code == 404
 
     # --- route_meta ---

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -26,6 +26,7 @@ from radicalbit_ai_gateway.utils.exceptions import (
     ProjectAlreadyExistsError,
     ProjectBudgetLimitAlreadyExistsError,
     ProjectBudgetLimitConflictError,
+    ProjectBudgetLimitNotFoundError,
     ProjectConfigValidationError,
     ProjectNotFoundError,
 )
@@ -475,6 +476,35 @@ class ProjectServiceTest(DatabaseIntegration):
     def test_get_budget_limits_for_project_not_found(self):
         with pytest.raises(ProjectNotFoundError):
             self.svc.get_budget_limits_for_project(uuid.uuid4())
+
+    def test_delete_budget_limit_from_project_ok(self):
+        out, _, _ = self._create(name='budget-delete-ok')
+        [limit] = self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        deleted = self.svc.delete_budget_limit_from_project(out.uuid, limit.uuid)
+        assert deleted.uuid == limit.uuid
+        assert self.svc.get_budget_limits_for_project(out.uuid) == []
+
+    def test_delete_budget_limit_from_project_not_found_project(self):
+        with pytest.raises(ProjectNotFoundError):
+            self.svc.delete_budget_limit_from_project(uuid.uuid4(), uuid.uuid4())
+
+    def test_delete_budget_limit_from_project_not_found_limit(self):
+        out, _, _ = self._create(name='budget-delete-not-found')
+        with pytest.raises(ProjectBudgetLimitNotFoundError):
+            self.svc.delete_budget_limit_from_project(out.uuid, uuid.uuid4())
+
+    def test_delete_budget_limit_from_project_not_found_when_owned_by_other_project(
+        self,
+    ):
+        owner, _, _ = self._create(name='budget-delete-owner')
+        other, _, _ = self._create(name='budget-delete-other')
+        [limit] = self.svc.add_budget_limits_to_project(
+            owner.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        with pytest.raises(ProjectBudgetLimitNotFoundError):
+            self.svc.delete_budget_limit_from_project(other.uuid, limit.uuid)
 
     # --- reverse validation: route config vs. existing project budget limit ---
 


### PR DESCRIPTION
## Summary

Adds a REST endpoint to delete a single budget limit configured on a project. Since a project can have multiple limits (one per time window — e.g. daily, monthly), the endpoint targets a specific limit by its own UUID rather than removing all limits for a category.

- `DELETE /projects/{project_uuid}/budget-limits/{limit_uuid}` — deletes the given limit and returns it in the response body.
- Returns `404` if the project doesn't exist, or if the limit doesn't exist or doesn't belong to that project (ownership is validated so one project's limit can't be deleted via another project's ID).
- Removes the row from the `project_budget_limit` table; no schema/migration changes required.

## Implementation

- `ProjectBudgetLimitDAO.delete_by_uuid` — new DAO method, mirrors the existing `KeyDAO.delete_by_uuid` pattern.
- `ProjectService.delete_budget_limit_from_project` — validates project/limit existence and ownership, builds the response before deleting, then deletes.
- `ProjectBudgetLimitNotFoundError` — new 404 exception, following the existing `ProjectNotFoundError` pattern.
- New route in `project_route.py`, reusing the existing `ProjectBudgetLimitOut` response schema; no router/wiring changes needed since the router is already registered.

## Tests

- DAO: delete an existing limit, delete a non-existent one (rowcount 0).
- Service: successful delete, project not found, limit not found, and limit belonging to a different project.
- Route: success (200) and not-found (404) cases, mocking the service layer per existing conventions.
