### PR TITLE
feat(api): enforce project budget limits counter

### DIFF
--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -649,6 +649,7 @@ class GatewayRoute:
             self.token_limiter
             or self.budget_limiter
             or get_current_credential_limiter()
+            or get_current_project_budget_limiter()
         ):
             set_operation_category(OperationCategory.LIMITING)
             await self._validate_embedding_limiters(
@@ -1079,6 +1080,7 @@ class GatewayRoute:
             self.token_limiter
             or self.budget_limiter
             or get_current_credential_limiter()
+            or get_current_project_budget_limiter()
         ):
             set_operation_category(OperationCategory.LIMITING)
             await self._validate_limiters(

--- a/gateway/radicalbit_ai_gateway/ai_gateway.py
+++ b/gateway/radicalbit_ai_gateway/ai_gateway.py
@@ -77,7 +77,10 @@ from radicalbit_ai_gateway.utils.exceptions import (
     GatewayInternalError,
     GuardrailBadRequest,
 )
-from radicalbit_ai_gateway.utils.request_context import get_current_credential_limiter
+from radicalbit_ai_gateway.utils.request_context import (
+    get_current_credential_limiter,
+    get_current_project_budget_limiter,
+)
 from radicalbit_ai_gateway.utils.streaming_utils import StreamingUtils
 from radicalbit_ai_gateway.utils.trace_attributes import (
     OperationCategory,
@@ -768,6 +771,11 @@ class GatewayRoute:
             set_operation_category(OperationCategory.LIMITING)
             await credential_limiter.check_budget()
 
+        project_budget_limiter = get_current_project_budget_limiter()
+        if project_budget_limiter:
+            set_operation_category(OperationCategory.LIMITING)
+            await project_budget_limiter.check_budget()
+
         if self.budget_limiter:
             set_operation_category(OperationCategory.LIMITING)
             await self.budget_limiter.check_budget()
@@ -847,6 +855,11 @@ class GatewayRoute:
         if credential_limiter:
             set_operation_category(OperationCategory.LIMITING)
             await credential_limiter.check_budget()
+
+        project_budget_limiter = get_current_project_budget_limiter()
+        if project_budget_limiter:
+            set_operation_category(OperationCategory.LIMITING)
+            await project_budget_limiter.check_budget()
 
         if self.budget_limiter:
             set_operation_category(OperationCategory.LIMITING)
@@ -1744,6 +1757,10 @@ class GatewayRoute:
             )
             await credential_limiter.check_budget()
 
+        project_budget_limiter = get_current_project_budget_limiter()
+        if project_budget_limiter:
+            await project_budget_limiter.check_budget()
+
         if self.token_limiter:
             if self.token_limiter.input_config:
                 await self.token_limiter.check_input(
@@ -1801,6 +1818,10 @@ class GatewayRoute:
             )
             await credential_limiter.check_budget()
 
+        project_budget_limiter = get_current_project_budget_limiter()
+        if project_budget_limiter:
+            await project_budget_limiter.check_budget()
+
         if self.token_limiter and self.token_limiter.input_config:
             await self.token_limiter.check_input(
                 text=user_content,
@@ -1854,6 +1875,19 @@ class GatewayRoute:
                     output_cost_per_token=model_selected.output_cost_per_token,
                 )
 
+        project_budget_limiter = get_current_project_budget_limiter()
+        if project_budget_limiter:
+            if model_selected.input_cost_per_token:
+                await project_budget_limiter.count_input(
+                    token_count=prompt_tokens,
+                    input_cost_per_token=model_selected.input_cost_per_token,
+                )
+            if model_selected.output_cost_per_token:
+                await project_budget_limiter.count_output(
+                    token_count=completion_tokens,
+                    output_cost_per_token=model_selected.output_cost_per_token,
+                )
+
     async def _count_transcription_usage(
         self,
         usage: UsageTokens | UsageDuration | None,
@@ -1861,7 +1895,12 @@ class GatewayRoute:
     ) -> None:
         """Count budget usage from a transcription response, mirroring _count_usage."""
         credential_limiter = get_current_credential_limiter()
-        if self.budget_limiter is None and credential_limiter is None:
+        project_budget_limiter = get_current_project_budget_limiter()
+        if (
+            self.budget_limiter is None
+            and credential_limiter is None
+            and project_budget_limiter is None
+        ):
             return
         if usage is None:
             return
@@ -1876,6 +1915,11 @@ class GatewayRoute:
                     )
                 if credential_limiter:
                     await credential_limiter.count_budget_duration(
+                        seconds=usage.seconds,
+                        cost_per_second=cost_per_second,
+                    )
+                if project_budget_limiter:
+                    await project_budget_limiter.count_duration(
                         seconds=usage.seconds,
                         cost_per_second=cost_per_second,
                     )
@@ -1898,6 +1942,11 @@ class GatewayRoute:
                     token_count=audio_tokens,
                     input_cost_per_token=model_selected.input_cost_per_audio_token,
                 )
+            if project_budget_limiter:
+                await project_budget_limiter.count_input(
+                    token_count=audio_tokens,
+                    input_cost_per_token=model_selected.input_cost_per_audio_token,
+                )
         if text_tokens > 0 and model_selected.input_cost_per_token:
             if self.budget_limiter:
                 await self.budget_limiter.count_input(
@@ -1909,6 +1958,11 @@ class GatewayRoute:
                     token_count=text_tokens,
                     input_cost_per_token=model_selected.input_cost_per_token,
                 )
+            if project_budget_limiter:
+                await project_budget_limiter.count_input(
+                    token_count=text_tokens,
+                    input_cost_per_token=model_selected.input_cost_per_token,
+                )
         if usage.output_tokens > 0 and model_selected.output_cost_per_token:
             if self.budget_limiter:
                 await self.budget_limiter.count_output(
@@ -1917,6 +1971,11 @@ class GatewayRoute:
                 )
             if credential_limiter:
                 await credential_limiter.count_budget_output(
+                    token_count=usage.output_tokens,
+                    output_cost_per_token=model_selected.output_cost_per_token,
+                )
+            if project_budget_limiter:
+                await project_budget_limiter.count_output(
                     token_count=usage.output_tokens,
                     output_cost_per_token=model_selected.output_cost_per_token,
                 )

--- a/gateway/radicalbit_ai_gateway/db/dao/project_budget_limit_dao.py
+++ b/gateway/radicalbit_ai_gateway/db/dao/project_budget_limit_dao.py
@@ -50,3 +50,10 @@ class ProjectBudgetLimitDAO:
                 ProjectBudgetLimit.uuid == limit_uuid
             )
             return session.execute(query).rowcount
+
+    def delete_by_project_uuid(self, project_uuid: UUID) -> int:
+        with self.db.begin_session() as session:
+            query = delete(ProjectBudgetLimit).where(
+                ProjectBudgetLimit.project_uuid == project_uuid
+            )
+            return session.execute(query).rowcount

