### PR TITLE
feat: delete credential limits endpoint

### DIFF
--- a/gateway/radicalbit_ai_gateway/db/dao/key_limit_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/key_limit_dao.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from radicalbit_ai_gateway.db.database import Database
 from radicalbit_ai_gateway.db.tables.key_limit_table import KeyLimit
@@ -41,3 +41,8 @@ class KeyLimitDAO:
         with self.db.begin_session() as session:
             stmt = select(KeyLimit).where(KeyLimit.key_uuid.in_(key_uuids))
             return session.scalars(stmt).all()
+
+    def delete_by_uuid(self, limit_uuid: UUID) -> int:
+        with self.db.begin_session() as session:
+            query = delete(KeyLimit).where(KeyLimit.uuid == limit_uuid)
+            return session.execute(query).rowcount

--- a/gateway/radicalbit_ai_gateway/limiter/storage/base.py
+++ b/gateway/radicalbit_ai_gateway/limiter/storage/base.py
@@ -64,3 +64,12 @@ class Storage(ABC):
             Tuple of (new_count, window_id).
 
         """
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        """Delete a key's counter, if present.
+
+        Args:
+            key: The storage key.
+
+        """

--- a/gateway/radicalbit_ai_gateway/limiter/storage/base.py
+++ b/gateway/radicalbit_ai_gateway/limiter/storage/base.py
@@ -67,9 +67,4 @@ class Storage(ABC):
 
     @abstractmethod
     async def delete(self, key: str) -> None:
-        """Delete a key's counter, if present.
-
-        Args:
-            key: The storage key.
-
-        """
+        """Delete a key's counter, if present."""

--- a/gateway/radicalbit_ai_gateway/limiter/storage/memory.py
+++ b/gateway/radicalbit_ai_gateway/limiter/storage/memory.py
@@ -96,3 +96,8 @@ class InMemoryStorage(Storage):
                 window_start=window_start,
             )
             return new_value, window_id
+
+    async def delete(self, key: str) -> None:
+        """Delete a key's counter, if present."""
+        async with self._lock:
+            self._data.pop(key, None)

--- a/gateway/radicalbit_ai_gateway/limiter/storage/redis.py
+++ b/gateway/radicalbit_ai_gateway/limiter/storage/redis.py
@@ -95,6 +95,10 @@ class RedisStorage(Storage):
         returned_window_id = result[1].decode('utf-8')
         return new_value, returned_window_id
 
+    async def delete(self, key: str) -> None:
+        """Delete a key's counter, if present."""
+        await self._client.delete(key)
+
     async def close(self) -> None:
         """Close the Redis connection."""
         await self._client.aclose()

--- a/gateway/radicalbit_ai_gateway/limiting/credential_limiter.py
+++ b/gateway/radicalbit_ai_gateway/limiting/credential_limiter.py
@@ -350,3 +350,33 @@ class CredentialLimiter:
     ) -> None:
         cost = int(seconds * cost_per_second * BUDGET_MULTIPLIER)
         await self._hit(CredentialLimitCategory.BUDGET, cost=cost)
+
+
+async def clear_limit_counter(
+    *, credential_uuid: str, category: str, algorithm: str, window_size: str
+) -> None:
+    """Delete the stored counter for one credential limit.
+
+    The storage key is derived from credential_uuid + category + algorithm +
+    window_size, not the limit's own uuid — so deleting a limit and then
+    recreating one with the same category/algorithm/window would otherwise
+    inherit the deleted one's usage unless this runs first.
+    """
+    if app_config.redis_config.redis_url:
+        storage = RedisStorage(uri=app_config.redis_config.redis_url)
+    else:
+        storage = InMemoryStorage()
+    limiter_cls = (
+        AlignedFixedWindowLimiter
+        if algorithm == LimitingAlgorithmType.ALIGNED_FIXED_WINDOW.value
+        else FixedWindowLimiter
+    )
+    limiter = limiter_cls(storage)
+    window = WindowConfig.from_parts(
+        limit=0,
+        window=window_size,
+        project_uuid=credential_uuid,
+        route_name='*',
+        scenario_type=ScenarioType(category),
+    )
+    await storage.delete(limiter._build_key(window))

