### PR TITLE
fix(docker): bump ui build stages to node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ============================================
 # Stage 1: UI Dependencies Installation
 # ============================================
-FROM node:20-bookworm-slim AS ui-install
+FROM node:22-bookworm-slim AS ui-install
 
 WORKDIR /app
 
@@ -23,7 +23,7 @@ COPY ./ui/*.js ./ui/*.cjs ./ui/*.html ./
 # ============================================
 # Stage 2: UI Build
 # ============================================
-FROM node:20-bookworm-slim AS ui-build
+FROM node:22-bookworm-slim AS ui-build
 
 WORKDIR /app
 


### PR DESCRIPTION
@radicalbit/formbit@4.0.0 raised its engines requirement from node >=10 to node >=22. The ui-install and ui-build stages ran on node:20-bookworm-slim, and `yarn install --frozen-lockfile` treats an engine mismatch as fatal, so the pipeline build job failed on main after #112:

  error @radicalbit/formbit@4.0.0: The engine "node" is incompatible
  with this module. Expected version ">=22". Got "20.20.2"