--- a/gateway/radicalbit_ai_gateway/limiting/project_budget_limiter.py
+++ b/gateway/radicalbit_ai_gateway/limiting/project_budget_limiter.py
@@ -1,0 +1,188 @@
+from uuid import UUID
+
+from radicalbit_ai_gateway.db.dao.project_budget_limit_dao import ProjectBudgetLimitDAO
+from radicalbit_ai_gateway.limiter import (
+    AlignedFixedWindowLimiter,
+    FixedWindowLimiter,
+    InMemoryStorage,
+    RedisStorage,
+    ScenarioType,
+    WindowConfig,
+)
+from radicalbit_ai_gateway.limiter.window_config import WindowStats
+from radicalbit_ai_gateway.models.limiting import LimitingAlgorithmType
+from radicalbit_ai_gateway.models.project_budget_limiting import ProjectBudgetLimitOut
+from radicalbit_ai_gateway.utils import BUDGET_MULTIPLIER
+from radicalbit_ai_gateway.utils.app_config import get_app_config
+from radicalbit_ai_gateway.utils.exceptions import BudgetLimitExceededError
+
+app_config = get_app_config()
+
+
+class _LimitEntry:
+    __slots__ = ('limiter', 'window', 'limit_out')
+
+    def __init__(
+        self,
+        limiter: FixedWindowLimiter | AlignedFixedWindowLimiter,
+        window: WindowConfig,
+        limit_out: ProjectBudgetLimitOut,
+    ):
+        self.limiter = limiter
+        self.window = window
+        self.limit_out = limit_out
+
+
+class ProjectBudgetLimiter:
+    """Runtime enforcement of a project's own budget limits.
+
+    Built fresh per request from the project's configured budget limits
+    (``ProjectBudgetLimit`` rows) and published on a context var right
+    after authentication — like ``CredentialLimiter``, it can't live on
+    the ``GatewayRoute`` singleton: project budget limits can be added or
+    removed via the API at any time, independent of the route config, and
+    the route singleton is only rebuilt when a project's config is
+    (re-)served.
+
+    ``ProjectBudgetLimit`` has no category column — a project can only
+    carry budget limits — so this only covers the budget subset of what
+    ``CredentialLimiter`` does.
+
+    A project can have several budget limits with different windows.
+    Semantics are AND: every configured window is checked on every
+    request, and the request is blocked if any one of them is exceeded.
+    """
+
+    def __init__(
+        self,
+        project_uuid: str,
+        project_name: str,
+        limits: list[ProjectBudgetLimitOut],
+    ):
+        self.project_uuid = project_uuid
+        self.project_name = project_name
+        self._entries: list[_LimitEntry] = []
+
+        if not limits:
+            return
+
+        if app_config.redis_config.redis_url:
+            storage = RedisStorage(uri=app_config.redis_config.redis_url)
+        else:
+            storage = InMemoryStorage()
+        for limit in limits:
+            self._entries.append(self._build_entry(limit, storage))
+
+    def _build_entry(self, limit: ProjectBudgetLimitOut, storage) -> _LimitEntry:
+        limiter_cls = (
+            AlignedFixedWindowLimiter
+            if limit.algorithm == LimitingAlgorithmType.ALIGNED_FIXED_WINDOW
+            else FixedWindowLimiter
+        )
+        window = WindowConfig.from_parts(
+            limit=int(limit.value * BUDGET_MULTIPLIER),
+            window=limit.window_size,
+            # Sentinel: '*' takes the route slot — a project limit applies
+            # across every route in the project, not one.
+            project_uuid=self.project_uuid,
+            route_name='*',
+            scenario_type=ScenarioType.BUDGET,
+        )
+        return _LimitEntry(limiter=limiter_cls(storage), window=window, limit_out=limit)
+
+    async def _first_exceeded(
+        self, cost: int
+    ) -> tuple[_LimitEntry, WindowStats] | None:
+        """Test only, no hit — the first window that *cost* would exceed,
+        or None if all have room.
+        """
+        for entry in self._entries:
+            if not await entry.limiter.test(entry.window, cost=cost):
+                stats = await entry.limiter.get_window_stats(entry.window)
+                return entry, stats
+        return None
+
+    async def _hit(self, cost: int) -> None:
+        for entry in self._entries:
+            await entry.limiter.hit(entry.window, cost=cost)
+
+    async def check_budget(self) -> None:
+        if not self._entries:
+            return
+
+        exceeded = await self._first_exceeded(cost=1)
+        if exceeded is not None:
+            entry, stats = exceeded
+            raise BudgetLimitExceededError(
+                message=(
+                    f'Project budget limit exceeded: {entry.limit_out.value:g} '
+                    f'per {entry.limit_out.window_size} on project '
+                    f'"{self.project_name}". Please retry after '
+                    f'{stats.remaining_time} seconds.'
+                ),
+                log_message=(
+                    '[PROJECT BUDGET LIMIT] '
+                    f'[project={self.project_name}] '
+                    f'[limit={entry.limit_out.value:g}] '
+                    f'[window={entry.limit_out.window_size}] '
+                    f'[reset_s={stats.remaining_time}] [action=BLOCK]'
+                ),
+            )
+
+    async def count_input(self, token_count: int, input_cost_per_token: float) -> None:
+        cost = int(token_count * input_cost_per_token * BUDGET_MULTIPLIER)
+        await self._hit(cost)
+
+    async def count_output(
+        self, token_count: int, output_cost_per_token: float
+    ) -> None:
+        cost = int(token_count * output_cost_per_token * BUDGET_MULTIPLIER)
+        await self._hit(cost)
+
+    async def count_duration(self, seconds: float, cost_per_second: float) -> None:
+        cost = int(seconds * cost_per_second * BUDGET_MULTIPLIER)
+        await self._hit(cost)
+
+
+def load_project_budget_limiter(
+    project_uuid: str, project_name: str, dao: ProjectBudgetLimitDAO
+) -> ProjectBudgetLimiter | None:
+    """Build a ``ProjectBudgetLimiter`` from the project's current budget
+    limits, or None if it has none configured (mirrors how a
+    ``CredentialLimiter`` is only published when the credential has
+    limits).
+    """
+    if not project_uuid:
+        return None
+    limits = dao.get_by_project_uuid(UUID(project_uuid))
+    if not limits:
+        return None
+    return ProjectBudgetLimiter(
+        project_uuid=project_uuid,
+        project_name=project_name,
+        limits=[ProjectBudgetLimitOut.from_project_budget_limit(row) for row in limits],
+    )
+
+
+async def clear_project_budget_limit_counter(
+    *, project_uuid: str, algorithm: str, window_size: str
+) -> None:
+    """Key is derived from algorithm/window_size, not the limit's uuid."""
+    if app_config.redis_config.redis_url:
+        storage = RedisStorage(uri=app_config.redis_config.redis_url)
+    else:
+        storage = InMemoryStorage()
+    limiter_cls = (
+        AlignedFixedWindowLimiter
+        if algorithm == LimitingAlgorithmType.ALIGNED_FIXED_WINDOW.value
+        else FixedWindowLimiter
+    )
+    limiter = limiter_cls(storage)
+    window = WindowConfig.from_parts(
+        limit=0,
+        window=window_size,
+        project_uuid=project_uuid,
+        route_name='*',
+        scenario_type=ScenarioType.BUDGET,
+    )
+    await storage.delete(limiter._build_key(window))

--- a/gateway/radicalbit_ai_gateway/routes/project_route.py
+++ b/gateway/radicalbit_ai_gateway/routes/project_route.py
@@ -279,7 +279,7 @@ class ProjectRoute:
         )
         @route_meta(entity_type='PROJECT', entity_uuid_param='project_uuid')
         async def delete_project(project_uuid: UUID):
-            project = project_service.delete_project(project_uuid)
+            project = await project_service.delete_project(project_uuid)
             if deregister_project_routes and project.served_config_uuid:
                 await deregister_project_routes(project_uuid)
             logger.info('Deleted project %s', project_uuid)
@@ -360,7 +360,7 @@ class ProjectRoute:
         async def delete_budget_limit_from_project(
             project_uuid: UUID, limit_uuid: UUID
         ):