--- a/gateway/radicalbit_ai_gateway/limiting/credential_limiter.py
+++ b/gateway/radicalbit_ai_gateway/limiting/credential_limiter.py
@@ -355,13 +355,7 @@ class CredentialLimiter:
 async def clear_limit_counter(
     *, credential_uuid: str, category: str, algorithm: str, window_size: str
 ) -> None:
-    """Delete the stored counter for one credential limit.
-
-    The storage key is derived from credential_uuid + category + algorithm +
-    window_size, not the limit's own uuid — so deleting a limit and then
-    recreating one with the same category/algorithm/window would otherwise
-    inherit the deleted one's usage unless this runs first.
-    """
+    """Key is derived from category/algorithm/window_size, not the limit's uuid."""
     if app_config.redis_config.redis_url:
         storage = RedisStorage(uri=app_config.redis_config.redis_url)
     else:

--- a/gateway/radicalbit_ai_gateway/routes/key_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/key_route.py
@@ -108,4 +108,15 @@ class KeyRoute:
         def get_limits_for_key(key_uuid: UUID):
             return key_service.get_limits_for_key(key_uuid)
 
+        @router.delete(
+            '/keys/{key_uuid}/limits/{limit_uuid}',
+            status_code=200,
+            response_model=CredentialLimitOut,
+        )
+        @route_meta(entity_type='KEY', entity_uuid_param='key_uuid')
+        async def delete_limit_from_key(key_uuid: UUID, limit_uuid: UUID):
+            limit = await key_service.delete_limit_from_key(key_uuid, limit_uuid)
+            logger.info('Deleted limit %s from key %s', limit_uuid, key_uuid)
+            return limit
+
         return router

--- a/gateway/radicalbit_ai_gateway/services/key_service.py
+++ b/gateway/radicalbit_ai_gateway/services/key_service.py
@@ -1,3 +1,4 @@
+import logging
 from uuid import UUID
 
 from sqlalchemy.exc import IntegrityError
@@ -5,6 +6,7 @@ from sqlalchemy.exc import IntegrityError
 from radicalbit_ai_gateway.db.dao.group_dao import GroupDAO
 from radicalbit_ai_gateway.db.dao.key_dao import KeyDAO
 from radicalbit_ai_gateway.db.dao.key_limit_dao import KeyLimitDAO
+from radicalbit_ai_gateway.limiting.credential_limiter import clear_limit_counter
 from radicalbit_ai_gateway.models.auth_dto import (
     GroupFullOut,
     KeyFullOut,
@@ -16,8 +18,10 @@ from radicalbit_ai_gateway.models.credential_limiting import (
     CredentialLimitsIn,
 )
 from radicalbit_ai_gateway.services.api_key_security import ApiKeySecurity
+from radicalbit_ai_gateway.utils.app_config import get_app_config
 from radicalbit_ai_gateway.utils.exceptions import (
     CredentialLimitAlreadyExistsError,
+    CredentialLimitNotFoundError,
     GroupNotFoundError,
     KeyAlreadyExistsError,
     KeyGroupAlreadyExistsError,
@@ -25,6 +29,9 @@ from radicalbit_ai_gateway.utils.exceptions import (
     KeyNotFoundError,
     KeyOperationNotAllowedError,
 )
+
+app_config = get_app_config()
+logger = logging.getLogger(app_config.log_config.logger_name)
 
 
 class KeyService:
@@ -275,3 +282,38 @@ class KeyService:
             CredentialLimitOut.from_key_limit(limit)
             for limit in self.key_limit_dao.get_by_key_uuid(key_uuid)
         ]
+
+    async def delete_limit_from_key(
+        self, key_uuid: UUID, limit_uuid: UUID
+    ) -> CredentialLimitOut:
+        key = self.key_dao.get_by_uuid(key_uuid)
+        if not key:
+            raise KeyNotFoundError(f'Key with UUID {key_uuid} not exists')
+        limit = self.key_limit_dao.get_by_uuid(limit_uuid)
+        if not limit or limit.key_uuid != key_uuid:
+            raise CredentialLimitNotFoundError(
+                f'Limit {limit_uuid} not found for key "{key.name}"'
+            )
+        # Built before deletion so the caller still sees what was removed.
+        out = CredentialLimitOut.from_key_limit(limit)
+        self.key_limit_dao.delete_by_uuid(limit_uuid)
+        try:
+            await clear_limit_counter(
+                credential_uuid=str(key_uuid),
+                category=limit.category,
+                algorithm=limit.algorithm,
+                window_size=limit.window_size,
+            )
+        except Exception:
+            # The DB row is already gone — that's the source of truth for
+            # whether the limit exists. A stale counter left behind here
+            # would only matter if a new limit with the exact same
+            # category/algorithm/window is created before it naturally
+            # expires, so this is worth logging but not worth failing the
+            # request over.
+            logger.exception(
+                'Failed to clear the limit counter for limit %s on key %s',
+                limit_uuid,
+                key_uuid,
+            )
+        return out

--- a/gateway/radicalbit_ai_gateway/services/key_service.py
+++ b/gateway/radicalbit_ai_gateway/services/key_service.py
@@ -294,7 +294,6 @@ class KeyService:
             raise CredentialLimitNotFoundError(
                 f'Limit {limit_uuid} not found for key "{key.name}"'
             )
-        # Built before deletion so the caller still sees what was removed.
         out = CredentialLimitOut.from_key_limit(limit)
         self.key_limit_dao.delete_by_uuid(limit_uuid)
         try:
@@ -305,12 +304,7 @@ class KeyService:
                 window_size=limit.window_size,
             )
         except Exception:
-            # The DB row is already gone — that's the source of truth for
-            # whether the limit exists. A stale counter left behind here
-            # would only matter if a new limit with the exact same
-            # category/algorithm/window is created before it naturally
-            # expires, so this is worth logging but not worth failing the
-            # request over.
+            # best-effort: the DB row is already gone, that's what matters
             logger.exception(
                 'Failed to clear the limit counter for limit %s on key %s',
                 limit_uuid,

--- a/gateway/radicalbit_ai_gateway/utils/exceptions.py
+++ b/gateway/radicalbit_ai_gateway/utils/exceptions.py
@@ -541,6 +541,16 @@ class CredentialLimitAlreadyExistsError(AuthRegistryError):
         )
 
 
+class CredentialLimitNotFoundError(AuthRegistryError):
+    def __init__(self, message: str, *, log_message: str | None = None):
+        super().__init__(
+            message,
+            status.HTTP_404_NOT_FOUND,
+            'credential_limit_not_found',
+            log_message=log_message,
+        )
+
+
 class GroupInternalError(AuthRegistryError):
     def __init__(self, message: str, *, log_message: str | None = None):
         super().__init__(

--- a/gateway/tests/dao/key_limit_dao_test.py
+++ b/gateway/tests/dao/key_limit_dao_test.py
@@ -116,3 +116,15 @@ class KeyLimitDAOTest(DatabaseIntegration):
         deleted_rows = self.key_dao.delete_by_uuid(key.uuid)
         assert deleted_rows == 1
         assert self.key_limit_dao.get_by_key_uuid(key.uuid) == []
+
+    def test_delete_by_uuid(self):
+        key = self._insert_key()
+        limit = self.key_limit_dao.insert(
+            db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key.uuid)
+        )
+        deleted_rows = self.key_limit_dao.delete_by_uuid(limit.uuid)
+        assert deleted_rows == 1
+        assert self.key_limit_dao.get_by_uuid(limit.uuid) is None
+
+    def test_delete_by_uuid_missing_returns_zero(self):
+        assert self.key_limit_dao.delete_by_uuid(uuid.uuid4()) == 0

--- a/gateway/tests/limiter/test_inmemory_storage.py
+++ b/gateway/tests/limiter/test_inmemory_storage.py
@@ -233,3 +233,19 @@ class TestInMemoryStorage:
             window_id_2 = await storage.get_window_id('test-key')
             assert window_id_2 is not None
             assert window_id_1 != window_id_2
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_existing_key(self) -> None:
+        storage = InMemoryStorage()
+        window_start = time.time_ns() // 1_000_000_000
+        await storage.increment(
+            'test-key', 5, ttl_seconds=60, window_start=window_start
+        )
+        await storage.delete('test-key')
+        assert await storage.get('test-key') is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_key_is_a_noop(self) -> None:
+        storage = InMemoryStorage()
+        await storage.delete('nonexistent')  # must not raise
+        assert await storage.get('nonexistent') is None