-            limit = project_service.delete_budget_limit_from_project(
+            limit = await project_service.delete_budget_limit_from_project(
                 project_uuid, limit_uuid
             )
             logger.info(

--- a/gateway/radicalbit_ai_gateway/server.py
+++ b/gateway/radicalbit_ai_gateway/server.py
@@ -41,6 +41,9 @@ from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.db.dao.request_event_dao import RequestEventDAO
 from radicalbit_ai_gateway.db.database import Database
 from radicalbit_ai_gateway.events.events_processor import set_alert_rule_service
+from radicalbit_ai_gateway.limiting.project_budget_limiter import (
+    load_project_budget_limiter,
+)
 from radicalbit_ai_gateway.mcp_proxy.upstream_client import McpUpstreamClient
 from radicalbit_ai_gateway.metrics.define_metrics import (
     request_latency_histogram,
@@ -129,6 +132,7 @@ from radicalbit_ai_gateway.utils.request_context import (
     get_current_credential_limiter,
     get_current_request_tags,
     reset_route_context,
+    set_current_project_budget_limiter,
     set_current_route_config,
 )
 from radicalbit_ai_gateway.utils.responses_streaming import (
@@ -656,6 +660,11 @@ async def chat_completions(
 
     ctx.project_uuid = route.project_uuid
     ctx.project_name = route.project_name
+    set_current_project_budget_limiter(
+        load_project_budget_limiter(
+            route.project_uuid, route.project_name, project_budget_limit_dao
+        )
+    )
 
     # Checked before route/project limits: decides which error is reported
     # when both would block.
@@ -887,6 +896,11 @@ async def embeddings(
 
     ctx.project_uuid = route.project_uuid
     ctx.project_name = route.project_name
+    set_current_project_budget_limiter(
+        load_project_budget_limiter(
+            route.project_uuid, route.project_name, project_budget_limit_dao
+        )
+    )
 
     # Check and count request rate limits BEFORE any processing. Credential
     # limit first: decides which error is reported when both would block.
@@ -984,6 +998,11 @@ async def audio_transcriptions(
 
     ctx.project_uuid = route.project_uuid
     ctx.project_name = route.project_name
+    set_current_project_budget_limiter(
+        load_project_budget_limiter(
+            route.project_uuid, route.project_name, project_budget_limit_dao
+        )
+    )
     request.state.otel_route_name = route_name
 
     # Check and count request rate limits BEFORE any processing. Credential
@@ -1199,6 +1218,11 @@ async def responses(
 
     ctx.project_uuid = route.project_uuid
     ctx.project_name = route.project_name
+    set_current_project_budget_limiter(
+        load_project_budget_limiter(
+            route.project_uuid, route.project_name, project_budget_limit_dao
+        )
+    )
 
     # Checked before route/project limits: decides which error is reported
     # when both would block.

--- a/gateway/radicalbit_ai_gateway/services/project_service.py
+++ b/gateway/radicalbit_ai_gateway/services/project_service.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import re
 from uuid import UUID
 import zipfile
@@ -10,6 +11,9 @@ from radicalbit_ai_gateway.db.dao.project_config_dao import ProjectConfigDAO
 from radicalbit_ai_gateway.db.dao.project_dao import ProjectDAO
 from radicalbit_ai_gateway.db.tables.project_config_table import ProjectConfig
 from radicalbit_ai_gateway.db.tables.project_table import Project
+from radicalbit_ai_gateway.limiting.project_budget_limiter import (
+    clear_project_budget_limit_counter,
+)
 from radicalbit_ai_gateway.models.config_slot import Slot
 from radicalbit_ai_gateway.models.config_status import ConfigStatus
 from radicalbit_ai_gateway.models.project_budget_limiting import (
@@ -24,6 +28,7 @@ from radicalbit_ai_gateway.models.project_dto import (
     ProjectIn,
     ProjectOut,
 )
+from radicalbit_ai_gateway.utils.app_config import get_app_config
 from radicalbit_ai_gateway.utils.exceptions import (
     ProjectAlreadyExistsError,
     ProjectBudgetLimitAlreadyExistsError,
@@ -38,6 +43,9 @@ from radicalbit_ai_gateway.utils.yaml_utils import (
     get_default_config_template,
     validate_gateway_config,
 )
+
+app_config = get_app_config()
+logger = logging.getLogger(app_config.log_config.logger_name)
 
 
 def _sanitize_filename(name: str) -> str:
@@ -207,7 +215,7 @@ class ProjectService:
             raise ProjectInternalError(f'Failed to unserve config {config_uuid}')
         return self._build_out_or_raise(project_uuid)
 
-    def delete_project(self, project_uuid: UUID) -> ProjectOut:
+    async def delete_project(self, project_uuid: UUID) -> ProjectOut:
         project = self._get_project_or_raise(project_uuid)
 
         # Build the response before deletion so the caller can still see the
@@ -220,6 +228,14 @@ class ProjectService:
 
         self.project_config_dao.soft_delete_by_project(project_uuid)
         self.project_dao.soft_delete(project_uuid)
+
+        # The project row is soft-deleted, so the table's ON DELETE CASCADE
+        # FK never fires — budget limits must be cleaned up explicitly.
+        limits = self.project_budget_limit_dao.get_by_project_uuid(project_uuid)
+        if limits:
+            self.project_budget_limit_dao.delete_by_project_uuid(project_uuid)
+            await self._clear_budget_limit_counters(project_uuid, limits)
+
         return out
 
     def get_by_uuid(
@@ -348,7 +364,7 @@ class ProjectService:
             for limit in self.project_budget_limit_dao.get_by_project_uuid(project_uuid)
         ]
 
-    def delete_budget_limit_from_project(
+    async def delete_budget_limit_from_project(
         self, project_uuid: UUID, limit_uuid: UUID
     ) -> ProjectBudgetLimitOut:
         self._get_project_or_raise(project_uuid)
@@ -360,7 +376,26 @@ class ProjectService:
         # Build the response before deletion so the caller can still see it.
         out = ProjectBudgetLimitOut.from_project_budget_limit(limit)
         self.project_budget_limit_dao.delete_by_uuid(limit_uuid)
+        await self._clear_budget_limit_counters(project_uuid, [limit])
         return out
+
+    @staticmethod
+    async def _clear_budget_limit_counters(project_uuid: UUID, limits) -> None:
+        """Best-effort: the DB rows are already gone, that's what matters."""
+        for limit in limits:
+            try:
+                await clear_project_budget_limit_counter(
+                    project_uuid=str(project_uuid),
+                    algorithm=limit.algorithm,
+                    window_size=limit.window_size,
+                )
+            except Exception:
+                logger.exception(
+                    'Failed to clear the budget limit counter for limit %s on '
+                    'project %s',
+                    limit.uuid,
+                    project_uuid,
+                )
 
     def validate_exists(self, project_uuid: UUID) -> None:
         if not self.project_dao.get_by_uuid(project_uuid):

--- a/gateway/radicalbit_ai_gateway/utils/request_context.py
+++ b/gateway/radicalbit_ai_gateway/utils/request_context.py
@@ -34,6 +34,7 @@ def reset_route_context(func):
         finally:
             current_route_config_ctx.set(None)
             current_credential_limiter_ctx.set(None)
+            current_project_budget_limiter_ctx.set(None)
 
     return wrapper
 
@@ -66,3 +67,21 @@ def set_current_credential_limiter(limiter: Any) -> None:
 
 def get_current_credential_limiter() -> Any:
     return current_credential_limiter_ctx.get()
+
+
+# The calling project's own ProjectBudgetLimiter, or None when it has no
+# budget limits configured. Same problem as the credential limiter above:
+# a GatewayRoute instance is a shared singleton, so a limiter built from
+# DB rows that can change independently of the route config can't live on
+# `self`.
+current_project_budget_limiter_ctx: ContextVar[Any] = ContextVar(
+    'current_project_budget_limiter', default=None
+)
+
+
+def set_current_project_budget_limiter(limiter: Any) -> None:
+    current_project_budget_limiter_ctx.set(limiter)
+
+
+def get_current_project_budget_limiter() -> Any:
+    return current_project_budget_limiter_ctx.get()

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -54,7 +54,10 @@ from radicalbit_ai_gateway.utils.exceptions import (
     BudgetLimitExceededError,
     GatewayBadRequest,
 )
-from radicalbit_ai_gateway.utils.request_context import set_current_credential_limiter
+from radicalbit_ai_gateway.utils.request_context import (
+    set_current_credential_limiter,
+    set_current_project_budget_limiter,
+)
 
 
 @patch('radicalbit_ai_gateway.invocation.model_invoker.emit_event', autospec=True)
@@ -923,6 +926,134 @@ async def test_credential_limit_is_checked_before_route_limit(
         set_current_credential_limiter(None)
 
     budget_limiter.check_budget.assert_not_awaited()
+    assert len(pook.pending_mocks()) == 0
+
+    pook.disable_network()
+
+
+@patch('radicalbit_ai_gateway.invocation.model_invoker.emit_event', autospec=True)
+@pook.activate
+@pytest.mark.asyncio
+async def test_project_budget_limit_is_checked_before_route_limit(
+    mock_model_invoker_emit_event,
+):
+    """When both the project's and the route's limit would block the same
+    request, the project's is the one reported.
+    """
+    pook.enable_network()
+    gateway_config = get_gateway_embedded_limiting()
+    cost_service = MagicMock(spec_set=CostService)
+    prompt_manager: PromptManager = MagicMock(spec_set=PromptManager)
+    guardrail_engine = GuardrailEngine(
+        presidio_engine=PresidioEngine(),
+        judge_engine=JudgeEngine(prompt_manager=prompt_manager),
+        cost_service=cost_service,
+        guardrails=gateway_config.guardrails or [],
+    )
+
+    route_cfg, chat_models, embedding_models = resolve_route_models(
+        gateway_config, 'rb-gateway'
+    )
+    budget_limiter = route_cfg.get_budget_limiter(
+        '2f1c6d4e-0000-4000-8000-0000000000aa'
+    )
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=chat_models,
+        embedding_models=embedding_models,
+        guardrail_engine=guardrail_engine,
+        gateway_cache=None,
+        cost_service=cost_service,
+        budget_limiter=budget_limiter,
+    )
+    budget_limiter.check_budget = AsyncMock(
+        side_effect=BudgetLimitExceededError('Route budget limit exceeded')
+    )
+
+    project_budget_limiter = MagicMock()
+    project_budget_limiter.check_budget = AsyncMock(
+        side_effect=BudgetLimitExceededError('Project budget limit exceeded')
+    )
+    set_current_project_budget_limiter(project_budget_limiter)
+    try:
+        with pytest.raises(BudgetLimitExceededError, match='Project budget'):
+            await ai_gateway.invoke_embeddings(
+                request_uuid=str(REQUEST_UUID),
+                api_key_uuid=str(API_KEY_UUID),
+                api_key_name='rb-key',
+                route_name='rb-gateway',
+                input_texts=['hello world'],
+                group_uuid=str(GROUP_UUID),
+                group_name='test-group',
+            )
+    finally:
+        set_current_project_budget_limiter(None)
+
+    budget_limiter.check_budget.assert_not_awaited()
+    assert len(pook.pending_mocks()) == 0
+
+    pook.disable_network()
+
+
+@patch('radicalbit_ai_gateway.invocation.model_invoker.emit_event', autospec=True)
+@pook.activate
+@pytest.mark.asyncio
+async def test_credential_limit_is_checked_before_project_limit(
+    mock_model_invoker_emit_event,
+):
+    """When both the credential's and the project's limit would block the
+    same request, the credential's is the one reported.
+    """
+    pook.enable_network()
+    gateway_config = get_gateway_embedded_limiting()
+    cost_service = MagicMock(spec_set=CostService)
+    prompt_manager: PromptManager = MagicMock(spec_set=PromptManager)
+    guardrail_engine = GuardrailEngine(
+        presidio_engine=PresidioEngine(),
+        judge_engine=JudgeEngine(prompt_manager=prompt_manager),
+        cost_service=cost_service,
+        guardrails=gateway_config.guardrails or [],
+    )
+
+    route_cfg, chat_models, embedding_models = resolve_route_models(
+        gateway_config, 'rb-gateway'
+    )
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=chat_models,
+        embedding_models=embedding_models,
+        guardrail_engine=guardrail_engine,
+        gateway_cache=None,
+        cost_service=cost_service,
+    )
+
+    credential_limiter = MagicMock()
+    credential_limiter.check_input_tokens = AsyncMock()
+    credential_limiter.check_budget = AsyncMock(
+        side_effect=BudgetLimitExceededError('Credential budget limit exceeded')
+    )
+    project_budget_limiter = MagicMock()
+    project_budget_limiter.check_budget = AsyncMock(
+        side_effect=BudgetLimitExceededError('Project budget limit exceeded')
+    )
+    set_current_credential_limiter(credential_limiter)
+    set_current_project_budget_limiter(project_budget_limiter)
+    try:
+        with pytest.raises(BudgetLimitExceededError, match='Credential budget'):
+            await ai_gateway.invoke_embeddings(
+                request_uuid=str(REQUEST_UUID),
+                api_key_uuid=str(API_KEY_UUID),
+                api_key_name='rb-key',
+                route_name='rb-gateway',
+                input_texts=['hello world'],
+                group_uuid=str(GROUP_UUID),
+                group_name='test-group',
+            )
+    finally:
+        set_current_credential_limiter(None)
+        set_current_project_budget_limiter(None)
+
+    project_budget_limiter.check_budget.assert_not_awaited()
     assert len(pook.pending_mocks()) == 0
 
     pook.disable_network()

--- a/gateway/tests/ai_gateway_test.py
+++ b/gateway/tests/ai_gateway_test.py
@@ -1059,6 +1059,134 @@ async def test_credential_limit_is_checked_before_project_limit(
     pook.disable_network()
 
 
+@patch('radicalbit_ai_gateway.invocation.model_invoker.emit_event', autospec=True)
+@pook.activate
+@pytest.mark.asyncio
+async def test_project_budget_limit_blocks_chat_with_no_other_limiters_configured(
+    mock_model_invoker_emit_event, fake_redis_client
+):
+    """Regression: _prepare_and_validate_request only calls
+    _validate_limiters when a route or credential limiter is configured —
+    a project-only budget limit must still be checked.
+    """
+    pook.enable_network()
+    gateway_config = get_gateway_openai_with_guardrails()
+    cost_service: CostService = MagicMock(spec_set=CostService)
+    prompt_manager: PromptManager = MagicMock(spec_set=PromptManager)
+    redis_cache = RedisCache(fake_redis_client)
+    guardrail_engine = GuardrailEngine(
+        presidio_engine=PresidioEngine(),
+        judge_engine=JudgeEngine(prompt_manager=prompt_manager),
+        cost_service=cost_service,
+        guardrails=gateway_config.guardrails or [],
+    )
+    gateway_cache = GatewayCache(redis_cache)
+
+    route_cfg, chat_models, embedding_models = resolve_route_models(
+        gateway_config, 'rb-gateway'
+    )
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=chat_models,
+        embedding_models=embedding_models,
+        guardrail_engine=guardrail_engine,
+        gateway_cache=gateway_cache,
+        cost_service=cost_service,
+        project_uuid=str(TEST_PROJECT_UUID),
+    )
+    assert ai_gateway.token_limiter is None
+    assert ai_gateway.budget_limiter is None
+    assert ai_gateway.request_rate_limiter is None
+
+    project_budget_limiter = MagicMock()
+    project_budget_limiter.check_budget = AsyncMock(
+        side_effect=BudgetLimitExceededError('Project budget limit exceeded')
+    )
+    set_current_project_budget_limiter(project_budget_limiter)
+    try:
+        with pytest.raises(BudgetLimitExceededError, match='Project budget'):
+            await ai_gateway.invoke(
+                request_uuid=str(REQUEST_UUID),
+                api_key_uuid=str(API_KEY_UUID),
+                api_key_name='rb-key',
+                messages=[HumanMessage(content='What is the capital of France?')],
+                route_name='rb-gateway',
+                tools=[],
+                tool_choice=None,
+                group_uuid=str(GROUP_UUID),
+                group_name='test-group',
+            )
+    finally:
+        set_current_project_budget_limiter(None)
+
+    project_budget_limiter.check_budget.assert_awaited_once()
+    assert len(pook.pending_mocks()) == 0
+
+    pook.disable_network()
+
+
+@patch('radicalbit_ai_gateway.invocation.model_invoker.emit_event', autospec=True)
+@pook.activate
+@pytest.mark.asyncio
+async def test_project_budget_limit_blocks_embeddings_with_no_other_limiters_configured(
+    mock_model_invoker_emit_event,
+):
+    """Regression: invoke_embeddings only calls _validate_embedding_limiters
+    when a route or credential limiter is configured — a project-only
+    budget limit must still be checked.
+    """
+    pook.enable_network()
+    gateway_config = get_gateway_openai_with_guardrails()
+    cost_service = MagicMock(spec_set=CostService)
+    prompt_manager: PromptManager = MagicMock(spec_set=PromptManager)
+    guardrail_engine = GuardrailEngine(
+        presidio_engine=PresidioEngine(),
+        judge_engine=JudgeEngine(prompt_manager=prompt_manager),
+        cost_service=cost_service,
+        guardrails=gateway_config.guardrails or [],
+    )
+
+    route_cfg, chat_models, embedding_models = resolve_route_models(
+        gateway_config, 'rb-gateway'
+    )
+
+    ai_gateway = GatewayRoute(
+        gateway_route_config=route_cfg,
+        chat_models=chat_models,
+        embedding_models=embedding_models,
+        guardrail_engine=guardrail_engine,
+        gateway_cache=None,
+        cost_service=cost_service,
+    )
+    assert ai_gateway.token_limiter is None
+    assert ai_gateway.budget_limiter is None
+
+    project_budget_limiter = MagicMock()
+    project_budget_limiter.check_budget = AsyncMock(
+        side_effect=BudgetLimitExceededError('Project budget limit exceeded')
+    )
+    set_current_project_budget_limiter(project_budget_limiter)
+    try:
+        with pytest.raises(BudgetLimitExceededError, match='Project budget'):
+            await ai_gateway.invoke_embeddings(
+                request_uuid=str(REQUEST_UUID),
+                api_key_uuid=str(API_KEY_UUID),
+                api_key_name='rb-key',
+                route_name='rb-gateway',
+                input_texts=['hello world'],
+                group_uuid=str(GROUP_UUID),
+                group_name='test-group',
+            )
+    finally:
+        set_current_project_budget_limiter(None)
+
+    project_budget_limiter.check_budget.assert_awaited_once()
+    assert len(pook.pending_mocks()) == 0
+
+    pook.disable_network()
+
+
 def _make_transcription_route_config(
     model_id: str = 'whisper-1', **budget_kwargs
 ) -> GatewayRouteConfig:

--- a/gateway/tests/dao/project_budget_limit_dao_test.py
+++ b/gateway/tests/dao/project_budget_limit_dao_test.py
@@ -106,6 +106,34 @@ class ProjectBudgetLimitDAOTest(DatabaseIntegration):
         rowcount = self.project_budget_limit_dao.delete_by_uuid(uuid.uuid4())
         assert rowcount == 0
 
+    def test_delete_by_project_uuid(self):
+        project = self._insert_project()
+        other_project = self._insert_project(name='rb-project-other')
+        limits = [
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 day'
+            ),
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project.uuid, window_size='1 month'
+            ),
+        ]
+        _ = [self.project_budget_limit_dao.insert(limit) for limit in limits]
+        other_limit = db_mock.get_sample_project_budget_limit(
+            uuid=uuid.uuid4(), project_uuid=other_project.uuid
+        )
+        self.project_budget_limit_dao.insert(other_limit)
+
+        rowcount = self.project_budget_limit_dao.delete_by_project_uuid(project.uuid)
+
+        assert rowcount == 2
+        assert self.project_budget_limit_dao.get_by_project_uuid(project.uuid) == []
+        # A different project's limits are untouched.
+        assert self.project_budget_limit_dao.get_by_uuid(other_limit.uuid) is not None
+
+    def test_delete_by_project_uuid_nonexistent_returns_zero(self):
+        rowcount = self.project_budget_limit_dao.delete_by_project_uuid(uuid.uuid4())
+        assert rowcount == 0
+
     def test_cascade_delete_on_project_delete(self):
         project = self._insert_project()
         self.project_budget_limit_dao.insert(

--- a/gateway/tests/limiting/test_project_budget_limiter.py
+++ b/gateway/tests/limiting/test_project_budget_limiter.py
@@ -1,0 +1,216 @@
+import datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from radicalbit_ai_gateway.db.dao.project_budget_limit_dao import ProjectBudgetLimitDAO
+from radicalbit_ai_gateway.db.tables.project_budget_limit_table import (
+    ProjectBudgetLimit,
+)
+from radicalbit_ai_gateway.limiting.project_budget_limiter import (
+    ProjectBudgetLimiter,
+    clear_project_budget_limit_counter,
+    load_project_budget_limiter,
+)
+from radicalbit_ai_gateway.models.limiting import LimitingAlgorithmType
+from radicalbit_ai_gateway.models.project_budget_limiting import ProjectBudgetLimitOut
+from radicalbit_ai_gateway.utils.exceptions import BudgetLimitExceededError
+
+_PROJECT_UUID = '3a2c6d4e-0000-4000-8000-0000000000bb'
+
+
+def _limit(
+    value: float,
+    window_size: str = '1 minute',
+    algorithm: LimitingAlgorithmType = LimitingAlgorithmType.FIXED_WINDOW,
+) -> ProjectBudgetLimitOut:
+    return ProjectBudgetLimitOut(
+        uuid=uuid4(),
+        algorithm=algorithm,
+        window_size=window_size,
+        value=value,
+        created_at='2026-01-01 00:00:00',
+        updated_at='2026-01-01 00:00:00',
+    )
+
+
+def _limiter(limits: list[ProjectBudgetLimitOut]) -> ProjectBudgetLimiter:
+    return ProjectBudgetLimiter(
+        project_uuid=_PROJECT_UUID,
+        project_name='my-project',
+        limits=limits,
+    )
+
+
+class TestNoLimitsConfigured:
+    @pytest.mark.asyncio
+    async def test_all_calls_are_noop(self):
+        limiter = _limiter([])
+        await limiter.check_budget()
+        await limiter.count_input(100, 0.01)
+        await limiter.count_output(100, 0.01)
+        await limiter.count_duration(10.0, 0.01)
+
+
+class TestBudgetLimiting:
+    @pytest.mark.asyncio
+    async def test_blocks_after_limit_reached(self):
+        limiter = _limiter([_limit(1.0)])
+        await limiter.count_input(token_count=1000, input_cost_per_token=0.001)
+        with pytest.raises(BudgetLimitExceededError) as exc:
+            await limiter.check_budget()
+        assert 'my-project' in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_count_output_and_duration_consume_same_window(self):
+        limiter = _limiter([_limit(10.0)])
+        await limiter.count_output(token_count=1000, output_cost_per_token=0.002)
+        await limiter.count_duration(seconds=5.0, cost_per_second=0.1)
+        await limiter.check_budget()  # still within limit
+
+    @pytest.mark.asyncio
+    async def test_and_semantics_across_multiple_windows(self):
+        """Two budget limits, different windows: the already-exhausted one
+        blocks first, and checking (test-only, no hit) never consumes the
+        other window's capacity.
+        """
+        limiter = _limiter(
+            [
+                _limit(0.0, window_size='1 minute'),
+                _limit(1000.0, window_size='1 hour'),
+            ]
+        )
+        with pytest.raises(BudgetLimitExceededError):
+            await limiter.check_budget()
+
+        hourly_entry = limiter._entries[1]
+        stats = await hourly_entry.limiter.get_window_stats(hourly_entry.window)
+        assert stats.remaining == hourly_entry.window.limit
+
+
+class TestProjectScoping:
+    def test_window_key_is_scoped_by_project_uuid_with_sentinel_route(self):
+        limiter = _limiter([_limit(5.0)])
+        entry = limiter._entries[0]
+        assert entry.window.project_uuid == _PROJECT_UUID
+        assert entry.window.route_name == '*'
+        key = entry.limiter._build_key(entry.window)
+        assert key.startswith(f'limiter:{_PROJECT_UUID}:*:budget:')
+
+    @pytest.mark.asyncio
+    async def test_two_projects_do_not_share_the_window(self):
+        limiter_a = ProjectBudgetLimiter(
+            project_uuid='3a2c6d4e-0000-4000-8000-00000000000a',
+            project_name='project-a',
+            limits=[_limit(1.0)],
+        )
+        limiter_b = ProjectBudgetLimiter(
+            project_uuid='3a2c6d4e-0000-4000-8000-00000000000b',
+            project_name='project-b',
+            limits=[_limit(1.0)],
+        )
+        entry_a = limiter_a._entries[0]
+        entry_b = limiter_b._entries[0]
+        entry_b.limiter._storage = entry_a.limiter._storage
+
+        await limiter_a.count_input(token_count=1000, input_cost_per_token=0.001)
+        with pytest.raises(BudgetLimitExceededError):
+            await limiter_a.check_budget()
+
+        # project B, same storage, untouched
+        await limiter_b.check_budget()
+
+
+def _fake_dao(rows: list[ProjectBudgetLimit]) -> ProjectBudgetLimitDAO:
+    dao = MagicMock(spec_set=ProjectBudgetLimitDAO)
+    dao.get_by_project_uuid = MagicMock(return_value=rows)
+    return dao
+
+
+class TestLoadProjectBudgetLimiter:
+    def test_returns_none_when_project_has_no_limits(self):
+        dao = _fake_dao([])
+        assert load_project_budget_limiter(_PROJECT_UUID, 'my-project', dao) is None
+
+    def test_returns_none_for_empty_project_uuid(self):
+        dao = _fake_dao([_raw_limit()])
+        assert load_project_budget_limiter('', 'my-project', dao) is None
+
+    def test_builds_limiter_from_dao_rows(self):
+        dao = _fake_dao([_raw_limit()])
+        limiter = load_project_budget_limiter(_PROJECT_UUID, 'my-project', dao)
+        assert limiter is not None
+        assert len(limiter._entries) == 1
+
+
+def _raw_limit():
+    now = datetime.datetime.now(tz=datetime.UTC)
+    return ProjectBudgetLimit(
+        uuid=uuid4(),
+        project_uuid=uuid4(),
+        algorithm=LimitingAlgorithmType.FIXED_WINDOW.value,
+        window_size='1 day',
+        max_value=10.0,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestClearProjectBudgetLimitCounter:
+    @pytest.mark.asyncio
+    async def test_clears_the_same_key_the_limiter_uses(self):
+        limiter = _limiter([_limit(2.0, window_size='1 minute')])
+        entry = limiter._entries[0]
+        await entry.limiter.hit(entry.window, cost=1)
+        assert (await entry.limiter.get_window_stats(entry.window)).remaining == (
+            entry.window.limit - 1
+        )
+
+        with patch(
+            'radicalbit_ai_gateway.limiting.project_budget_limiter.InMemoryStorage',
+            return_value=entry.limiter._storage,
+        ):
+            await clear_project_budget_limit_counter(
+                project_uuid=_PROJECT_UUID,
+                algorithm=LimitingAlgorithmType.FIXED_WINDOW.value,
+                window_size='1 minute',
+            )
+
+        stats = await entry.limiter.get_window_stats(entry.window)
+        assert stats.remaining == entry.window.limit  # back to full capacity
+
+    @pytest.mark.asyncio
+    async def test_matches_aligned_fixed_window_key(self):
+        limiter = _limiter(
+            [
+                _limit(
+                    5,
+                    window_size='1 hour',
+                    algorithm=LimitingAlgorithmType.ALIGNED_FIXED_WINDOW,
+                )
+            ]
+        )
+        entry = limiter._entries[0]
+        await entry.limiter.hit(entry.window, cost=1)
+
+        with patch(
+            'radicalbit_ai_gateway.limiting.project_budget_limiter.InMemoryStorage',
+            return_value=entry.limiter._storage,
+        ):
+            await clear_project_budget_limit_counter(
+                project_uuid=_PROJECT_UUID,
+                algorithm=LimitingAlgorithmType.ALIGNED_FIXED_WINDOW.value,
+                window_size='1 hour',
+            )
+
+        stats = await entry.limiter.get_window_stats(entry.window)
+        assert stats.remaining == entry.window.limit
+
+    @pytest.mark.asyncio
+    async def test_clearing_a_never_hit_counter_does_not_raise(self):
+        await clear_project_budget_limit_counter(
+            project_uuid=str(uuid4()),
+            algorithm=LimitingAlgorithmType.FIXED_WINDOW.value,
+            window_size='1 minute',
+        )

--- a/gateway/tests/routes/test_project_route.py
+++ b/gateway/tests/routes/test_project_route.py
@@ -377,7 +377,7 @@ class TestProjectRoute(unittest.TestCase):
     def test_delete_project_deregisters_when_served(self):
         pid = uuid.uuid4()
         out = db_mock.get_sample_project_out(uuid=pid, served_config_uuid=uuid.uuid4())
-        self.project_service.delete_project = MagicMock(return_value=out)
+        self.project_service.delete_project = AsyncMock(return_value=out)
         res = self.client.delete(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
         self.project_service.delete_project.assert_called_once_with(pid)
@@ -386,7 +386,7 @@ class TestProjectRoute(unittest.TestCase):
     def test_delete_project_no_deregister_when_dev(self):
         pid = uuid.uuid4()
         out = db_mock.get_sample_project_out(uuid=pid, served_config_uuid=None)
-        self.project_service.delete_project = MagicMock(return_value=out)
+        self.project_service.delete_project = AsyncMock(return_value=out)
         res = self.client.delete(f'{self.prefix}/projects/{pid}')
         assert res.status_code == 200
         self.deregister.assert_not_awaited()
@@ -471,7 +471,7 @@ class TestProjectRoute(unittest.TestCase):
         limit_out = ProjectBudgetLimitOut.from_project_budget_limit(
             db_mock.get_sample_project_budget_limit(uuid=lid, project_uuid=pid)
         )
-        self.project_service.delete_budget_limit_from_project = MagicMock(
+        self.project_service.delete_budget_limit_from_project = AsyncMock(
             return_value=limit_out
         )
         res = self.client.delete(f'{self.prefix}/projects/{pid}/budget-limits/{lid}')
@@ -483,7 +483,7 @@ class TestProjectRoute(unittest.TestCase):
 
     def test_delete_budget_limit_from_project_not_found(self):
         pid, lid = uuid.uuid4(), uuid.uuid4()
-        self.project_service.delete_budget_limit_from_project = MagicMock(
+        self.project_service.delete_budget_limit_from_project = AsyncMock(
             side_effect=ProjectBudgetLimitNotFoundError('nope')
         )
         res = self.client.delete(f'{self.prefix}/projects/{pid}/budget-limits/{lid}')

--- a/gateway/tests/services/project_service_test.py
+++ b/gateway/tests/services/project_service_test.py
@@ -1,5 +1,6 @@
+import asyncio
 import io
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 import zipfile
 
@@ -235,14 +236,22 @@ class ProjectServiceTest(DatabaseIntegration):
 
     def test_delete_project(self):
         out, _, _ = self._create()
-        deleted = self.svc.delete_project(out.uuid)
+        deleted = asyncio.run(self.svc.delete_project(out.uuid))
         assert deleted.uuid == out.uuid
         with pytest.raises(ProjectNotFoundError):
             self.svc.get_by_uuid(out.uuid)
 
+    def test_delete_project_removes_its_budget_limits(self):
+        out, _, _ = self._create(name='delete-cascades-budget-limits')
+        self.svc.add_budget_limits_to_project(
+            out.uuid, db_mock.get_sample_project_budget_limits_in()
+        )
+        asyncio.run(self.svc.delete_project(out.uuid))
+        assert self.svc.project_budget_limit_dao.get_by_project_uuid(out.uuid) == []
+
     def test_recreate_with_deleted_project_name_succeeds(self):
         out, _, _ = self._create(name='reuse-me')
-        self.svc.delete_project(out.uuid)
+        asyncio.run(self.svc.delete_project(out.uuid))
         again = self.svc.create_project(ProjectIn(name='reuse-me'))
         assert again.uuid != out.uuid
         assert again.name == 'reuse-me'
@@ -482,18 +491,24 @@ class ProjectServiceTest(DatabaseIntegration):
         [limit] = self.svc.add_budget_limits_to_project(
             out.uuid, db_mock.get_sample_project_budget_limits_in()
         )
-        deleted = self.svc.delete_budget_limit_from_project(out.uuid, limit.uuid)
+        deleted = asyncio.run(
+            self.svc.delete_budget_limit_from_project(out.uuid, limit.uuid)
+        )
         assert deleted.uuid == limit.uuid
         assert self.svc.get_budget_limits_for_project(out.uuid) == []
 
     def test_delete_budget_limit_from_project_not_found_project(self):
         with pytest.raises(ProjectNotFoundError):
-            self.svc.delete_budget_limit_from_project(uuid.uuid4(), uuid.uuid4())
+            asyncio.run(
+                self.svc.delete_budget_limit_from_project(uuid.uuid4(), uuid.uuid4())
+            )
 
     def test_delete_budget_limit_from_project_not_found_limit(self):
         out, _, _ = self._create(name='budget-delete-not-found')
         with pytest.raises(ProjectBudgetLimitNotFoundError):
-            self.svc.delete_budget_limit_from_project(out.uuid, uuid.uuid4())
+            asyncio.run(
+                self.svc.delete_budget_limit_from_project(out.uuid, uuid.uuid4())
+            )
 
     def test_delete_budget_limit_from_project_not_found_when_owned_by_other_project(
         self,
@@ -504,7 +519,9 @@ class ProjectServiceTest(DatabaseIntegration):
             owner.uuid, db_mock.get_sample_project_budget_limits_in()
         )
         with pytest.raises(ProjectBudgetLimitNotFoundError):
-            self.svc.delete_budget_limit_from_project(other.uuid, limit.uuid)
+            asyncio.run(
+                self.svc.delete_budget_limit_from_project(other.uuid, limit.uuid)
+            )
 
     # --- reverse validation: route config vs. existing project budget limit ---
 
@@ -576,3 +593,173 @@ class ProjectServiceTest(DatabaseIntegration):
             out.uuid, a, ProjectConfigFileIn(config_file=_VALID)
         )
         assert next(c for c in res.configs if c.uuid == a).config_file == _VALID
+
+
+class TestBudgetLimitRedisClear:
+    """Mock-based tests for the Redis-clear side effects of budget limit
+    deletion, mirroring key_service_test.py::TestDeleteLimitFromKey.
+    """
+
+    def _make_service(self):
+        project_dao = MagicMock(spec_set=ProjectDAO)
+        project_config_dao = MagicMock(spec_set=ProjectConfigDAO)
+        project_budget_limit_dao = MagicMock(spec_set=ProjectBudgetLimitDAO)
+        service = ProjectService(
+            project_dao, project_config_dao, project_budget_limit_dao
+        )
+        return service, project_dao, project_config_dao, project_budget_limit_dao
+
+    @pytest.mark.asyncio
+    async def test_delete_budget_limit_from_project_clears_redis_counter(self):
+        service, project_dao, _, project_budget_limit_dao = self._make_service()
+        project_uuid = uuid.uuid4()
+        limit_uuid = uuid.uuid4()
+        project = db_mock.get_sample_project(uuid=project_uuid)
+        limit = db_mock.get_sample_project_budget_limit(
+            uuid=limit_uuid, project_uuid=project_uuid
+        )
+        project_dao.get_by_uuid = MagicMock(return_value=project)
+        project_budget_limit_dao.get_by_uuid = MagicMock(return_value=limit)
+        project_budget_limit_dao.delete_by_uuid = MagicMock(return_value=1)
+
+        with patch(
+            'radicalbit_ai_gateway.services.project_service.clear_project_budget_limit_counter',
+            new=AsyncMock(),
+        ) as mock_clear:
+            res = await service.delete_budget_limit_from_project(
+                project_uuid, limit_uuid
+            )
+
+        project_budget_limit_dao.delete_by_uuid.assert_called_once_with(limit_uuid)
+        mock_clear.assert_awaited_once_with(
+            project_uuid=str(project_uuid),
+            algorithm=limit.algorithm,
+            window_size=limit.window_size,
+        )
+        assert res.uuid == limit_uuid
+
+    @pytest.mark.asyncio
+    async def test_delete_budget_limit_redis_clear_failure_does_not_fail_the_request(
+        self,
+    ):
+        """A Redis-side error clearing the counter must not undo the delete."""
+        service, project_dao, _, project_budget_limit_dao = self._make_service()
+        project_uuid = uuid.uuid4()
+        limit_uuid = uuid.uuid4()
+        project = db_mock.get_sample_project(uuid=project_uuid)
+        limit = db_mock.get_sample_project_budget_limit(
+            uuid=limit_uuid, project_uuid=project_uuid
+        )
+        project_dao.get_by_uuid = MagicMock(return_value=project)
+        project_budget_limit_dao.get_by_uuid = MagicMock(return_value=limit)
+        project_budget_limit_dao.delete_by_uuid = MagicMock(return_value=1)
+
+        with patch(
+            'radicalbit_ai_gateway.services.project_service.clear_project_budget_limit_counter',
+            new=AsyncMock(side_effect=ConnectionError('redis unreachable')),
+        ):
+            res = await service.delete_budget_limit_from_project(
+                project_uuid, limit_uuid
+            )
+
+        project_budget_limit_dao.delete_by_uuid.assert_called_once_with(limit_uuid)
+        assert res.uuid == limit_uuid
+
+    @pytest.mark.asyncio
+    async def test_delete_project_clears_every_budget_limit_counter(self):
+        service, project_dao, project_config_dao, project_budget_limit_dao = (
+            self._make_service()
+        )
+        project_uuid = uuid.uuid4()
+        project = db_mock.get_sample_project(uuid=project_uuid)
+        limits = [
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project_uuid, window_size='1 day'
+            ),
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project_uuid, window_size='1 month'
+            ),
+        ]
+        project_dao.get_by_uuid = MagicMock(return_value=project)
+        project_config_dao.list_by_project = MagicMock(return_value=[])
+        project_config_dao.get_served_by_project = MagicMock(return_value=None)
+        project_config_dao.soft_delete_by_project = MagicMock(return_value=1)
+        project_dao.soft_delete = MagicMock(return_value=1)
+        project_budget_limit_dao.get_by_project_uuid = MagicMock(return_value=limits)
+        project_budget_limit_dao.delete_by_project_uuid = MagicMock(return_value=2)
+
+        with patch(
+            'radicalbit_ai_gateway.services.project_service.clear_project_budget_limit_counter',
+            new=AsyncMock(),
+        ) as mock_clear:
+            res = await service.delete_project(project_uuid)
+
+        project_budget_limit_dao.delete_by_project_uuid.assert_called_once_with(
+            project_uuid
+        )
+        assert mock_clear.await_count == 2
+        mock_clear.assert_any_await(
+            project_uuid=str(project_uuid),
+            algorithm=limits[0].algorithm,
+            window_size=limits[0].window_size,
+        )
+        mock_clear.assert_any_await(
+            project_uuid=str(project_uuid),
+            algorithm=limits[1].algorithm,
+            window_size=limits[1].window_size,
+        )
+        assert res.uuid == project_uuid
+
+    @pytest.mark.asyncio
+    async def test_delete_project_with_no_budget_limits_skips_cleanup(self):
+        service, project_dao, project_config_dao, project_budget_limit_dao = (
+            self._make_service()
+        )
+        project_uuid = uuid.uuid4()
+        project = db_mock.get_sample_project(uuid=project_uuid)
+        project_dao.get_by_uuid = MagicMock(return_value=project)
+        project_config_dao.list_by_project = MagicMock(return_value=[])
+        project_config_dao.get_served_by_project = MagicMock(return_value=None)
+        project_config_dao.soft_delete_by_project = MagicMock(return_value=1)
+        project_dao.soft_delete = MagicMock(return_value=1)
+        project_budget_limit_dao.get_by_project_uuid = MagicMock(return_value=[])
+
+        with patch(
+            'radicalbit_ai_gateway.services.project_service.clear_project_budget_limit_counter',
+            new=AsyncMock(),
+        ) as mock_clear:
+            await service.delete_project(project_uuid)
+
+        project_budget_limit_dao.delete_by_project_uuid.assert_not_called()
+        mock_clear.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_project_redis_clear_failure_does_not_fail_the_request(self):
+        service, project_dao, project_config_dao, project_budget_limit_dao = (
+            self._make_service()
+        )
+        project_uuid = uuid.uuid4()
+        project = db_mock.get_sample_project(uuid=project_uuid)
+        limits = [
+            db_mock.get_sample_project_budget_limit(
+                uuid=uuid.uuid4(), project_uuid=project_uuid
+            )
+        ]
+        project_dao.get_by_uuid = MagicMock(return_value=project)
+        project_config_dao.list_by_project = MagicMock(return_value=[])
+        project_config_dao.get_served_by_project = MagicMock(return_value=None)
+        project_config_dao.soft_delete_by_project = MagicMock(return_value=1)
+        project_dao.soft_delete = MagicMock(return_value=1)
+        project_budget_limit_dao.get_by_project_uuid = MagicMock(return_value=limits)
+        project_budget_limit_dao.delete_by_project_uuid = MagicMock(return_value=1)
+
+        with patch(
+            'radicalbit_ai_gateway.services.project_service.clear_project_budget_limit_counter',
+            new=AsyncMock(side_effect=ConnectionError('redis unreachable')),
+        ):
+            res = await service.delete_project(project_uuid)
+
+        project_budget_limit_dao.delete_by_project_uuid.assert_called_once_with(
+            project_uuid
+        )
+        assert res.uuid == project_uuid


### PR DESCRIPTION
## Summary

Adds runtime evaluation for project-level budget limits: a request is now blocked once any budget limit configured on the called project is exceeded, evaluated after credential limits and before route limits. Also fixes two related cleanup gaps — deleting a budget limit or a whole project now clears the corresponding Redis counters.

`ProjectBudgetLimit` (table, DAO, CRUD service/routes) already existed but was never wired into the request path, so configured project budget limits were silently unenforced.

## What changed

**Runtime enforcement** (mirrors `CredentialLimiter`, not the route-level `BudgetLimiter`, since project budget limits are DB rows that can change via the API at any time, independent of a project's served config):
- New `ProjectBudgetLimiter` (`limiting/project_budget_limiter.py`) — built fresh per request from the project's `ProjectBudgetLimit` rows, AND semantics across multiple windows, same Redis key scheme as route/credential limiters (`limiter:{project_uuid}:*:budget:...`, no collisions).
- Published on a new `current_project_budget_limiter_ctx` context var (`utils/request_context.py`), set in `server.py`'s four request handlers (chat, embeddings, transcriptions, responses) right after route resolution.
- Checked/counted in `ai_gateway.py` between the existing credential and route budget checks — using the `# Checked before route/project limits` markers already present in the code for this purpose.
- Blocks raise the existing `BudgetLimitExceededError`, identified by a `[PROJECT BUDGET LIMIT]` log prefix and a message naming the project (same convention as credential vs. route budget blocks).

**Deletion cascades**:
- `ProjectBudgetLimitDAO.delete_by_project_uuid` — new bulk delete.
- `ProjectService.delete_budget_limit_from_project` and `delete_project` are now `async` and best-effort clear the matching Redis counter(s) via the new `clear_project_budget_limit_counter`, mirroring `KeyService.delete_limit_from_key`. Since projects are soft-deleted, the table's `ON DELETE CASCADE` FK never fires on project delete, so budget limit rows are now deleted explicitly too.
- `project_route.py` now `await`s both service calls.

## Testing

- New unit tests for `ProjectBudgetLimiter` and `clear_project_budget_limit_counter` (`tests/limiting/test_project_budget_limiter.py`).
- New DAO test for `delete_by_project_uuid`.
- Updated `project_service_test.py` / `test_project_route.py` for the async signatures, plus new tests asserting Redis counters are cleared on delete (and that a Redis failure doesn't fail the request).
- New `ai_gateway_test.py` tests confirming block-priority ordering: credential → project → route.
- Full suite: 2205 passed. `ruff check` / `ruff format --check` clean.