--- a/gateway/tests/limiter/test_redis_storage.py
+++ b/gateway/tests/limiter/test_redis_storage.py
@@ -157,3 +157,21 @@ class TestRedisStorage:
         window_id_2 = await redis_storage.get_window_id(key)
         assert window_id_2 is not None
         assert window_id_1 != window_id_2
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_existing_key(
+        self, redis_storage: RedisStorage
+    ) -> None:
+        window_start = time.time_ns() // 1_000_000_000
+        await redis_storage.increment(
+            'test-key-delete', 5, ttl_seconds=60, window_start=window_start
+        )
+        await redis_storage.delete('test-key-delete')
+        assert await redis_storage.get('test-key-delete') is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_key_is_a_noop(
+        self, redis_storage: RedisStorage
+    ) -> None:
+        await redis_storage.delete('nonexistent-key')  # must not raise
+        assert await redis_storage.get('nonexistent-key') is None

--- a/gateway/tests/limiting/test_credential_limiter.py
+++ b/gateway/tests/limiting/test_credential_limiter.py
@@ -5,7 +5,10 @@ import pytest
 
 from tests.common.db_mock import GROUP_UUID, REQUEST_UUID
 
-from radicalbit_ai_gateway.limiting.credential_limiter import CredentialLimiter
+from radicalbit_ai_gateway.limiting.credential_limiter import (
+    CredentialLimiter,
+    clear_limit_counter,
+)
 from radicalbit_ai_gateway.models.credential_limiting import (
     CredentialLimitCategory,
     CredentialLimitOut,
@@ -208,3 +211,67 @@ class TestCredentialScoping:
 
         # credential B, same route, untouched
         await limiter_b.check_and_count_request(**_CALL_ARGS)
+
+
+class TestClearLimitCounter:
+    @pytest.mark.asyncio
+    async def test_clears_the_same_key_the_limiter_uses(self):
+        limiter = _limiter(
+            [_limit(CredentialLimitCategory.RATE, 2, window_size='1 minute')]
+        )
+        entry = limiter._entries[CredentialLimitCategory.RATE][0]
+        await entry.limiter.hit(entry.window, cost=1)
+        assert (await entry.limiter.get_window_stats(entry.window)).remaining == 1
+
+        with patch(
+            'radicalbit_ai_gateway.limiting.credential_limiter.InMemoryStorage',
+            return_value=entry.limiter._storage,
+        ):
+            await clear_limit_counter(
+                credential_uuid=_CREDENTIAL_UUID,
+                category=CredentialLimitCategory.RATE.value,
+                algorithm=LimitingAlgorithmType.FIXED_WINDOW.value,
+                window_size='1 minute',
+            )
+
+        stats = await entry.limiter.get_window_stats(entry.window)
+        assert stats.remaining == 2  # back to full capacity
+
+    @pytest.mark.asyncio
+    async def test_matches_aligned_fixed_window_key(self):
+        limiter = _limiter(
+            [
+                _limit(
+                    CredentialLimitCategory.BUDGET,
+                    5,
+                    window_size='1 hour',
+                    algorithm=LimitingAlgorithmType.ALIGNED_FIXED_WINDOW,
+                )
+            ]
+        )
+        entry = limiter._entries[CredentialLimitCategory.BUDGET][0]
+        await entry.limiter.hit(entry.window, cost=1)
+
+        with patch(
+            'radicalbit_ai_gateway.limiting.credential_limiter.InMemoryStorage',
+            return_value=entry.limiter._storage,
+        ):
+            await clear_limit_counter(
+                credential_uuid=_CREDENTIAL_UUID,
+                category=CredentialLimitCategory.BUDGET.value,
+                algorithm=LimitingAlgorithmType.ALIGNED_FIXED_WINDOW.value,
+                window_size='1 hour',
+            )
+
+        stats = await entry.limiter.get_window_stats(entry.window)
+        # BUDGET values are stored in micro-units (BUDGET_MULTIPLIER).
+        assert stats.remaining == entry.window.limit
+
+    @pytest.mark.asyncio
+    async def test_clearing_a_never_hit_counter_does_not_raise(self):
+        await clear_limit_counter(
+            credential_uuid=str(uuid4()),
+            category=CredentialLimitCategory.RATE.value,
+            algorithm=LimitingAlgorithmType.FIXED_WINDOW.value,
+            window_size='1 minute',
+        )

--- a/gateway/tests/routes/test_key_route.py
+++ b/gateway/tests/routes/test_key_route.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 import uuid
 
 from fastapi import FastAPI
@@ -14,6 +14,7 @@ from radicalbit_ai_gateway.routes.key_route import KeyRoute
 from radicalbit_ai_gateway.services.key_service import KeyService
 from radicalbit_ai_gateway.utils.exceptions import (
     AuthRegistryError,
+    CredentialLimitNotFoundError,
     ErrorOut,
     KeyInternalError,
     KeyNotFoundError,
@@ -321,6 +322,53 @@ class TestKeyRoute(unittest.TestCase):
             side_effect=KeyNotFoundError('error')
         )
         res = self.client.get(f'{self.prefix}/keys/{key.uuid}/limits')
+        assert res.status_code == 404
+        assert (
+            res.json()['error']
+            == ErrorOut(
+                'error', 'auth_registry_error', code='key_not_found', param=None
+            ).error
+        )
+
+    def test_delete_limit_from_key_success(self):
+        key = db_mock.get_sample_key()
+        limit_out = CredentialLimitOut.from_key_limit(
+            db_mock.get_sample_key_limit(uuid=uuid.uuid4(), key_uuid=key.uuid)
+        )
+        self.key_service.delete_limit_from_key = AsyncMock(return_value=limit_out)
+        res = self.client.delete(
+            f'{self.prefix}/keys/{key.uuid}/limits/{limit_out.uuid}'
+        )
+        assert res.status_code == 200
+        assert res.json() == jsonable_encoder(limit_out)
+        self.key_service.delete_limit_from_key.assert_awaited_once_with(
+            key.uuid, limit_out.uuid
+        )
+
+    def test_delete_limit_from_key_not_found(self):
+        key = db_mock.get_sample_key()
+        self.key_service.delete_limit_from_key = AsyncMock(
+            side_effect=CredentialLimitNotFoundError('error')
+        )
+        res = self.client.delete(f'{self.prefix}/keys/{key.uuid}/limits/{uuid.uuid4()}')
+        assert res.status_code == 404
+        assert (
+            res.json()['error']
+            == ErrorOut(
+                'error',
+                'auth_registry_error',
+                code='credential_limit_not_found',
+                param=None,
+            ).error
+        )
+
+    def test_delete_limit_from_key_key_not_found(self):
+        self.key_service.delete_limit_from_key = AsyncMock(
+            side_effect=KeyNotFoundError('error')
+        )
+        res = self.client.delete(
+            f'{self.prefix}/keys/{uuid.uuid4()}/limits/{uuid.uuid4()}'
+        )
         assert res.status_code == 404
         assert (
             res.json()['error']

--- a/gateway/tests/services/key_service_test.py
+++ b/gateway/tests/services/key_service_test.py
@@ -558,10 +558,7 @@ class TestDeleteLimitFromKey:
 
     @pytest.mark.asyncio
     async def test_redis_clear_failure_does_not_fail_the_request(self):
-        """The DB row is the source of truth: a Redis-side error clearing the
-        counter must not undo (or fail to report) an already-successful
-        deletion.
-        """
+        """A Redis-side error clearing the counter must not undo the delete."""
         service, key_dao, key_limit_dao = self._make_service()
         key_uuid = uuid.uuid4()
         limit_uuid = uuid.uuid4()

--- a/gateway/tests/services/key_service_test.py
+++ b/gateway/tests/services/key_service_test.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 import pytest
@@ -24,6 +24,7 @@ from radicalbit_ai_gateway.services.api_key_security import ApiKeySecurity
 from radicalbit_ai_gateway.services.key_service import KeyService
 from radicalbit_ai_gateway.utils.exceptions import (
     CredentialLimitAlreadyExistsError,
+    CredentialLimitNotFoundError,
     KeyGroupAlreadyExistsError,
     KeyInternalError,
     KeyNotFoundError,
@@ -475,3 +476,106 @@ class KeyServiceTest(unittest.TestCase):
             self.key_service.get_limits_for_key,
             uuid.uuid4(),
         )
+
+
+class TestDeleteLimitFromKey:
+    def _make_service(self):
+        key_dao = MagicMock(spec_set=KeyDAO)
+        key_limit_dao = MagicMock(spec_set=KeyLimitDAO)
+        service = KeyService(
+            key_dao=key_dao,
+            api_key_security=MagicMock(spec_set=ApiKeySecurity),
+            group_dao=MagicMock(spec_set=GroupDAO),
+            key_limit_dao=key_limit_dao,
+        )
+        return service, key_dao, key_limit_dao
+
+    @pytest.mark.asyncio
+    async def test_ok(self):
+        service, key_dao, key_limit_dao = self._make_service()
+        key_uuid = uuid.uuid4()
+        limit_uuid = uuid.uuid4()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        limit = db_mock.get_sample_key_limit(uuid=limit_uuid, key_uuid=key_uuid)
+        key_dao.get_by_uuid = MagicMock(return_value=key)
+        key_limit_dao.get_by_uuid = MagicMock(return_value=limit)
+        key_limit_dao.delete_by_uuid = MagicMock(return_value=1)
+
+        with patch(
+            'radicalbit_ai_gateway.services.key_service.clear_limit_counter',
+            new=AsyncMock(),
+        ) as mock_clear:
+            res = await service.delete_limit_from_key(key_uuid, limit_uuid)
+
+        key_limit_dao.delete_by_uuid.assert_called_once_with(limit_uuid)
+        mock_clear.assert_awaited_once_with(
+            credential_uuid=str(key_uuid),
+            category=limit.category,
+            algorithm=limit.algorithm,
+            window_size=limit.window_size,
+        )
+        assert res == CredentialLimitOut.from_key_limit(limit)
+
+    @pytest.mark.asyncio
+    async def test_key_not_found(self):
+        service, key_dao, key_limit_dao = self._make_service()
+        key_dao.get_by_uuid = MagicMock(return_value=None)
+
+        with pytest.raises(KeyNotFoundError):
+            await service.delete_limit_from_key(uuid.uuid4(), uuid.uuid4())
+        key_limit_dao.delete_by_uuid.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_limit_not_found(self):
+        service, key_dao, key_limit_dao = self._make_service()
+        key_uuid = uuid.uuid4()
+        key_dao.get_by_uuid = MagicMock(
+            return_value=db_mock.get_sample_key(uuid=key_uuid)
+        )
+        key_limit_dao.get_by_uuid = MagicMock(return_value=None)
+
+        with pytest.raises(CredentialLimitNotFoundError):
+            await service.delete_limit_from_key(key_uuid, uuid.uuid4())
+        key_limit_dao.delete_by_uuid.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_limit_belongs_to_a_different_key(self):
+        service, key_dao, key_limit_dao = self._make_service()
+        key_uuid = uuid.uuid4()
+        limit_uuid = uuid.uuid4()
+        key_dao.get_by_uuid = MagicMock(
+            return_value=db_mock.get_sample_key(uuid=key_uuid)
+        )
+        key_limit_dao.get_by_uuid = MagicMock(
+            return_value=db_mock.get_sample_key_limit(
+                uuid=limit_uuid, key_uuid=uuid.uuid4()
+            )
+        )
+
+        with pytest.raises(CredentialLimitNotFoundError):
+            await service.delete_limit_from_key(key_uuid, limit_uuid)
+        key_limit_dao.delete_by_uuid.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis_clear_failure_does_not_fail_the_request(self):
+        """The DB row is the source of truth: a Redis-side error clearing the
+        counter must not undo (or fail to report) an already-successful
+        deletion.
+        """
+        service, key_dao, key_limit_dao = self._make_service()
+        key_uuid = uuid.uuid4()
+        limit_uuid = uuid.uuid4()
+        key = db_mock.get_sample_key(uuid=key_uuid)
+        limit = db_mock.get_sample_key_limit(uuid=limit_uuid, key_uuid=key_uuid)
+        key_dao.get_by_uuid = MagicMock(return_value=key)
+        key_limit_dao.get_by_uuid = MagicMock(return_value=limit)
+        key_limit_dao.delete_by_uuid = MagicMock(return_value=1)
+
+        with patch(
+            'radicalbit_ai_gateway.services.key_service.clear_limit_counter',
+            new=AsyncMock(side_effect=ConnectionError('redis unreachable')),
+        ):
+            res = await service.delete_limit_from_key(key_uuid, limit_uuid)
+
+        key_limit_dao.delete_by_uuid.assert_called_once_with(limit_uuid)
+        assert res == CredentialLimitOut.from_key_limit(limit)


### PR DESCRIPTION
# PR Summary: feat/AG-920-delete-credential-limit (BE only)

Adds an endpoint to delete a single limit from a credential. A credential
can have several limits per category (different windows), so deletion
targets one limit by its own id, not the whole category. Also clears the
corresponding rate-limiting counter so a newly created limit with the same
category/algorithm/window doesn't inherit the deleted one's usage.

---

## DTO Changes

No new or modified DTOs — the endpoint returns the existing
`CredentialLimitOut` (unchanged shape), representing the limit that was
just deleted.

---

## Affected Endpoints

### `DELETE /keys/{key_uuid}/limits/{limit_uuid}` (NEW)

**Example request:**
```
DELETE /keys/550e8400-e29b-41d4-a716-446655440000/limits/661f9511-f3ac-52e5-b827-557766551111
```

| Parameter | Type | Required | Description |
|-----------|------|----------|--------------|
| `key_uuid` | string | yes | Credential UUID (path) |
| `limit_uuid` | string | yes | UUID of the specific limit to delete (path) |

**Example response (200):**
```json
{
  "uuid": "661f9511-f3ac-52e5-b827-557766551111",
  "category": "request_rate",
  "algorithm": "FIXED_WINDOW",
  "windowSize": "1 minute",
  "value": 5,
  "createdAt": "2024-01-15T10:30:00Z",
  "updatedAt": "2024-01-15T10:30:00Z"
}
```

**Errors:**
- `404` `key_not_found` — `key_uuid` doesn't exist.
- `404` `credential_limit_not_found` — `limit_uuid` doesn't exist, or exists but belongs to a different credential.

---

## Other Changes

- `services/key_service.py` — `KeyService.delete_limit_from_key`: looks up
  the limit, verifies it belongs to the given credential, deletes the DB
  row, then clears the corresponding rate-limiting counter. This is the
  only `async` method on `KeyService` — needed because clearing the counter
  is an async I/O call. The counter clear is **best-effort**: if it fails
  (e.g. the storage backend is unreachable), the error is logged but the
  request still succeeds, since the DB row (already deleted) is the source
  of truth for whether the limit exists.
- `limiting/credential_limiter.py` — new `clear_limit_counter()` function.
  The counter's storage key is derived from
  `credential_uuid + category + algorithm + window_size`, not the limit's
  own id, so this reconstructs that same key (via the same limiter classes
  used for enforcement) and deletes it.
- `limiter/storage/base.py`, `limiter/storage/redis.py`,
  `limiter/storage/memory.py` — new `Storage.delete(key)` method,
  implemented for both the Redis and in-memory backends.
- `db/dao/key_limit_dao.py` — new `KeyLimitDAO.delete_by_uuid()`.
- `utils/exceptions.py` — new `CredentialLimitNotFoundError` (404).
- `routes/key_route.py` — wires the new endpoint; route-meta tagged the
  same way as the other key-scoped mutations, for audit logging.
- Test coverage: storage-level `delete()` for both backends, DAO
  `delete_by_uuid`, `clear_limit_counter` (including the
  `ALIGNED_FIXED_WINDOW` case), the service method (success, key not
  found, limit not found, limit belonging to a different key, and the
  counter-clear-failure-doesn't-fail-the-request case), and the route.
